### PR TITLE
Feature/persist dom ref

### DIFF
--- a/apps/insight-viewer-demo/src/containers/MultiFrame/Base.tsx
+++ b/apps/insight-viewer-demo/src/containers/MultiFrame/Base.tsx
@@ -2,6 +2,7 @@ import { Box } from '@chakra-ui/react'
 import useInsightViewer from '@lunit/insight-viewer'
 import React from 'react'
 import CodeBlock from '../../components/CodeBlock'
+import useThrottle from './useThrottle'
 
 const IMAGES = [
   'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000000.dcm',
@@ -54,6 +55,8 @@ export default function Base(): JSX.Element {
     setFrame(Number(value))
   }
 
+  const throttleOnChange = useThrottle(changeFrame, 150)
+
   return (
     <Box w={500} h={500}>
       <Box mb={6}>
@@ -65,7 +68,7 @@ export default function Base(): JSX.Element {
           max="10"
           step="1"
           defaultValue={0}
-          onChange={changeFrame}
+          onChange={throttleOnChange}
         />
       </Box>
       <DICOMImageViewer imageId={IMAGES[frame]} />

--- a/apps/insight-viewer-demo/src/containers/MultiFrame/Base.tsx
+++ b/apps/insight-viewer-demo/src/containers/MultiFrame/Base.tsx
@@ -55,7 +55,7 @@ export default function Base(): JSX.Element {
     setFrame(Number(value))
   }
 
-  const throttleOnChange = useThrottle(changeFrame, 150)
+  const throttleOnChange = useThrottle(changeFrame, 30)
 
   return (
     <Box w={500} h={500}>

--- a/apps/insight-viewer-demo/src/containers/MultiFrame/useThrottle.ts
+++ b/apps/insight-viewer-demo/src/containers/MultiFrame/useThrottle.ts
@@ -1,0 +1,19 @@
+import { useRef } from 'react'
+
+function useThrottle<T extends unknown[]>(
+  callback: (...params: T) => void,
+  time: number
+): () => void {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  return (...params: T) => {
+    if (!timer.current) {
+      timer.current = setTimeout(() => {
+        callback(...params)
+        timer.current = null
+      }, time)
+    }
+  }
+}
+
+export default useThrottle

--- a/packages/insight-viewer/src/components/ViewerWrapper/index.tsx
+++ b/packages/insight-viewer/src/components/ViewerWrapper/index.tsx
@@ -6,11 +6,9 @@ import { VIEWER_TYPE } from '../../const'
 import useResize from './useResize'
 import { ViewportContextProvider } from '../../Context/Viewport'
 
-const ViewerWrapper = forwardRef<
+const Forwarded = forwardRef<
   HTMLDivElement,
-  WithChildren<{
-    type: ViewerType
-  }>
+  WithChildren<{ type: ViewerType }>
 >(({ type, children }, ref) => {
   const { resizeRef } = useResize(ref)
 
@@ -27,5 +25,9 @@ const ViewerWrapper = forwardRef<
   )
 })
 
+const ViewerWrapper = React.memo(Forwarded)
+// for eslintr(eact/display-name)
+Forwarded.displayName = 'Forwarded'
 ViewerWrapper.displayName = 'ViewerWrapper'
+
 export default ViewerWrapper

--- a/packages/insight-viewer/src/hooks/useImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useImageLoader.ts
@@ -26,10 +26,8 @@ export default function useImageLoader({
   const { onError, setHeader } = useContext(LoaderContext)
 
   // eslint-disable-next-line no-extra-semi
-  ;(async function asyncLoad(): Promise<undefined> {
-    if (hasLoader) return undefined
-    setHasLoader(await setLoader())
-    return undefined
+  ;(async function asyncLoad(): Promise<void> {
+    if (!hasLoader) setHasLoader(await setLoader())
   })()
 
   useViewport(<HTMLDivElement>element)


### PR DESCRIPTION
Ticket
---
https://app.asana.com/0/1200128631446379/1200451360595022/f

Feature
---
컴퍼넌트가 rerender될 때마다 DOM ref가 갱신되어 cornerstone.js의 enable/disable가 반복되는 현상 제거.
- DOM ref를 설정하는 ViewerWrapper 컴퍼넌트에 React.memo를 사용하여, prop이 변경될 때만 DOM을 업데이트 하도록 한다. https://github.com/lunit-io/frontend-components/commit/884b584d9cc235a8116af3424e52a2dc2d677978
- 위 변경으로 인해 imageId가 바뀌어도 더 이상 enable/disable이 반복되지 않으나, type="range"인 input 슬라이드를 빠르게 움직여 imageId를 변경하면 cornerstone.js의 [getEnabledElement](https://github.com/cornerstonejs/cornerstone/blob/650ba0c76475f765088cbf929d12a79dfc25a4f2/src/enabledElements.js#L153)에서 'element not enabled' 에러를 던진다. 따라서 onChange이벤트에 throttle을 적용했다. https://github.com/lunit-io/frontend-components/commit/7a9f9891047f5193a6be8961c35bf91c875655b0 https://github.com/lunit-io/frontend-components/pull/55/commits/05171a9bf16e00a2259b5ee633ac128635085700
