### PR TITLE
Feature/viewport feedback

### DIFF
--- a/apps/insight-viewer-demo/src/containers/Basic/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Basic/index.tsx
@@ -30,10 +30,6 @@ function Basic(): JSX.Element {
 
   return (
     <>
-      <Box mb={6}>
-        <Heading as="h3">InsightViewer</Heading>
-      </Box>
-
       <SelectableImage />
       <Box w={700}>
         <CodeBlock code={insightViewerCode} />

--- a/apps/insight-viewer-demo/src/containers/Error/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Error/index.tsx
@@ -1,15 +1,10 @@
-import { Box, Heading } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 import Tabs from './Tabs'
 
 export default function Error(): JSX.Element {
   return (
-    <>
-      <Box mb={6}>
-        <Heading as="h3">InsightViewer Error</Heading>
-      </Box>
-      <Box mb={6}>
-        <Tabs />
-      </Box>
-    </>
+    <Box mb={6}>
+      <Tabs />
+    </Box>
   )
 }

--- a/apps/insight-viewer-demo/src/containers/HttpHeader/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/HttpHeader/index.tsx
@@ -1,13 +1,9 @@
-import { Box, Heading } from '@chakra-ui/react'
 import WithCookie from './WithCookie'
 import WithJwt from './WithJwt'
 
 function Basic(): JSX.Element {
   return (
     <>
-      <Box mb={6}>
-        <Heading as="h3">Http header</Heading>
-      </Box>
       <WithCookie />
       <WithJwt />
     </>

--- a/apps/insight-viewer-demo/src/containers/MultiFrame/Base.tsx
+++ b/apps/insight-viewer-demo/src/containers/MultiFrame/Base.tsx
@@ -1,5 +1,6 @@
-import { Box, Input } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 import useInsightViewer from '@lunit/insight-viewer'
+import React from 'react'
 import CodeBlock from '../../components/CodeBlock'
 
 const IMAGES = [
@@ -45,26 +46,26 @@ export default function Base(): JSX.Element {
   })
   const { frame, setFrame } = useFrame()
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>): void {
-    const { key, target } = e
-    const current = Number((target as HTMLInputElement).value)
+  function changeFrame(e: React.ChangeEvent<HTMLInputElement>): void {
+    const {
+      target: { value },
+    } = e
 
-    if (current < 0 || current > IMAGES.length - 1)
-      // eslint-disable-next-line no-alert
-      return alert('invalid input')
-
-    if (key !== 'Enter') return undefined
-    setFrame(current)
-    return undefined
+    setFrame(Number(value))
   }
 
   return (
     <Box w={500} h={500}>
       <Box mb={6}>
-        <Input
-          placeholder="Press 'enter' after typing frame index (range 0-10)"
-          variant="outline"
-          onKeyDown={handleKeyDown}
+        <input
+          type="range"
+          id="frame"
+          name="frame"
+          min="0"
+          max="10"
+          step="1"
+          defaultValue={0}
+          onChange={changeFrame}
         />
       </Box>
       <DICOMImageViewer imageId={IMAGES[frame]} />

--- a/apps/insight-viewer-demo/src/containers/MultiFrame/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/MultiFrame/index.tsx
@@ -1,15 +1,10 @@
-import { Box, Heading } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 import Tabs from './Tabs'
 
 export default function MultiFrame(): JSX.Element {
   return (
-    <>
-      <Box mb={6}>
-        <Heading as="h3">InsightViewer MultiFrame</Heading>
-      </Box>
-      <Box mb={6}>
-        <Tabs />
-      </Box>
-    </>
+    <Box mb={6}>
+      <Tabs />
+    </Box>
   )
 }

--- a/apps/insight-viewer-demo/src/containers/Overlay/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Overlay/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, UnorderedList, ListItem } from '@chakra-ui/react'
+import { Box, UnorderedList, ListItem } from '@chakra-ui/react'
 import useInsightViewer, { Viewport } from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 import { WithChildren } from '../../types'
@@ -76,24 +76,18 @@ function Overlay(): JSX.Element {
   const { DICOMImageViewer, ViewportConsumer } = useInsightViewer()
 
   return (
-    <>
-      <Box mb={6}>
-        <Heading as="h3">Overlay</Heading>
+    <Box w={700}>
+      <Box w={500} h={500}>
+        <DICOMImageViewer imageId={IMAGE_ID}>
+          <ViewportConsumer>
+            {viewport => <Nested viewport={viewport} />}
+          </ViewportConsumer>
+        </DICOMImageViewer>
       </Box>
-
       <Box w={700}>
-        <Box w={500} h={500}>
-          <DICOMImageViewer imageId={IMAGE_ID}>
-            <ViewportConsumer>
-              {viewport => <Nested viewport={viewport} />}
-            </ViewportConsumer>
-          </DICOMImageViewer>
-        </Box>
-        <Box w={700}>
-          <CodeBlock code={Code} />
-        </Box>
+        <CodeBlock code={Code} />
       </Box>
-    </>
+    </Box>
   )
 }
 

--- a/apps/insight-viewer-demo/src/containers/Overlay/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Overlay/index.tsx
@@ -1,48 +1,51 @@
 import { Box, UnorderedList, ListItem } from '@chakra-ui/react'
-import useInsightViewer, { Viewport } from '@lunit/insight-viewer'
+import useInsightViewer, { useViewportContext } from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
-import { WithChildren } from '../../types'
 
 const IMAGE_ID =
   'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000011.dcm'
 
 const Code = `\
-  import useInsightViewer, { Viewport } from '@lunit/insight-viewer'
+  import useInsightViewer, { Viewport, useViewportContext } from '@lunit/insight-viewer'
 
   function Nested({ viewport }: {viewport: Viewport }) {
+    const { scale, invert, hflip, vflip, x, y, windowWidth, windowCenter } =
+      useViewportContext()
+
     return (
       <ul>
-        <li>scale: {viewport?.scale}</li>
-        <li>
-          hflip/vflip: {viewport?.hflip} / {viewport?.vflip}
-        </li>
-        <li>
-          translation: {viewport?.translation?.x} / {viewport?.translation?.y}
-        </li>
-        <li>invert: {viewport?.invert}</li>
-        <li>
-          voi: {viewport?.voi?.windowWidth} / {viewport?.voi?.windowCenter}
-        </li>
+        <li>scale: {scale}</li>
+        <li>hflip/vflip: {hflip} / {vflip}</li>
+        <li>translation: {x} / {y}</li>
+        <li>invert: {invert}</li>
+        <li>voi: {windowWidth} / {windowCenter}</li>
       </ul>
     )
   }
 
   export default function Viewer() {
-    const { DICOMImageViewer, ViewportConsumer } = useInsightViewer()
+    const { DICOMImageViewer } = useInsightViewer()
 
     return (
       <DICOMImageViewer imageId={IMAGE_ID}>
-        <ViewportConsumer>
-          {viewport => <Nested viewport={viewport} />}
-        </ViewportConsumer>
+        <Nested />
       </DICOMImageViewer>
     )
   }
   `
 
-function Nested({
-  viewport,
-}: WithChildren<{ viewport?: Viewport }>): JSX.Element {
+function Nested(): JSX.Element {
+  const {
+    scale,
+    invert,
+    hflip,
+    vflip,
+    x,
+    y,
+    windowWidth,
+    windowCenter,
+  } = useViewportContext()
+
   return (
     <Box
       position="absolute"
@@ -56,16 +59,16 @@ function Nested({
       textShadow="1px 1px 1px black"
     >
       <UnorderedList>
-        <ListItem>scale: {viewport?.scale}</ListItem>
+        <ListItem>scale: {scale}</ListItem>
         <ListItem>
-          hflip/vflip: {`${viewport?.hflip}`} / {`${viewport?.vflip}`}
+          hflip/vflip: {`${hflip}`} / {`${vflip}`}
         </ListItem>
         <ListItem>
-          translation: {viewport?.translation?.x} / {viewport?.translation?.y}
+          translation: {x} / {y}
         </ListItem>
-        <ListItem>invert: {`${viewport?.invert}`}</ListItem>
+        <ListItem>invert: {`${invert}`}</ListItem>
         <ListItem>
-          voi: {viewport?.voi?.windowWidth} / {viewport?.voi?.windowCenter}
+          voi: {windowWidth} / {windowCenter}
         </ListItem>
       </UnorderedList>
     </Box>
@@ -73,15 +76,13 @@ function Nested({
 }
 
 function Overlay(): JSX.Element {
-  const { DICOMImageViewer, ViewportConsumer } = useInsightViewer()
+  const { DICOMImageViewer } = useInsightViewer()
 
   return (
     <Box w={700}>
       <Box w={500} h={500}>
         <DICOMImageViewer imageId={IMAGE_ID}>
-          <ViewportConsumer>
-            {viewport => <Nested viewport={viewport} />}
-          </ViewportConsumer>
+          <Nested />
         </DICOMImageViewer>
       </Box>
       <Box w={700}>

--- a/apps/insight-viewer-demo/src/containers/Overlay/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Overlay/index.tsx
@@ -1,16 +1,16 @@
 import { Box, UnorderedList, ListItem } from '@chakra-ui/react'
-import useInsightViewer, { useViewportContext } from '@lunit/insight-viewer'
+import useInsightViewer, { useViewport } from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 
 const IMAGE_ID =
   'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000011.dcm'
 
 const Code = `\
-  import useInsightViewer, { Viewport, useViewportContext } from '@lunit/insight-viewer'
+  import useInsightViewer, { Viewport, useViewport } from '@lunit/insight-viewer'
 
   function Nested({ viewport }: {viewport: Viewport }) {
     const { scale, invert, hflip, vflip, x, y, windowWidth, windowCenter } =
-      useViewportContext()
+    useViewport()
 
     return (
       <ul>
@@ -44,7 +44,7 @@ function Nested(): JSX.Element {
     y,
     windowWidth,
     windowCenter,
-  } = useViewportContext()
+  } = useViewport()
 
   return (
     <Box

--- a/apps/insight-viewer-demo/src/containers/Progress/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Progress/index.tsx
@@ -1,15 +1,10 @@
-import { Box, Heading } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 import Tabs from './Tabs'
 
 export default function Error(): JSX.Element {
   return (
-    <>
-      <Box mb={6}>
-        <Heading as="h3">InsightViewer Progress</Heading>
-      </Box>
-      <Box mb={6}>
-        <Tabs />
-      </Box>
-    </>
+    <Box mb={6}>
+      <Tabs />
+    </Box>
   )
 }

--- a/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
@@ -46,13 +46,13 @@ function Viewport(): JSX.Element {
         <Box mb={6}>
           <HStack spacing="24px">
             <Box>
-              Invert{' '}
+              invert{' '}
               <Switch
                 onChange={e => setViewport({ invert: e.target.checked })}
               />
             </Box>
             <Box>
-              Hflip{' '}
+              hflip{' '}
               <Switch
                 onChange={e => setViewport({ hflip: e.target.checked })}
               />

--- a/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
@@ -7,11 +7,11 @@ const IMAGE_ID =
 
 const Code = `\
   import useInsightViewer from '@lunit/insight-viewer'
-  
-  export default function Viewer() {
+
+  export default function App() {
     const { DICOMImageViewer, setViewport } = useInsightViewer()
 
-    function handleViewport() {
+    function updateViewport() {
       setViewport({ invert: true })
       setViewport({ hflip: false })
       setViewport({ vflip: true })
@@ -27,8 +27,13 @@ const Code = `\
         windowCenter: 256 
       })
     }
-  
-    return <DICOMImageViewer imageId={IMAGE_ID} />
+
+    return (
+      <>
+        <button type="button" onClick={updateViewport}>update viewport</button>
+        <DICOMImageViewer imageId={IMAGE_ID} />
+      </>
+    )
   }
   `
 

--- a/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
@@ -12,14 +12,20 @@ const Code = `\
     const { DICOMImageViewer, setViewport } = useInsightViewer()
 
     function handleViewport() {
-      setViewport('invert', true)
-      setViewport('hflip', false)
-      setViewport('vflip', true)
-      setViewport('x', 0)
-      setViewport('y', 10)
-      setViewport('scale', 1)
-      setViewport('windowWidth', 128)
-      setViewport('windowCenter', 256)
+      setViewport({ invert: true })
+      setViewport({ hflip: false })
+      setViewport({ vflip: true })
+      setViewport({ x: 0 })
+      setViewport({ y: 10 })
+      setViewport({ scale: 1 })
+      setViewport({ windowWidth: 128 })
+      setViewport({ windowCenter: 256 })
+      // or
+      setViewport({
+        invert: false,
+        x: 10,
+        windowCenter: 256 
+      })
     }
   
     return <DICOMImageViewer imageId={IMAGE_ID} />
@@ -36,15 +42,21 @@ function Viewport(): JSX.Element {
           <HStack spacing="24px">
             <Box>
               Invert{' '}
-              <Switch onChange={e => setViewport('invert', e.target.checked)} />
+              <Switch
+                onChange={e => setViewport({ invert: e.target.checked })}
+              />
             </Box>
             <Box>
               Hflip{' '}
-              <Switch onChange={e => setViewport('hflip', e.target.checked)} />
+              <Switch
+                onChange={e => setViewport({ hflip: e.target.checked })}
+              />
             </Box>
             <Box>
               vflip{' '}
-              <Switch onChange={e => setViewport('vflip', e.target.checked)} />
+              <Switch
+                onChange={e => setViewport({ vflip: e.target.checked })}
+              />
             </Box>
           </HStack>
           <HStack spacing="24px" mt={3}>
@@ -60,7 +72,7 @@ function Viewport(): JSX.Element {
                   step="10"
                   defaultValue={0}
                   onChange={e => {
-                    setViewport('x', Number(e.target.value))
+                    setViewport({ x: Number(e.target.value) })
                   }}
                 />
               </Box>
@@ -77,7 +89,7 @@ function Viewport(): JSX.Element {
                   step="10"
                   defaultValue={0}
                   onChange={e => {
-                    setViewport('y', Number(e.target.value))
+                    setViewport({ y: Number(e.target.value) })
                   }}
                 />
               </Box>
@@ -95,7 +107,7 @@ function Viewport(): JSX.Element {
               step="0.1"
               defaultValue={1}
               onChange={e => {
-                setViewport('scale', Number(e.target.value))
+                setViewport({ scale: Number(e.target.value) })
               }}
             />
           </Box>
@@ -112,7 +124,7 @@ function Viewport(): JSX.Element {
                   step="25.6"
                   defaultValue={128}
                   onChange={e => {
-                    setViewport('windowWidth', Number(e.target.value))
+                    setViewport({ windowWidth: Number(e.target.value) })
                   }}
                 />
               </Box>
@@ -129,7 +141,7 @@ function Viewport(): JSX.Element {
                   step="25.6"
                   defaultValue={128}
                   onChange={e => {
-                    setViewport('windowCenter', Number(e.target.value))
+                    setViewport({ windowCenter: Number(e.target.value) })
                   }}
                 />
               </Box>

--- a/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, HStack, Switch } from '@chakra-ui/react'
+import { Box, HStack, Switch } from '@chakra-ui/react'
 import useInsightViewer from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 
@@ -31,10 +31,6 @@ function Viewport(): JSX.Element {
 
   return (
     <>
-      <Box mb={6}>
-        <Heading as="h3">Viewport</Heading>
-      </Box>
-
       <Box w={700}>
         <Box mb={6}>
           <HStack spacing="24px">

--- a/packages/insight-viewer/jest.config.js
+++ b/packages/insight-viewer/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   ...baseConfig,
   name: packageJson.name,
   displayName: packageJson.name,
+  roots: ['<rootDir>/src'],
 }

--- a/packages/insight-viewer/package.json
+++ b/packages/insight-viewer/package.json
@@ -59,7 +59,7 @@
     "@storybook/addon-essentials": "^6.2.3",
     "@storybook/addon-links": "^6.2.3",
     "@storybook/react": "^6.2.3",
-    "@types/jest": "^26.0.22",
+    "@types/jest": "^26.0.23",
     "@types/react": "^17.0.3",
     "@types/styled-components": "^5.1.9",
     "babel-loader": "^8.2.2",

--- a/packages/insight-viewer/src/Context/Viewport.tsx
+++ b/packages/insight-viewer/src/Context/Viewport.tsx
@@ -1,27 +1,46 @@
 import React, { createContext, useEffect, useState } from 'react'
 import { WithChildren, Element } from '../types'
-import {
-  getViewport,
-  EVENT,
-  CornerstoneViewport,
-} from '../utils/cornerstoneHelper'
+import { getViewport, EVENT } from '../utils/cornerstoneHelper'
+import { formatViewport } from '../utils/common/formatViewport'
 
-const ViewportContext =
-  createContext<CornerstoneViewport | undefined>(undefined)
+export interface Viewport {
+  scale: number
+  invert: boolean
+  hflip: boolean
+  vflip: boolean
+  x: number
+  y: number
+  windowWidth: number
+  windowCenter: number
+}
 
-export type Viewport = CornerstoneViewport | undefined
+export const ViewportContextDefaultValue: Viewport = {
+  scale: 1,
+  invert: false,
+  hflip: false,
+  vflip: false,
+  x: 0,
+  y: 0,
+  windowWidth: 127,
+  windowCenter: 256,
+}
+
+const ViewportContext = createContext<Viewport>(ViewportContextDefaultValue)
 
 export function ViewportContextProvider({
   element,
   children,
 }: WithChildren<{ element: Element }>): JSX.Element {
-  const [viewport, setViewport] = useState<Viewport>(undefined)
+  const [viewport, setViewport] = useState<Viewport>(
+    ViewportContextDefaultValue
+  )
 
   useEffect(() => {
     if (!element) return undefined
 
     function onRender(): void {
-      setViewport(getViewport(element as HTMLDivElement))
+      const v = getViewport(element as HTMLDivElement)
+      setViewport(formatViewport(v))
     }
 
     element.addEventListener(EVENT.IMAGE_RENDERED, onRender)

--- a/packages/insight-viewer/src/Context/Viewport.tsx
+++ b/packages/insight-viewer/src/Context/Viewport.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useEffect, useState } from 'react'
-import { WithChildren } from '../types'
+import { WithChildren, Element } from '../types'
 import {
   getViewport,
   EVENT,
@@ -14,7 +14,7 @@ export type Viewport = CornerstoneViewport | undefined
 export function ViewportContextProvider({
   element,
   children,
-}: WithChildren<{ element: HTMLDivElement | null }>): JSX.Element {
+}: WithChildren<{ element: Element }>): JSX.Element {
   const [viewport, setViewport] = useState<Viewport>(undefined)
 
   useEffect(() => {

--- a/packages/insight-viewer/src/Context/Viewport/const.ts
+++ b/packages/insight-viewer/src/Context/Viewport/const.ts
@@ -1,0 +1,12 @@
+import { Viewport } from './types'
+
+export const ViewportContextDefaultValue: Viewport = {
+  scale: 1,
+  invert: false,
+  hflip: false,
+  vflip: false,
+  x: 0,
+  y: 0,
+  windowWidth: 127,
+  windowCenter: 256,
+}

--- a/packages/insight-viewer/src/Context/Viewport/index.tsx
+++ b/packages/insight-viewer/src/Context/Viewport/index.tsx
@@ -1,29 +1,9 @@
 import React, { createContext, useEffect, useState } from 'react'
-import { WithChildren, Element } from '../types'
-import { getViewport, EVENT } from '../utils/cornerstoneHelper'
-import { formatViewport } from '../utils/common/formatViewport'
-
-export interface Viewport {
-  scale: number
-  invert: boolean
-  hflip: boolean
-  vflip: boolean
-  x: number
-  y: number
-  windowWidth: number
-  windowCenter: number
-}
-
-export const ViewportContextDefaultValue: Viewport = {
-  scale: 1,
-  invert: false,
-  hflip: false,
-  vflip: false,
-  x: 0,
-  y: 0,
-  windowWidth: 127,
-  windowCenter: 256,
-}
+import { WithChildren, Element } from '../../types'
+import { getViewport, EVENT } from '../../utils/cornerstoneHelper'
+import { formatViewport } from '../../utils/common/formatViewport'
+import { Viewport } from './types'
+import { ViewportContextDefaultValue } from './const'
 
 const ViewportContext = createContext<Viewport>(ViewportContextDefaultValue)
 
@@ -39,8 +19,8 @@ export function ViewportContextProvider({
     if (!element) return undefined
 
     function onRender(): void {
-      const v = getViewport(element as HTMLDivElement)
-      setViewport(formatViewport(v))
+      const currentViewport = getViewport(element as HTMLDivElement)
+      setViewport(formatViewport(currentViewport))
     }
 
     element.addEventListener(EVENT.IMAGE_RENDERED, onRender)

--- a/packages/insight-viewer/src/Context/Viewport/index.tsx
+++ b/packages/insight-viewer/src/Context/Viewport/index.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useState } from 'react'
+import React, { createContext, useEffect, useState, useContext } from 'react'
 import { WithChildren, Element } from '../../types'
 import { getViewport, EVENT } from '../../utils/cornerstoneHelper'
 import { formatViewport } from '../../utils/common/formatViewport'
@@ -37,3 +37,18 @@ export function ViewportContextProvider({
 }
 
 export default ViewportContext
+
+export function useViewportContext(): Viewport {
+  const {
+    scale,
+    invert,
+    hflip,
+    vflip,
+    x,
+    y,
+    windowWidth,
+    windowCenter,
+  } = useContext(ViewportContext)
+
+  return { scale, invert, hflip, vflip, x, y, windowWidth, windowCenter }
+}

--- a/packages/insight-viewer/src/Context/Viewport/types.ts
+++ b/packages/insight-viewer/src/Context/Viewport/types.ts
@@ -1,0 +1,10 @@
+export interface Viewport {
+  scale: number
+  invert: boolean
+  hflip: boolean
+  vflip: boolean
+  x: number
+  y: number
+  windowWidth: number
+  windowCenter: number
+}

--- a/packages/insight-viewer/src/Context/index.tsx
+++ b/packages/insight-viewer/src/Context/index.tsx
@@ -10,6 +10,6 @@ export const ContextDefaultValue: ContextProp = {
   setHeader: _request => {},
 }
 
-const Context = createContext<ContextProp>(ContextDefaultValue)
+const LoaderContext = createContext<ContextProp>(ContextDefaultValue)
 
-export default Context
+export default LoaderContext

--- a/packages/insight-viewer/src/Viewer/DICOMImagesViewer.tsx
+++ b/packages/insight-viewer/src/Viewer/DICOMImagesViewer.tsx
@@ -2,16 +2,14 @@ import React, { useRef } from 'react'
 import ViewerWrapper from '../components/ViewerWrapper'
 import { WithChildren } from '../types'
 import useDICOMImageLoader from '../hooks/useDICOMImageLoader'
-import usePrefetch from '../hooks/usePrefetch'
 import { VIEWER_TYPE } from '../const'
 
 export function DICOMImagesViewer({
   imageId,
-  images,
   children,
-}: WithChildren<{ imageId: string; images: string[] }>): JSX.Element {
+}: WithChildren<{ imageId: string }>): JSX.Element {
   const elRef = useRef<HTMLDivElement>(null)
-  usePrefetch(images)
+
   useDICOMImageLoader({
     imageId,
     element: elRef.current,

--- a/packages/insight-viewer/src/components/LoadingProgress/index.tsx
+++ b/packages/insight-viewer/src/components/LoadingProgress/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useContext } from 'react'
 import styled from 'styled-components'
 import { Subscription } from 'rxjs'
-import ViewContext from '../../Context'
+import LoaderContext from '../../Context'
 import { loadingProgressMessage } from '../../utils/messageService'
 
 const ProgressWrapper = styled.div`
@@ -15,7 +15,7 @@ const ProgressWrapper = styled.div`
 let subscription: Subscription
 
 export default function LoadingProgress(): JSX.Element {
-  const { Progress } = useContext(ViewContext)
+  const { Progress } = useContext(LoaderContext)
   const [{ progress, hidden }, setState] = useState<{
     progress?: number
     hidden: boolean

--- a/packages/insight-viewer/src/components/ViewerWrapper/index.tsx
+++ b/packages/insight-viewer/src/components/ViewerWrapper/index.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react'
-import { WithChildren, ViewerType } from '../../types'
+import { WithChildren, ViewerType, Element } from '../../types'
 import LoadingProgress from '../LoadingProgress'
 import Wrapper from './Wrapper'
 import { VIEWER_TYPE } from '../../const'
@@ -19,7 +19,7 @@ const ViewerWrapper = forwardRef<
       {type === VIEWER_TYPE.DICOM && <LoadingProgress />}
       <canvas className="cornerstone-canvas" />
       <ViewportContextProvider
-        element={(ref as React.MutableRefObject<HTMLDivElement | null>).current}
+        element={(ref as React.MutableRefObject<Element>).current}
       >
         {children}
       </ViewportContextProvider>

--- a/packages/insight-viewer/src/components/ViewerWrapper/useResize.ts
+++ b/packages/insight-viewer/src/components/ViewerWrapper/useResize.ts
@@ -1,14 +1,12 @@
 import React, { useCallback } from 'react'
 import { useResizeDetector } from 'react-resize-detector'
 import { resize } from '../../utils/cornerstoneHelper'
+import { Element } from '../../types'
 
-export default function useResize(
-  ref: React.ForwardedRef<HTMLDivElement>
-): {
+export default function useResize(ref: React.ForwardedRef<HTMLDivElement>): {
   resizeRef: React.RefObject<HTMLDivElement>
 } {
-  const element = (ref as React.MutableRefObject<HTMLDivElement | null>)
-    ?.current
+  const element = (ref as React.MutableRefObject<Element>)?.current
 
   const handleResize = useCallback(() => {
     if (!element) return undefined

--- a/packages/insight-viewer/src/components/ViewerWrapper/useResize.ts
+++ b/packages/insight-viewer/src/components/ViewerWrapper/useResize.ts
@@ -3,7 +3,9 @@ import { useResizeDetector } from 'react-resize-detector'
 import { resize } from '../../utils/cornerstoneHelper'
 import { Element } from '../../types'
 
-export default function useResize(ref: React.ForwardedRef<HTMLDivElement>): {
+export default function useResize(
+  ref: React.ForwardedRef<HTMLDivElement>
+): {
   resizeRef: React.RefObject<HTMLDivElement>
 } {
   const element = (ref as React.MutableRefObject<Element>)?.current

--- a/packages/insight-viewer/src/hooks/useCornerstone.ts
+++ b/packages/insight-viewer/src/hooks/useCornerstone.ts
@@ -2,10 +2,11 @@ import { useEffect } from 'react'
 import { Subscription } from 'rxjs'
 import { enable, disable } from '../utils/cornerstoneHelper'
 import { cornerstoneMessage } from '../utils/messageService'
+import { Element } from '../types'
 
 let subscription: Subscription
 
-export default function useCornerstone(element: HTMLDivElement | null): void {
+export default function useCornerstone(element: Element): void {
   useEffect(() => {
     if (!element) return undefined
 

--- a/packages/insight-viewer/src/hooks/useCornerstone.ts
+++ b/packages/insight-viewer/src/hooks/useCornerstone.ts
@@ -1,24 +1,14 @@
 import { useEffect } from 'react'
-import { Subscription } from 'rxjs'
 import { enable, disable } from '../utils/cornerstoneHelper'
-import { cornerstoneMessage } from '../utils/messageService'
 import { Element } from '../types'
-
-let subscription: Subscription
 
 export default function useCornerstone(element: Element): void {
   useEffect(() => {
     if (!element) return undefined
-
-    subscription = cornerstoneMessage
-      .getMessage()
-      .subscribe((message: boolean) => {
-        if (message) enable(element)
-        if (!message) disable(element)
-      })
+    enable(element)
 
     return () => {
-      subscription.unsubscribe()
+      disable(element)
     }
   }, [element])
 }

--- a/packages/insight-viewer/src/hooks/useDICOMImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useDICOMImageLoader.ts
@@ -6,10 +6,11 @@ import { setWadoImageLoader } from '../utils/cornerstoneHelper'
 import useCornerstone from './useCornerstone'
 import useImageLoader from './useImageLoader'
 import ViewContext from '../Context'
+import { Element } from '../types'
 
 interface Prop {
   imageId: string
-  element: HTMLDivElement | null
+  element: Element
   isSingleImage: boolean
 }
 

--- a/packages/insight-viewer/src/hooks/useDICOMImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useDICOMImageLoader.ts
@@ -5,7 +5,7 @@ import { useContext } from 'react'
 import { setWadoImageLoader } from '../utils/cornerstoneHelper'
 import useCornerstone from './useCornerstone'
 import useImageLoader from './useImageLoader'
-import ViewContext from '../Context'
+import LoaderContext from '../Context'
 import { Element } from '../types'
 
 interface Prop {
@@ -19,7 +19,7 @@ export default async function useDICOMImageLoader({
   element,
   isSingleImage,
 }: Prop): Promise<void> {
-  const { onError } = useContext(ViewContext)
+  const { onError } = useContext(LoaderContext)
   useCornerstone(element)
 
   useImageLoader({

--- a/packages/insight-viewer/src/hooks/useImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useImageLoader.ts
@@ -5,7 +5,7 @@ import {
 } from '../utils/cornerstoneHelper'
 import getHttpClient from '../utils/httpClient'
 import { loadingProgressMessage } from '../utils/messageService'
-import ViewContext from '../Context'
+import LoaderContext from '../Context'
 import useViewport from './useViewport'
 import { Element } from '../types'
 
@@ -23,7 +23,7 @@ export default function useImageLoader({
   isSingleImage = true,
 }: Prop): void {
   const [hasLoader, setHasLoader] = useState(false)
-  const { onError, setHeader } = useContext(ViewContext)
+  const { onError, setHeader } = useContext(LoaderContext)
 
   // eslint-disable-next-line no-extra-semi
   ;(async function asyncLoad(): Promise<undefined> {

--- a/packages/insight-viewer/src/hooks/useImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useImageLoader.ts
@@ -7,10 +7,11 @@ import getHttpClient from '../utils/httpClient'
 import { loadingProgressMessage } from '../utils/messageService'
 import ViewContext from '../Context'
 import useViewport from './useViewport'
+import { Element } from '../types'
 
 interface Prop {
   imageId: string
-  element: HTMLDivElement | null
+  element: Element
   setLoader: () => Promise<boolean>
   isSingleImage?: boolean
 }

--- a/packages/insight-viewer/src/hooks/useInsightViewer.tsx
+++ b/packages/insight-viewer/src/hooks/useInsightViewer.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import ViewContext, { ContextDefaultValue } from '../Context'
+import LoaderContext, { ContextDefaultValue } from '../Context'
 import { DICOMImageViewer, DICOMImagesViewer, WebImageViewer } from '../Viewer'
 import { handleError } from '../utils/common'
 import { viewportMessage } from '../utils/messageService'
@@ -34,13 +34,13 @@ export default function useInsightViewer(
     imageId: string
   }>): JSX.Element {
     return (
-      <ViewContext.Provider value={{ onError, Progress, setHeader }}>
+      <LoaderContext.Provider value={{ onError, Progress, setHeader }}>
         {images.length > 1 ? (
           <DICOMImagesViewer imageId={imageId}>{children}</DICOMImagesViewer>
         ) : (
           <DICOMImageViewer imageId={imageId}>{children}</DICOMImageViewer>
         )}
-      </ViewContext.Provider>
+      </LoaderContext.Provider>
     )
   }
 
@@ -51,9 +51,9 @@ export default function useInsightViewer(
     imageId: string
   }>): JSX.Element {
     return (
-      <ViewContext.Provider value={{ onError, Progress, setHeader }}>
+      <LoaderContext.Provider value={{ onError, Progress, setHeader }}>
         <WebImageViewer imageId={imageId}>{children}</WebImageViewer>
-      </ViewContext.Provider>
+      </LoaderContext.Provider>
     )
   }
 

--- a/packages/insight-viewer/src/hooks/useInsightViewer.tsx
+++ b/packages/insight-viewer/src/hooks/useInsightViewer.tsx
@@ -6,7 +6,6 @@ import { viewportMessage } from '../utils/messageService'
 import CircularProgress from '../components/CircularProgress'
 import { Viewer, ContextProp, WithChildren } from '../types'
 import useFrame, { UseFrame } from './useFrame'
-import ViewportContext from '../Context/Viewport'
 import usePrefetch from './usePrefetch'
 
 export default function useInsightViewer(
@@ -27,7 +26,6 @@ export default function useInsightViewer(
   WebImageViewer: Viewer
   useFrame: UseFrame
   setViewport: typeof viewportMessage.sendMessage
-  ViewportConsumer: typeof ViewportContext.Consumer
 } {
   function DICOMImageViewerWithContent({
     imageId,
@@ -66,6 +64,5 @@ export default function useInsightViewer(
     WebImageViewer: WebImageViewerWithContent,
     useFrame,
     setViewport: viewportMessage.sendMessage,
-    ViewportConsumer: ViewportContext.Consumer,
   }
 }

--- a/packages/insight-viewer/src/hooks/useInsightViewer.tsx
+++ b/packages/insight-viewer/src/hooks/useInsightViewer.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import ViewContext, { ContextDefaultValue } from '../Context'
 import { DICOMImageViewer, DICOMImagesViewer, WebImageViewer } from '../Viewer'
 import { handleError } from '../utils/common'
-import { cornerstoneMessage, viewportMessage } from '../utils/messageService'
+import { viewportMessage } from '../utils/messageService'
 import CircularProgress from '../components/CircularProgress'
 import { Viewer, ContextProp, WithChildren } from '../types'
 import useFrame, { UseFrame } from './useFrame'
@@ -59,14 +59,6 @@ export default function useInsightViewer(
       </ViewContext.Provider>
     )
   }
-
-  useEffect(() => {
-    cornerstoneMessage.sendMessage(true)
-
-    return () => {
-      cornerstoneMessage.sendMessage(false)
-    }
-  }, [])
 
   return {
     DICOMImageViewer: DICOMImageViewerWithContent,

--- a/packages/insight-viewer/src/hooks/useInsightViewer.tsx
+++ b/packages/insight-viewer/src/hooks/useInsightViewer.tsx
@@ -7,6 +7,7 @@ import CircularProgress from '../components/CircularProgress'
 import { Viewer, ContextProp, WithChildren } from '../types'
 import useFrame, { UseFrame } from './useFrame'
 import ViewportContext from '../Context/Viewport'
+import usePrefetch from './usePrefetch'
 
 export default function useInsightViewer(
   {
@@ -37,9 +38,7 @@ export default function useInsightViewer(
     return (
       <ViewContext.Provider value={{ onError, Progress, setHeader }}>
         {images.length > 1 ? (
-          <DICOMImagesViewer imageId={imageId} images={images}>
-            {children}
-          </DICOMImagesViewer>
+          <DICOMImagesViewer imageId={imageId}>{children}</DICOMImagesViewer>
         ) : (
           <DICOMImageViewer imageId={imageId}>{children}</DICOMImageViewer>
         )}
@@ -59,6 +58,8 @@ export default function useInsightViewer(
       </ViewContext.Provider>
     )
   }
+
+  usePrefetch(images)
 
   return {
     DICOMImageViewer: DICOMImageViewerWithContent,

--- a/packages/insight-viewer/src/hooks/usePrefetch.ts
+++ b/packages/insight-viewer/src/hooks/usePrefetch.ts
@@ -1,5 +1,5 @@
 import { useEffect, useContext } from 'react'
-import ViewContext from '../Context'
+import LoaderContext from '../Context'
 import {
   loadImage,
   setWadoImageLoader,
@@ -48,7 +48,7 @@ async function prefetch({ images, setHeader, onError }: Load) {
 }
 
 export default function usePrefetch(images: string[]): void {
-  const { onError, setHeader } = useContext(ViewContext)
+  const { onError, setHeader } = useContext(LoaderContext)
 
   useEffect(() => {
     let loaded = false

--- a/packages/insight-viewer/src/hooks/useViewport.ts
+++ b/packages/insight-viewer/src/hooks/useViewport.ts
@@ -7,6 +7,7 @@ import {
 } from '../utils/cornerstoneHelper'
 import { viewportMessage } from '../utils/messageService'
 import { ViewportMessageProp } from '../utils/messageService/viewport'
+import { Element } from '../types'
 
 function format(
   key: string,
@@ -37,7 +38,7 @@ function format(
 
 let subscription: Subscription
 
-export default function useViewport(element: HTMLDivElement | null): void {
+export default function useViewport(element: Element): void {
   useEffect(() => {
     if (!element) return undefined
 

--- a/packages/insight-viewer/src/hooks/useViewport.ts
+++ b/packages/insight-viewer/src/hooks/useViewport.ts
@@ -6,35 +6,9 @@ import {
   CornerstoneViewport,
 } from '../utils/cornerstoneHelper'
 import { viewportMessage } from '../utils/messageService'
-import { ViewportMessageProp } from '../utils/messageService/viewport'
+import { formatCornerstoneViewport } from '../utils/common/formatViewport'
 import { Element } from '../types'
-
-function format(
-  key: string,
-  value: unknown,
-  viewport: CornerstoneViewport
-): Record<string, unknown> {
-  if (key === 'x' || key === 'y') {
-    return {
-      translation: {
-        ...viewport.translation,
-        [key]: value,
-      },
-    }
-  }
-  if (key === 'windowWidth' || key === 'windowCenter') {
-    return {
-      voi: {
-        ...viewport.voi,
-        [key]: value,
-      },
-    }
-  }
-
-  return {
-    [key]: value,
-  }
-}
+import { Viewport } from '../Context/Viewport'
 
 let subscription: Subscription
 
@@ -45,14 +19,16 @@ export default function useViewport(element: Element): void {
     subscription = viewportMessage
       .getMessage()
 
-      .subscribe(({ key, value }: ViewportMessageProp) => {
-        const viewport = getViewport(<HTMLDivElement>element)
+      .subscribe((message: Partial<Viewport>) => {
+        const viewport = getViewport(
+          <HTMLDivElement>element
+        ) as CornerstoneViewport
 
         if (viewport)
-          setViewport(<HTMLDivElement>element, {
-            ...viewport,
-            ...format(key, value, viewport),
-          })
+          setViewport(
+            <HTMLDivElement>element,
+            formatCornerstoneViewport(viewport, message)
+          )
       })
 
     return () => {

--- a/packages/insight-viewer/src/hooks/useViewport.ts
+++ b/packages/insight-viewer/src/hooks/useViewport.ts
@@ -8,7 +8,7 @@ import {
 import { viewportMessage } from '../utils/messageService'
 import { formatCornerstoneViewport } from '../utils/common/formatViewport'
 import { Element } from '../types'
-import { Viewport } from '../Context/Viewport'
+import { Viewport } from '../Context/Viewport/types'
 
 let subscription: Subscription
 

--- a/packages/insight-viewer/src/hooks/useWebImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useWebImageLoader.ts
@@ -6,7 +6,7 @@ import { getCornerstone } from '../utils/cornerstoneHelper'
 import useCornerstone from './useCornerstone'
 import useImageLoader from './useImageLoader'
 import ViewContext from '../Context'
-import { OnError } from '../types'
+import { OnError, Element } from '../types'
 
 async function setLoader(onError: OnError): Promise<boolean> {
   try {
@@ -24,7 +24,7 @@ async function setLoader(onError: OnError): Promise<boolean> {
 
 export default async function useWebImageLoader(
   imageId: string,
-  element: HTMLDivElement | null
+  element: Element
 ): Promise<void> {
   const { onError } = useContext(ViewContext)
 

--- a/packages/insight-viewer/src/hooks/useWebImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useWebImageLoader.ts
@@ -5,7 +5,7 @@ import { useContext } from 'react'
 import { getCornerstone } from '../utils/cornerstoneHelper'
 import useCornerstone from './useCornerstone'
 import useImageLoader from './useImageLoader'
-import ViewContext from '../Context'
+import LoaderContext from '../Context'
 import { OnError, Element } from '../types'
 
 async function setLoader(onError: OnError): Promise<boolean> {
@@ -26,7 +26,7 @@ export default async function useWebImageLoader(
   imageId: string,
   element: Element
 ): Promise<void> {
-  const { onError } = useContext(ViewContext)
+  const { onError } = useContext(LoaderContext)
 
   useCornerstone(element)
 

--- a/packages/insight-viewer/src/index.ts
+++ b/packages/insight-viewer/src/index.ts
@@ -1,2 +1,2 @@
 export { default } from './hooks/useInsightViewer'
-export type { Viewport } from './Context/Viewport'
+export type { Viewport } from './Context/Viewport/types'

--- a/packages/insight-viewer/src/index.ts
+++ b/packages/insight-viewer/src/index.ts
@@ -1,3 +1,3 @@
 export { default } from './hooks/useInsightViewer'
 export type { Viewport } from './Context/Viewport/types'
-export { useViewportContext } from './Context/Viewport'
+export { useViewportContext as useViewport } from './Context/Viewport'

--- a/packages/insight-viewer/src/index.ts
+++ b/packages/insight-viewer/src/index.ts
@@ -1,2 +1,3 @@
 export { default } from './hooks/useInsightViewer'
 export type { Viewport } from './Context/Viewport/types'
+export { useViewportContext } from './Context/Viewport'

--- a/packages/insight-viewer/src/types/index.ts
+++ b/packages/insight-viewer/src/types/index.ts
@@ -3,7 +3,7 @@ import { VIEWER_TYPE } from '../const'
 export type WithChildren<T = Record<string, unknown>> = T & {
   children?: React.ReactNode
 }
-
+export type Element = HTMLDivElement | null
 export type ViewerType = typeof VIEWER_TYPE[keyof typeof VIEWER_TYPE]
 export type OnError = (e: Error) => void
 export type Progress = ({ progress }: { progress: number }) => JSX.Element

--- a/packages/insight-viewer/src/utils/common/formatViewport.spec.ts
+++ b/packages/insight-viewer/src/utils/common/formatViewport.spec.ts
@@ -1,0 +1,219 @@
+import { formatViewport, formatCornerstoneViewport } from './formatViewport'
+import { ViewportContextDefaultValue } from '../../Context/Viewport/const'
+
+describe('formatViewport:', () => {
+  it('cornerstone viewport should be formatted', () => {
+    const viewportData = {
+      colormap: undefined,
+      displayedArea: {
+        brhc: { x: 512, y: 512 },
+        columnPixelSpacing: 0.488281,
+        presentationSizeMode: 'NONE',
+        rowPixelSpacing: 0.488281,
+        tlhc: { x: 1, y: 1 },
+      },
+      hflip: false,
+      invert: false,
+      labelmap: false,
+      modalityLUT: undefined,
+      pixelReplication: false,
+      rotation: 0,
+      scale: 0.9765625,
+      translation: { x: 0, y: 0 },
+      vflip: false,
+      voi: { windowWidth: 90, windowCenter: 32 },
+      voiLUT: undefined,
+    }
+
+    expect(formatViewport(viewportData)).toEqual({
+      scale: viewportData.scale,
+      invert: viewportData.invert,
+      hflip: viewportData.hflip,
+      vflip: viewportData.vflip,
+      x: viewportData.translation.x,
+      y: viewportData.translation.y,
+      windowWidth: viewportData.voi.windowWidth,
+      windowCenter: viewportData.voi.windowCenter,
+    })
+  })
+
+  it('undefined cornerstone viewport should be default viewport context value', () => {
+    expect(formatViewport(undefined)).toEqual(ViewportContextDefaultValue)
+  })
+})
+
+describe('formatCornerstoneViewport:', () => {
+  const viewportData = {
+    colormap: undefined,
+    displayedArea: {
+      brhc: { x: 512, y: 512 },
+      columnPixelSpacing: 0.488281,
+      presentationSizeMode: 'NONE',
+      rowPixelSpacing: 0.488281,
+      tlhc: { x: 1, y: 1 },
+    },
+    hflip: false,
+    invert: false,
+    labelmap: false,
+    modalityLUT: undefined,
+    pixelReplication: false,
+    rotation: 0,
+    scale: 0.9765625,
+    translation: { x: 0, y: 0 },
+    vflip: false,
+    voi: { windowWidth: 90, windowCenter: 32 },
+    voiLUT: undefined,
+  }
+
+  describe('single viewport property should be formatted', () => {
+    describe('scale/invert/hflip/vflip viewport property', () => {
+      it('scale', () => {
+        expect(
+          formatCornerstoneViewport(viewportData, {
+            scale: 0,
+          })
+        ).toEqual({ ...viewportData, scale: 0 })
+      })
+      it('invert', () => {
+        expect(
+          formatCornerstoneViewport(viewportData, {
+            invert: true,
+          })
+        ).toEqual({ ...viewportData, invert: true })
+      })
+      it('hflip', () => {
+        expect(
+          formatCornerstoneViewport(viewportData, {
+            hflip: true,
+          })
+        ).toEqual({ ...viewportData, hflip: true })
+      })
+      it('vflip', () => {
+        expect(
+          formatCornerstoneViewport(viewportData, {
+            vflip: false,
+          })
+        ).toEqual({ ...viewportData, vflip: false })
+      })
+    })
+
+    describe('translation/voi viewport property', () => {
+      it('x', () => {
+        expect(
+          formatCornerstoneViewport(viewportData, {
+            x: 10,
+          })
+        ).toEqual({
+          ...viewportData,
+          translation: { x: 10, y: viewportData.translation.y },
+        })
+      })
+      it('y', () => {
+        expect(
+          formatCornerstoneViewport(viewportData, {
+            y: 10,
+          })
+        ).toEqual({
+          ...viewportData,
+          translation: { x: viewportData.translation.x, y: 10 },
+        })
+      })
+      it('windowWidth', () => {
+        expect(
+          formatCornerstoneViewport(viewportData, {
+            windowWidth: 10,
+          })
+        ).toEqual({
+          ...viewportData,
+          // voi: { windowWidth: 90, windowCenter: 32 },
+          voi: {
+            windowWidth: 10,
+            windowCenter: viewportData.voi.windowCenter,
+          },
+        })
+      })
+      it('windowCenter', () => {
+        expect(
+          formatCornerstoneViewport(viewportData, {
+            windowCenter: 10,
+          })
+        ).toEqual({
+          ...viewportData,
+          voi: { windowWidth: viewportData.voi.windowWidth, windowCenter: 10 },
+        })
+      })
+    })
+
+    describe('multiple viewport properties', () => {
+      it('scale + invert', () => {
+        expect(
+          formatCornerstoneViewport(viewportData, {
+            scale: 20,
+            invert: false,
+          })
+        ).toEqual({ ...viewportData, scale: 20, invert: false })
+      })
+      it('scale + invert + hflip + vflip', () => {
+        expect(
+          formatCornerstoneViewport(viewportData, {
+            scale: 10,
+            invert: false,
+            hflip: true,
+            vflip: true,
+          })
+        ).toEqual({
+          ...viewportData,
+          scale: 10,
+          invert: false,
+          hflip: true,
+          vflip: true,
+        })
+      })
+    })
+    it('x + y', () => {
+      expect(
+        formatCornerstoneViewport(viewportData, {
+          x: 10,
+          y: 10,
+        })
+      ).toEqual({ ...viewportData, translation: { x: 10, y: 10 } })
+    })
+    it('windowWidth + windowCenter', () => {
+      expect(
+        formatCornerstoneViewport(viewportData, {
+          windowWidth: 50,
+          windowCenter: 50,
+        })
+      ).toEqual({
+        ...viewportData,
+        voi: { windowWidth: 50, windowCenter: 50 },
+      })
+    })
+    it('x + windowWidth + windowCenter', () => {
+      expect(
+        formatCornerstoneViewport(viewportData, {
+          x: 100,
+          windowWidth: 80,
+          windowCenter: 90,
+        })
+      ).toEqual({
+        ...viewportData,
+        translation: { x: 100, y: viewportData.translation.y },
+        voi: { windowWidth: 80, windowCenter: 90 },
+      })
+    })
+  })
+
+  describe('invalid custom viewport should be ignored', () => {
+    it('undefined viewport', () => {
+      expect(formatCornerstoneViewport(viewportData, undefined)).toEqual({
+        ...viewportData,
+      })
+    })
+    it('empty object viewport', () => {
+      expect(formatCornerstoneViewport(viewportData, {})).toEqual({
+        ...viewportData,
+      })
+    })
+  })
+})

--- a/packages/insight-viewer/src/utils/common/formatViewport.ts
+++ b/packages/insight-viewer/src/utils/common/formatViewport.ts
@@ -1,0 +1,56 @@
+import { CornerstoneViewport } from '../cornerstoneHelper'
+import { Viewport } from '../../Context/Viewport/types'
+import { ViewportContextDefaultValue } from '../../Context/Viewport/const'
+
+const nestedKeys = ['x', 'y', 'windowWidth', 'windowCenter']
+
+export function formatViewport(
+  cornerstoneViewport: CornerstoneViewport | undefined
+): Viewport {
+  if (!cornerstoneViewport) return ViewportContextDefaultValue
+
+  const { scale, invert, hflip, vflip, translation, voi } = cornerstoneViewport
+
+  return {
+    scale,
+    invert,
+    hflip,
+    vflip,
+    x: translation.x,
+    y: translation.y,
+    windowWidth: voi.windowWidth,
+    windowCenter: voi.windowCenter,
+  }
+}
+
+type ViewportEntry = [keyof Viewport, Viewport[keyof Viewport]]
+
+export function formatCornerstoneViewport(
+  cornerstoneViewport: CornerstoneViewport,
+  viewport: Partial<Viewport> = {}
+): CornerstoneViewport {
+  const translationOrVoiEntries = (Object.entries(
+    viewport
+  ) as ViewportEntry[]).filter(entry => nestedKeys.includes(entry[0]))
+  const translationOrVoi = Object.fromEntries(
+    translationOrVoiEntries
+  ) as Record<keyof Viewport, number>
+
+  return {
+    ...cornerstoneViewport,
+    scale: viewport.scale ?? cornerstoneViewport.scale,
+    invert: viewport.invert ?? cornerstoneViewport.invert,
+    hflip: viewport.hflip ?? cornerstoneViewport.hflip,
+    vflip: viewport.vflip ?? cornerstoneViewport.vflip,
+    translation: {
+      x: translationOrVoi.x ?? cornerstoneViewport.translation.x,
+      y: translationOrVoi.y ?? cornerstoneViewport.translation.y,
+    },
+    voi: {
+      windowWidth:
+        translationOrVoi.windowWidth ?? cornerstoneViewport.voi.windowWidth,
+      windowCenter:
+        translationOrVoi.windowCenter ?? cornerstoneViewport.voi.windowCenter,
+    },
+  }
+}

--- a/packages/insight-viewer/src/utils/cornerstoneHelper/utils.ts
+++ b/packages/insight-viewer/src/utils/cornerstoneHelper/utils.ts
@@ -1,5 +1,8 @@
 import cornerstone from 'cornerstone-core'
 
+export type Image = cornerstone.Image
+export type CornerstoneViewport = cornerstone.Viewport
+
 export function enable(element: HTMLDivElement): void {
   cornerstone.enable(element)
 }
@@ -33,7 +36,7 @@ export function loadImage(
 
 export function getViewport(
   element: HTMLDivElement
-): ReturnType<typeof cornerstone.getViewport> {
+): cornerstone.Viewport | undefined {
   return cornerstone.getViewport(element)
 }
 
@@ -43,9 +46,6 @@ export function setViewport(
 ): ReturnType<typeof cornerstone.setViewport> {
   return cornerstone.setViewport(element, viewport)
 }
-
-export type Image = cornerstone.Image
-export type CornerstoneViewport = cornerstone.Viewport
 
 export const EVENT = {
   IMAGE_RENDERED: 'cornerstoneimagerendered',

--- a/packages/insight-viewer/src/utils/messageService/cornerstone.ts
+++ b/packages/insight-viewer/src/utils/messageService/cornerstone.ts
@@ -1,8 +1,0 @@
-import { Observable, BehaviorSubject } from 'rxjs'
-
-const subject = new BehaviorSubject<boolean>(true)
-
-export const cornerstoneMessage = {
-  sendMessage: (message: boolean): void => subject.next(message),
-  getMessage: (): Observable<boolean> => subject.asObservable(),
-}

--- a/packages/insight-viewer/src/utils/messageService/index.ts
+++ b/packages/insight-viewer/src/utils/messageService/index.ts
@@ -1,3 +1,2 @@
 export { loadingProgressMessage } from './loadingProgress'
-export { cornerstoneMessage } from './cornerstone'
 export { viewportMessage } from './viewport'

--- a/packages/insight-viewer/src/utils/messageService/viewport.ts
+++ b/packages/insight-viewer/src/utils/messageService/viewport.ts
@@ -1,5 +1,5 @@
 import { Observable, Subject } from 'rxjs'
-import { Viewport } from '../../Context/Viewport'
+import { Viewport } from '../../Context/Viewport/types'
 
 export interface ViewportMessageProp<K extends keyof Viewport> {
   key: K

--- a/packages/insight-viewer/src/utils/messageService/viewport.ts
+++ b/packages/insight-viewer/src/utils/messageService/viewport.ts
@@ -1,17 +1,14 @@
 import { Observable, Subject } from 'rxjs'
+import { Viewport } from '../../Context/Viewport/types'
 
-export interface ViewportMessageProp {
-  key: string
-  value: unknown
+export interface ViewportMessageProp<K extends keyof Viewport> {
+  key: K
+  value: Viewport[K]
 }
 
-const subject = new Subject<ViewportMessageProp>()
+const subject = new Subject<Partial<Viewport>>()
 
 export const viewportMessage = {
-  sendMessage: (key: string, value: unknown): void =>
-    subject.next({
-      key,
-      value,
-    }),
-  getMessage: (): Observable<ViewportMessageProp> => subject.asObservable(),
+  sendMessage: (message: Partial<Viewport>): void => subject.next(message),
+  getMessage: (): Observable<Partial<Viewport>> => subject.asObservable(),
 }

--- a/packages/insight-viewer/src/utils/messageService/viewport.ts
+++ b/packages/insight-viewer/src/utils/messageService/viewport.ts
@@ -1,5 +1,5 @@
 import { Observable, Subject } from 'rxjs'
-import { Viewport } from '../../Context/Viewport/types'
+import { Viewport } from '../../Context/Viewport'
 
 export interface ViewportMessageProp<K extends keyof Viewport> {
   key: K

--- a/yarn.lock
+++ b/yarn.lock
@@ -4260,6 +4260,14 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/jest@^26.0.23":
+  version "26.0.23"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
+  integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/js-levenshtein@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz#9541eec4ad6e3ec5633270a3a2b55d981edc44a9"


### PR DESCRIPTION
Ticket
---
https://app.asana.com/0/0/1200406987506511/f

Feature
---
- 코너스톤 enable/disable은 뷰어 컴퍼넌트가 mount/unmount 될 때 하도록 한다. 기존의 message 서비스 제거. https://github.com/lunit-io/frontend-components/commit/b49d6540d36ff13209791682cedd7e2b80e1a144
   멀티프레임 뷰어에서 프레임 바뀔 때마다 enable/disable 되는 것은, 마우스휠 이벤트 발생시 프레임 변경하는 작업 시에 수정하겠습니다.
- prefetch 호출 위치 변경하여, 멀티프레임 뷰어의 프레임 변경시에 loader가 보이는 버그 fix https://github.com/lunit-io/frontend-components/commit/da031c29148053e481ed968c9a9af1b60d35b9e4
- 외부에 노출하는 뷰포트 컨텍스트 속성 재정의
  - AS-IS: 코너스톤의 Viewport 그대로 노출
  - TO-BE: flat한 형태로 { scale, invert, hflip, vflip, x, y, windowWidth, windowCenter } 만 노출
  - 뷰포트 get/set 할 때, 커스텀 뷰포트 <-> 코너스톤 뷰포트로 formatting 필요
    - formatter 유닛테스트 추가 https://github.com/lunit-io/frontend-components/commit/116272167e4b7beb8d30cb96b41ac2c25158558a
    - formatter 추가 https://github.com/lunit-io/frontend-components/commit/08cc42a186e79bf58a6dcf77a13b7bc1aaaaaf4d
  - setViewport 파라미터 변경 https://github.com/lunit-io/frontend-components/commit/d69fb22c5618e8b1370bed9fea94126302d333ca
    - AS-IS: 한 번에 속성 하나만 설정 가능 e.g. setViewport('invert', true)
    - TO-BE: 여러 속성 설정 가능 e.g. setViewport({ invert: false, x: 10 })
   - viewport context 업데이트 https://github.com/lunit-io/frontend-components/commit/5ce5d07830264b83b7bc3ae67b48440dde1fd207
   - public useViewportContext 추가 https://github.com/lunit-io/frontend-components/commit/d69a35f3de2b9d83c0947f23c12446bfdd500082
 - 데모 페이지 업데이트 https://github.com/lunit-io/frontend-components/commit/8edef3d812e0c995f4eca5217f90e876271ce632
