### PR TITLE
Feature/multiframe viewer enable disable once

### DIFF
--- a/apps/insight-viewer-demo/src/containers/MultiFrame/Base.tsx
+++ b/apps/insight-viewer-demo/src/containers/MultiFrame/Base.tsx
@@ -27,24 +27,27 @@ const IMAGES = [
 ]
 
 export default function Viewer() {
-  const { DICOMImageViewer, useFrame } = useInsightViewer({
-    images: IMAGES,
-  })
-  const { frame, setFrame } = useFrame()
+  const { DICOMImagesViewer, setFrame } = useInsightViewer()
 
-  function handleKeyDown() {
-    setFrame(5)
+  function changeFrame(e: React.ChangeEvent<HTMLInputElement>): void {
+    const {
+      target: { value },
+    } = e
+
+    setFrame(Number(value))
   }
 
-  return <DICOMImageViewer imageId={IMAGES[frame]} /> />
+  return (
+    <>
+      <input type="range" onChange={changeFrame} />
+      <DICOMImagesViewer imageIds={IMAGES} />
+    </>
+  )
 }
 `
 
 export default function Base(): JSX.Element {
-  const { DICOMImageViewer, useFrame } = useInsightViewer({
-    images: IMAGES,
-  })
-  const { frame, setFrame } = useFrame()
+  const { DICOMImagesViewer, setFrame } = useInsightViewer()
 
   function changeFrame(e: React.ChangeEvent<HTMLInputElement>): void {
     const {
@@ -68,7 +71,7 @@ export default function Base(): JSX.Element {
           onChange={changeFrame}
         />
       </Box>
-      <DICOMImageViewer imageId={IMAGES[frame]} />
+      <DICOMImagesViewer imageIds={IMAGES} />
       <Box w={700}>
         <CodeBlock code={Code} />
       </Box>

--- a/packages/insight-viewer/src/Viewer/DICOMImagesViewer.tsx
+++ b/packages/insight-viewer/src/Viewer/DICOMImagesViewer.tsx
@@ -2,16 +2,20 @@ import React, { useRef } from 'react'
 import ViewerWrapper from '../components/ViewerWrapper'
 import { WithChildren } from '../types'
 import useDICOMImageLoader from '../hooks/useDICOMImageLoader'
+import usePrefetch from '../hooks/usePrefetch'
+import useFrame from '../hooks/useFrame'
 import { VIEWER_TYPE } from '../const'
 
 export function DICOMImagesViewer({
-  imageId,
+  imageIds,
+  initial,
   children,
-}: WithChildren<{ imageId: string }>): JSX.Element {
+}: WithChildren<{ imageIds: string[]; initial: number }>): JSX.Element {
   const elRef = useRef<HTMLDivElement>(null)
-
+  usePrefetch(imageIds)
+  useFrame(elRef.current, imageIds)
   useDICOMImageLoader({
-    imageId,
+    imageId: imageIds[initial],
     element: elRef.current,
     isSingleImage: false,
   })

--- a/packages/insight-viewer/src/hooks/useFrame.ts
+++ b/packages/insight-viewer/src/hooks/useFrame.ts
@@ -1,4 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useContext } from 'react'
+import { Subscription } from 'rxjs'
+import { multiframeMessage } from '../utils/messageService'
+import loadAndDisplayImage from '../utils/cornerstoneHelper/loadAndDisplayImage'
+import LoaderContext from '../Context'
+import { Element } from '../types'
 
 export interface UseFrame {
   (f?: number): {
@@ -7,13 +12,24 @@ export interface UseFrame {
   }
 }
 
-const useFrame: UseFrame = (initial = 0) => {
-  const [frame, setFrame] = useState(initial)
+let subscription: Subscription
 
-  return {
-    frame,
-    setFrame,
-  }
+export default function useFrame(element: Element, imageIds: string[]): void {
+  const { onError, setHeader } = useContext(LoaderContext)
+
+  useEffect(() => {
+    subscription = multiframeMessage.getMessage().subscribe(message => {
+      loadAndDisplayImage({
+        imageId: imageIds[message],
+        element,
+        onError,
+        setHeader,
+        isSingleImage: false,
+      })
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [imageIds, element, onError, setHeader])
 }
-
-export default useFrame

--- a/packages/insight-viewer/src/hooks/useImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useImageLoader.ts
@@ -1,10 +1,5 @@
 import { useEffect, useState, useContext } from 'react'
-import {
-  displayImage,
-  loadImage as cornerstoneLoadImage,
-} from '../utils/cornerstoneHelper'
-import getHttpClient from '../utils/httpClient'
-import { loadingProgressMessage } from '../utils/messageService'
+import loadAndDisplayImage from '../utils/cornerstoneHelper/loadAndDisplayImage'
 import LoaderContext from '../Context'
 import useViewport from './useViewport'
 import { Element } from '../types'
@@ -38,26 +33,13 @@ export default function useImageLoader({
     if (!hasLoader) return undefined
     if (!element) return undefined
 
-    async function loadImage(): Promise<void> {
-      try {
-        const image = await cornerstoneLoadImage(imageId, {
-          loader: getHttpClient(isSingleImage, setHeader),
-        })
-
-        if (isSingleImage) loadingProgressMessage.sendMessage(100)
-
-        displayImage(<HTMLDivElement>element, image)
-      } catch (e) {
-        /**
-         * ky HTTPError
-         * https://github.com/sindresorhus/ky/blob/main/source/errors/HTTPError.ts
-         * { error: { name: 'HTTPError', options, request, response, message, stack }
-         */
-        onError(new Error(e?.error?.message || e.message))
-      }
-    }
-
-    loadImage()
+    loadAndDisplayImage({
+      imageId,
+      element,
+      onError,
+      setHeader,
+      isSingleImage,
+    })
     return undefined
   }, [imageId, element, isSingleImage, hasLoader, onError, setHeader])
   return undefined

--- a/packages/insight-viewer/src/types/index.ts
+++ b/packages/insight-viewer/src/types/index.ts
@@ -13,6 +13,14 @@ export type Viewer = ({
 }: WithChildren<{
   imageId: string
 }>) => JSX.Element
+export type MultiframeViewer = ({
+  imageIds,
+  initial,
+  children,
+}: WithChildren<{
+  imageIds: string[]
+  initial?: number
+}>) => JSX.Element
 export type SetHeader = (request: Request) => void
 
 export interface ContextProp {

--- a/packages/insight-viewer/src/utils/cornerstoneHelper/loadAndDisplayImage.ts
+++ b/packages/insight-viewer/src/utils/cornerstoneHelper/loadAndDisplayImage.ts
@@ -1,0 +1,37 @@
+import { loadImage, displayImage } from './utils'
+import getHttpClient from '../httpClient'
+import { loadingProgressMessage } from '../messageService/loadingProgress'
+import { Element, OnError, SetHeader } from '../../types'
+
+interface Prop {
+  imageId: string
+  element: Element
+  onError: OnError
+  setHeader: SetHeader
+  isSingleImage: boolean
+}
+
+export default async function loadAndDisplayImage({
+  imageId,
+  element,
+  onError,
+  setHeader,
+  isSingleImage,
+}: Prop): Promise<void> {
+  try {
+    const image = await loadImage(imageId, {
+      loader: getHttpClient(isSingleImage, setHeader),
+    })
+
+    if (isSingleImage) loadingProgressMessage.sendMessage(100)
+
+    displayImage(<HTMLDivElement>element, image)
+  } catch (e) {
+    /**
+     * ky HTTPError
+     * https://github.com/sindresorhus/ky/blob/main/source/errors/HTTPError.ts
+     * { error: { name: 'HTTPError', options, request, response, message, stack }
+     */
+    onError(new Error(e?.error?.message || e.message))
+  }
+}

--- a/packages/insight-viewer/src/utils/messageService/index.ts
+++ b/packages/insight-viewer/src/utils/messageService/index.ts
@@ -1,2 +1,3 @@
 export { loadingProgressMessage } from './loadingProgress'
 export { viewportMessage } from './viewport'
+export { multiframeMessage } from './multiframe'

--- a/packages/insight-viewer/src/utils/messageService/multiframe.ts
+++ b/packages/insight-viewer/src/utils/messageService/multiframe.ts
@@ -1,0 +1,8 @@
+import { Observable, Subject } from 'rxjs'
+
+const subject = new Subject<number>()
+
+export const multiframeMessage = {
+  sendMessage: (message: number): void => subject.next(message),
+  getMessage: (): Observable<number> => subject.asObservable(),
+}


### PR DESCRIPTION
Feature
---
멀티프레임 뷰어의 프레임 변경될 때마다 cornerstone이 enable/disable 되는 현상 제거

@deminoth 이런 식으로도 생각해보았습니다. 

```
const IMAGES = [
  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000000.dcm',
  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000001.dcm',
  ...
]

export default function App() {
  const { DICOMImagesViewer, setFrame } = useInsightViewer()

  function changeFrame(e: React.ChangeEvent&lt;HTMLInputElement&gt;): void {    
    const { target: { value } } = e    
    setFrame(Number(value))  
  }

  return (
    <>
      <input type="range" onChange={changeFrame} />
      <DICOMImagesViewer imageIds={IMAGES} />
    </>
  )
}
```