### PR TITLE
opt-component/QuarterView 에 useShortcut 적용

### DIFF
--- a/src/_packages/@lunit/opt-components/__pages__/Basic.mdx
+++ b/src/_packages/@lunit/opt-components/__pages__/Basic.mdx
@@ -1,0 +1,18 @@
+import { component, source } from '@handbook/source';
+import { Example, Preview } from '@handbook/components';
+import { InsightViewerPreview } from '@lunit/handbook';
+
+# `@lunit/opt-components/QuarterView`
+
+QuarterView 를 수정하여 테스트 해보기
+
+# API
+
+<Example example={source('@lunit/opt-components/components/QuarterView')} api />
+
+# Sample
+
+<Example example={component('./Sample')}>
+  <InsightViewerPreview height={720} />
+  {/* <Preview height={720} /> */}
+</Example>

--- a/src/_packages/@lunit/opt-components/__pages__/Sample.tsx
+++ b/src/_packages/@lunit/opt-components/__pages__/Sample.tsx
@@ -2,12 +2,9 @@ import {
   CornerstoneImage,
   CornerstoneSingleImage,
   CornerstoneViewer,
-  InsightViewerControllerOptions,
-  InsightViewerTestController,
   installWADOImageLoader,
   unloadImage,
   InsightViewerContainer,
-  useInsightViewerSync,
   useViewerInteractions,
 } from '@lunit/insight-viewer';
 import React, { useMemo, useState } from 'react';
@@ -16,9 +13,6 @@ import styled from 'styled-components';
 import useResizeObserver from 'use-resize-observer';
 
 installWADOImageLoader();
-
-const _width: number = 400;
-const _height: number = 400;
 
 export default () => {
   const image1: CornerstoneImage = useMemo(
@@ -64,7 +58,7 @@ export default () => {
 
   return (
     <div>
-      <QuarterViewContainer>
+      <QuarterViewContainer shortcuts={['1', '2', '3', '4']}>
         <Viewer image={image1} />
         <Viewer image={image2} />
         <Viewer image={image3} />
@@ -77,7 +71,7 @@ export default () => {
 function Viewer({ image }: { image: CornerstoneImage }) {
   const [interactionElement, setInteractionElement] = useState<HTMLElement | null>(null);
   const interactions = useViewerInteractions(['none', 'zoom'], { element: interactionElement });
-  const { ref: resizeRef, width = 200, height = 300 } = useResizeObserver<HTMLDivElement>({});
+  const { ref: resizeRef, width = 200, height = 400 } = useResizeObserver<HTMLDivElement>({});
 
   return (
     <div
@@ -97,7 +91,6 @@ function Viewer({ image }: { image: CornerstoneImage }) {
           flip={false}
           resetTime={0}
           image={image}
-          // ref={viewerRef as RefObject<CornerstoneViewer>}
           updateCornerstoneRenderData={() => {}}
           interactions={interactions}
         />

--- a/src/_packages/@lunit/opt-components/__pages__/Sample.tsx
+++ b/src/_packages/@lunit/opt-components/__pages__/Sample.tsx
@@ -1,0 +1,113 @@
+import {
+  CornerstoneImage,
+  CornerstoneSingleImage,
+  CornerstoneViewer,
+  InsightViewerControllerOptions,
+  InsightViewerTestController,
+  installWADOImageLoader,
+  unloadImage,
+  InsightViewerContainer,
+  useInsightViewerSync,
+  useViewerInteractions,
+} from '@lunit/insight-viewer';
+import React, { useMemo, useState } from 'react';
+import { QuarterView } from '../components/QuarterView';
+import styled from 'styled-components';
+import useResizeObserver from 'use-resize-observer';
+
+installWADOImageLoader();
+
+const _width: number = 400;
+const _height: number = 400;
+
+export default () => {
+  const image1: CornerstoneImage = useMemo(
+    () =>
+      new CornerstoneSingleImage(
+        `wadouri:https://static.lunit.io/insight/samples/mmg/2.2.1-5.5.0-density/case01_RCC.dcm`,
+        {
+          unload: unloadImage,
+        },
+      ),
+    [],
+  );
+  const image2: CornerstoneImage = useMemo(
+    () =>
+      new CornerstoneSingleImage(
+        `wadouri:https://static.lunit.io/insight/samples/mmg/2.2.1-5.5.0-density/case01_LCC.dcm`,
+        {
+          unload: unloadImage,
+        },
+      ),
+    [],
+  );
+  const image3: CornerstoneImage = useMemo(
+    () =>
+      new CornerstoneSingleImage(
+        `wadouri:https://static.lunit.io/insight/samples/mmg/2.2.1-5.5.0-density/case01_RMLO.dcm`,
+        {
+          unload: unloadImage,
+        },
+      ),
+    [],
+  );
+  const image4: CornerstoneImage = useMemo(
+    () =>
+      new CornerstoneSingleImage(
+        `wadouri:https://static.lunit.io/insight/samples/mmg/2.2.1-5.5.0-density/case01_LMLO.dcm`,
+        {
+          unload: unloadImage,
+        },
+      ),
+    [],
+  );
+
+  return (
+    <div>
+      <QuarterViewContainer>
+        <Viewer image={image1} />
+        <Viewer image={image2} />
+        <Viewer image={image3} />
+        <Viewer image={image4} />
+      </QuarterViewContainer>
+    </div>
+  );
+};
+
+function Viewer({ image }: { image: CornerstoneImage }) {
+  const [interactionElement, setInteractionElement] = useState<HTMLElement | null>(null);
+  const interactions = useViewerInteractions(['none', 'zoom'], { element: interactionElement });
+  const { ref: resizeRef, width = 200, height = 300 } = useResizeObserver<HTMLDivElement>({});
+
+  return (
+    <div
+      ref={resizeRef}
+      style={{
+        overflow: 'hidden',
+        position: 'relative',
+        height: '100%',
+        minHeight: 0,
+      }}
+    >
+      <InsightViewerContainer ref={setInteractionElement} width={width} height={height}>
+        <CornerstoneViewer
+          width={width}
+          height={height}
+          invert={false}
+          flip={false}
+          resetTime={0}
+          image={image}
+          // ref={viewerRef as RefObject<CornerstoneViewer>}
+          updateCornerstoneRenderData={() => {}}
+          interactions={interactions}
+        />
+      </InsightViewerContainer>
+    </div>
+  );
+}
+
+const QuarterViewContainer = styled(QuarterView)`
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+`;

--- a/src/_packages/@lunit/opt-components/__pages__/index.ts
+++ b/src/_packages/@lunit/opt-components/__pages__/index.ts
@@ -1,0 +1,3 @@
+import { page } from '@handbook/source';
+
+export const QuarterViewTest = page('./Basic');

--- a/src/_packages/@lunit/opt-components/components/QuarterView.tsx
+++ b/src/_packages/@lunit/opt-components/components/QuarterView.tsx
@@ -3,17 +3,49 @@ import { Fullscreen, FullscreenExit } from '@material-ui/icons';
 import React, { Children, ReactNode, useState } from 'react';
 import styled, { css } from 'styled-components';
 import useResizeObserver from 'use-resize-observer/polyfilled';
+import { useShortcut, key } from '@lunit/use-shortcut';
 
 export interface QuarterViewProps {
   children: ReactNode;
   className?: string;
+  shortcuts?: string[];
 }
 
-export function QuarterView({ children, className }: QuarterViewProps) {
+export function QuarterView({ children, className, shortcuts = ['', '', '', ''] }: QuarterViewProps) {
   const { ref: resizeRef, width = 500, height = 500 } = useResizeObserver<HTMLDivElement>({});
   const [solo, setSolo] = useState<number>(-1);
 
   const soloEnabled: boolean = solo > -1;
+
+  useShortcut({
+    test: key(shortcuts[0] || ''),
+    callback: () => setSoloShortcut(0),
+  });
+
+  useShortcut({
+    test: key(shortcuts[1] || ''),
+    callback: () => setSoloShortcut(1),
+  });
+
+  useShortcut({
+    test: key(shortcuts[2] || ''),
+    callback: () => setSoloShortcut(2),
+  });
+
+  useShortcut({
+    test: key(shortcuts[3] || ''),
+    callback: () => setSoloShortcut(3),
+  });
+
+  function setSoloShortcut(index: number) {
+    if (Children.count(children) > index) {
+      if (solo > -1) {
+        setSolo(-1);
+      } else {
+        setSolo(index);
+      }
+    }
+  }
 
   return (
     <Container ref={resizeRef} soloEnabled={soloEnabled} width={width} height={height} className={className}>
@@ -94,15 +126,17 @@ const soloContainerStyle = css`
 `;
 
 const ExpandButton = styled(IconButton)`
-  position: absolute;
-  top: 0;
-  left: 0;
-  border-radius: 0;
-  padding: 4px 6px;
-  color: #8694b1;
-  font-size: 18px;
+  && {
+    position: absolute;
+    top: 0;
+    left: 0;
+    border-radius: 0;
+    padding: 4px 6px;
+    color: #8694b1;
+    font-size: 18px;
 
-  .MuiSvgIcon-root {
-    font-size: 1em;
+    .MuiSvgIcon-root {
+      font-size: 1em;
+    }
   }
 `;

--- a/src/_packages/@lunit/opt-components/package.json
+++ b/src/_packages/@lunit/opt-components/package.json
@@ -10,6 +10,10 @@
     {
       "name": "Seula Lee",
       "email": "seula@lunit.io"
+    },
+    {
+      "name": "Jiyeon Seo",
+      "email": "jyseo@lunit.io"
     }
   ],
   "repository": "lunit-io/frontend-components",

--- a/src/_packages/@lunit/opt-components/package.json
+++ b/src/_packages/@lunit/opt-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunit/opt-components",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Component library for annotation / opt apps",
   "author": {
     "name": "Seoyeon Lee",
@@ -33,6 +33,7 @@
     "use-resize-observer": "^5.0.0",
     "@lunit/insight-viewer": "^4.0.0",
     "@ssen/snackbar": "^0.1.0",
-    "@lunit/is-touch-device": "^0.1.0"
+    "@lunit/is-touch-device": "^0.1.0",
+    "@lunit/use-shortcut": "^1.1.0"
   }
 }

--- a/src/_packages/@lunit/opt-components/package.json
+++ b/src/_packages/@lunit/opt-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunit/opt-components",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Component library for annotation / opt apps",
   "author": {
     "name": "Seoyeon Lee",

--- a/src/handbook/index.tsx
+++ b/src/handbook/index.tsx
@@ -12,6 +12,7 @@ import { useDialogPages } from '@lunit/use-dialog/__pages__';
 import { useControlPages } from '@lunit/use-opt-control/__pages__';
 import { useResetTimePages } from '@lunit/use-reset-time/__pages__';
 import { useShortcutPages } from '@lunit/use-shortcut/__pages__';
+import { QuarterViewTest } from '@lunit/opt-components/__pages__';
 import React from 'react';
 import { render } from 'react-dom';
 import { createGlobalStyle } from 'styled-components';
@@ -44,6 +45,7 @@ const handbookConfig: HandbookConfig = {
     'use-opt-control': useControlPages,
     'use-reset-time': useResetTimePages,
     'use-shortcut': useShortcutPages,
+    QuarterViewTest: QuarterViewTest,
   },
 };
 

--- a/src/handbook/index.tsx
+++ b/src/handbook/index.tsx
@@ -12,7 +12,6 @@ import { useDialogPages } from '@lunit/use-dialog/__pages__';
 import { useControlPages } from '@lunit/use-opt-control/__pages__';
 import { useResetTimePages } from '@lunit/use-reset-time/__pages__';
 import { useShortcutPages } from '@lunit/use-shortcut/__pages__';
-import { QuarterViewTest } from '@lunit/opt-components/__pages__';
 import React from 'react';
 import { render } from 'react-dom';
 import { createGlobalStyle } from 'styled-components';
@@ -45,7 +44,6 @@ const handbookConfig: HandbookConfig = {
     'use-opt-control': useControlPages,
     'use-reset-time': useResetTimePages,
     'use-shortcut': useShortcutPages,
-    QuarterViewTest: QuarterViewTest,
   },
 };
 


### PR DESCRIPTION
QuarterView 컴포넌트에 useShortcut 을 적용하고 단축키를 props 로 전달받아 이용할 수 있게 수정.
(Shortcut 관련 부분 코드를 아름답게 혹은 깔끔하게 정리할 수 있는 방법은 없을까요)

Handbook 에서 확인할 수 있게 파일도 생성해 두었으니 확인하고 싶을 때 handbook/index에 페이지를 등록해 확인할 수 있음.

