### PR TITLE
Feature/wheel interaction

### DIFF
--- a/apps/insight-viewer-demo/src/containers/Interaction/Control/Click.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Control/Click.tsx
@@ -1,10 +1,9 @@
 import { Box, RadioGroup, Radio, Stack, HStack } from '@chakra-ui/react'
-import { DragEvent } from '@lunit/insight-viewer'
 
 export default function Click({
   onChange,
 }: {
-  onChange: (type: string) => (value: DragEvent | 'none') => void
+  onChange: (type: string) => (value: 'click' | 'none') => void
 }): JSX.Element {
   return (
     <Box mb={6}>

--- a/apps/insight-viewer-demo/src/containers/Interaction/Control/Wheel.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Control/Wheel.tsx
@@ -1,0 +1,24 @@
+import { Box, RadioGroup, Radio, Stack, HStack } from '@chakra-ui/react'
+
+export default function Wheel({
+  onChange,
+}: {
+  onChange: (value: 'frame' | 'zoom' | 'none') => void
+}): JSX.Element {
+  return (
+    <Box mb={6}>
+      <HStack spacing="80px">
+        <Box w={200}>
+          <Box>Mouse Wheel</Box>
+          <RadioGroup defaultValue="none" onChange={onChange}>
+            <Stack direction="row">
+              <Radio value="none">none</Radio>
+              <Radio value="frame">frame</Radio>
+              <Radio value="zoom">zoom</Radio>
+            </Stack>
+          </RadioGroup>
+        </Box>
+      </HStack>
+    </Box>
+  )
+}

--- a/apps/insight-viewer-demo/src/containers/Interaction/Custom.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Custom.tsx
@@ -38,7 +38,7 @@ const Code = `\
         y: prev.y + delta.y / prev.scale,
       }))
     }
-    
+
     const customAdjust: Drag = ({ viewport, delta }) => {
       console.log(
         'adjust',
@@ -87,7 +87,7 @@ const Code = `\
         <input type="radio" value="pan" onChange={handleCustomPan} />
         <input type="radio" value="adjust" onChange={handleCustomAdjust} />
         <input type="checkbox" value="adjust" onChange={handleClick} />
-        <Viewer.Dicom 
+        <Viewer.Dicom
           imageId={IMAGE_ID}
           interaction={interaction}
           viewport={viewport}

--- a/apps/insight-viewer-demo/src/containers/Interaction/Tabs.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Tabs.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Tabs, TabList, TabPanels, Tab, TabPanel } from '@chakra-ui/react'
 import Base from './Base'
 import Custom from './Custom'
+import Wheel from './Wheel'
 
 export default function App(): JSX.Element {
   const [active, setActive] = useState(0)
@@ -15,11 +16,13 @@ export default function App(): JSX.Element {
       <TabList>
         <Tab>Base Interaction</Tab>
         <Tab>Custom Interaction</Tab>
+        <Tab>Mousewheel Interaction</Tab>
       </TabList>
 
       <TabPanels>
         <TabPanel>{active === 0 && <Base />}</TabPanel>
         <TabPanel>{active === 1 && <Custom />}</TabPanel>
+        <TabPanel>{active === 2 && <Wheel />}</TabPanel>
       </TabPanels>
     </Tabs>
   )

--- a/apps/insight-viewer-demo/src/containers/Interaction/Wheel.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Wheel.tsx
@@ -8,6 +8,7 @@ import Viewer, {
 } from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 import WheelControl from './Control/Wheel'
+import Control from './Control'
 import OverlayLayer from '../../components/OverlayLayer'
 
 const IMAGES = [
@@ -46,7 +47,9 @@ const MAX_SCALE = 3
 
 export default function App(): JSX.Element {
   const { image, frame, setFrame } = useMultiframe(IMAGES)
-  const { viewport, setViewport } = useViewport()
+  const { viewport, setViewport } = useViewport({
+    scale: 0.5,
+  })
   const { interaction, setInteraction } = useInteraction()
 
   const handleFrame: Wheel = (_, deltaY) => {
@@ -80,9 +83,19 @@ export default function App(): JSX.Element {
     }))
   }
 
+  function handleChange(type: string) {
+    return (value: string) => {
+      setInteraction((prev: Interaction) => ({
+        ...prev,
+        [type]: value === 'none' ? undefined : value,
+      }))
+    }
+  }
+
   return (
     <Box w={700}>
       <WheelControl onChange={handleWheel} />
+      <Control onChange={handleChange} />
       <Box mb={6}>
         <Text>frame: {frame}</Text>
       </Box>

--- a/apps/insight-viewer-demo/src/containers/Interaction/Wheel.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Wheel.tsx
@@ -1,0 +1,50 @@
+import { Box, Text } from '@chakra-ui/react'
+import Viewer, { useMultiframe } from '@lunit/insight-viewer'
+import CodeBlock from '../../components/CodeBlock'
+
+const IMAGES = [
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000000.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000001.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000002.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000003.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000004.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000005.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000006.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000007.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000008.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000009.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000010.dcm',
+]
+
+const Code = `\
+  import Viewer, { useMultiframe } from '@lunit/insight-viewer'
+
+  export default function App(): JSX.Element {
+    const { image, frame, setFrame } = useMultiframe(IMAGES)
+  
+    return (
+      <>
+        <Text>frame: {frame}</Text>
+        <Viewer.Dicom imageId={image} onFrameChange={setFrame} />
+      </>
+    )
+  }
+`
+
+export default function App(): JSX.Element {
+  const { image, frame, setFrame } = useMultiframe(IMAGES)
+
+  return (
+    <Box w={700}>
+      <Box mb={6}>
+        <Text>frame: {frame}</Text>
+      </Box>
+      <Box w={500} h={500}>
+        <Viewer.Dicom imageId={image} onFrameChange={setFrame} />
+      </Box>
+      <Box w={900}>
+        <CodeBlock code={Code} />
+      </Box>
+    </Box>
+  )
+}

--- a/packages/insight-viewer/src/Viewer/DICOMImageViewer.tsx
+++ b/packages/insight-viewer/src/Viewer/DICOMImageViewer.tsx
@@ -24,7 +24,6 @@ export function DICOMImageViewer({
   viewport,
   interaction,
   onViewportChange,
-  onFrameChange,
   children,
 }: WithChildren<
   ViewerProp & {
@@ -58,7 +57,6 @@ export function DICOMImageViewer({
     interaction,
     viewport,
     onViewportChange,
-    onFrameChange,
   })
 
   return (

--- a/packages/insight-viewer/src/Viewer/DICOMImageViewer.tsx
+++ b/packages/insight-viewer/src/Viewer/DICOMImageViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useRef, useEffect } from 'react'
 import ViewerWrapper from '../components/ViewerWrapper'
 import {
   WithChildren,
@@ -36,7 +36,7 @@ export function DICOMImageViewer({
 >): JSX.Element {
   const elRef = useRef<HTMLDivElement>(null)
   // eslint-disable-next-line no-underscore-dangle
-  const initialViewportRef = useRef(viewport?._initial)
+  const viewportRef = useRef(viewport)
   // enable/disable cornerstone.js
   useCornerstone(elRef.current)
   // enable cornerstone.js image loader and load/display image
@@ -46,7 +46,7 @@ export function DICOMImageViewer({
     onError,
     requestInterceptor,
     setLoader: () => setWadoImageLoader(onError),
-    initialViewportRef,
+    viewportRef,
     onViewportChange,
   })
   // update cornerstone viewport when viewport prop changes
@@ -58,6 +58,10 @@ export function DICOMImageViewer({
     viewport,
     onViewportChange,
   })
+
+  useEffect(() => {
+    if (viewport) viewportRef.current = viewport
+  }, [viewport])
 
   return (
     <ViewerWrapper ref={elRef} Progress={Progress}>

--- a/packages/insight-viewer/src/Viewer/DICOMImageViewer.tsx
+++ b/packages/insight-viewer/src/Viewer/DICOMImageViewer.tsx
@@ -12,6 +12,7 @@ import useImageLoader from '../hooks/useImageLoader'
 import useViewportUpdate from '../hooks/useViewportUpdate'
 import { Interaction } from '../hooks/useInteraction/types'
 import useViewportInteraction from '../hooks/useInteraction/useViewportInteraction'
+import { SetFrame } from '../hooks/useMultiframe/useFrame'
 import setWadoImageLoader from '../utils/cornerstoneHelper/setWadoImageLoader'
 import { DefaultProp } from './const'
 
@@ -23,20 +24,23 @@ export function DICOMImageViewer({
   viewport,
   interaction,
   onViewportChange,
+  onFrameChange,
   children,
 }: WithChildren<
   ViewerProp & {
     Progress?: ProgressComponent
     viewport?: Viewport
     onViewportChange?: OnViewportChange
+    onFrameChange?: SetFrame
     interaction?: Interaction
   }
 >): JSX.Element {
   const elRef = useRef<HTMLDivElement>(null)
   // eslint-disable-next-line no-underscore-dangle
   const initialViewportRef = useRef(viewport?._initial)
-
+  // enable/disable cornerstone.js
   useCornerstone(elRef.current)
+  // enable cornerstone.js image loader and load/display image
   useImageLoader({
     imageId,
     element: elRef.current,
@@ -46,12 +50,15 @@ export function DICOMImageViewer({
     initialViewportRef,
     onViewportChange,
   })
+  // update cornerstone viewport when viewport prop changes
   useViewportUpdate(elRef.current, viewport)
+  // update cornerstone viewport on user interaction
   useViewportInteraction({
     element: elRef.current,
     interaction,
     viewport,
     onViewportChange,
+    onFrameChange,
   })
 
   return (

--- a/packages/insight-viewer/src/hooks/useImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useImageLoader.ts
@@ -43,7 +43,7 @@ export default function useImageLoader({
     // determine whether it is first load or subsequent load(multiframe viewer)
     loadCountRef.current += 1
 
-    async function loadImage(): Promise<void> {
+    async function loadAndDisplayImage(): Promise<void> {
       try {
         const image = await cornerstoneLoadImage(imageId, {
           loader: getHttpClient(requestInterceptor),
@@ -75,7 +75,7 @@ export default function useImageLoader({
       }
     }
 
-    loadImage()
+    loadAndDisplayImage()
     return undefined
   }, [
     imageId,

--- a/packages/insight-viewer/src/hooks/useImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useImageLoader.ts
@@ -46,16 +46,14 @@ export default function useImageLoader({
         })
         loadingProgressMessage.sendMessage(100)
 
-        const { viewport } = displayImage(<HTMLDivElement>element, image)
+        const { viewport } = displayImage(
+          <HTMLDivElement>element,
+          image,
+          initialViewportRef?.current
+        )
 
         if (onViewportChange) {
-          const formatted = formatViewport(viewport)
-
-          onViewportChange(
-            initialViewportRef?.current
-              ? { ...formatted, ...initialViewportRef?.current }
-              : formatted
-          )
+          onViewportChange(formatViewport(viewport))
         }
       } catch (e) {
         /**

--- a/packages/insight-viewer/src/hooks/useInteraction/types.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/types.ts
@@ -1,6 +1,5 @@
 import {
   DRAG,
-  MOUSE_WHEEL,
   PRIMARY_DRAG,
   SECONDARY_DRAG,
   PRIMARY_CLICK,
@@ -9,10 +8,8 @@ import {
 } from './const'
 import { CornerstoneViewport } from '../../utils/cornerstoneHelper'
 import { Element, Viewport, OnViewportChange } from '../../types'
-import { SetFrame } from '../useMultiframe/useFrame'
 
 export type DragEvent = keyof typeof DRAG
-export type WheelEvent = keyof typeof MOUSE_WHEEL
 export type Click = (offsetX: number, offsetY: number) => void
 export interface Coord {
   x: number
@@ -33,6 +30,7 @@ export type Adjust = (
   windowWidth: number
   windowCenter: number
 }
+export type Wheel = (deltaX: number, deltaY: number) => void
 export interface DragInteraction {
   [PRIMARY_DRAG]: DragEvent | Drag | undefined
   [SECONDARY_DRAG]: DragEvent | Drag | undefined
@@ -44,7 +42,7 @@ export interface ClickInteraction {
 }
 
 export interface WheelInteraction {
-  [MOUSEWHEEL]: WheelEvent | undefined
+  [MOUSEWHEEL]: Wheel | undefined
 }
 
 export type Interaction = DragInteraction & ClickInteraction & WheelInteraction
@@ -56,5 +54,4 @@ export interface ViewportInteraction {
   interaction?: Interaction
   viewport?: Viewport
   onViewportChange?: OnViewportChange
-  onFrameChange?: SetFrame
 }

--- a/packages/insight-viewer/src/hooks/useInteraction/types.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/types.ts
@@ -9,6 +9,7 @@ import {
 } from './const'
 import { CornerstoneViewport } from '../../utils/cornerstoneHelper'
 import { Element, Viewport, OnViewportChange } from '../../types'
+import { SetFrame } from '../useMultiframe/useFrame'
 
 export type DragEvent = keyof typeof DRAG
 export type WheelEvent = keyof typeof MOUSE_WHEEL
@@ -55,4 +56,5 @@ export interface ViewportInteraction {
   interaction?: Interaction
   viewport?: Viewport
   onViewportChange?: OnViewportChange
+  onFrameChange?: SetFrame
 }

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleClick/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleClick/index.ts
@@ -51,7 +51,6 @@ export default function useHandleClick({
     let clickType: ClickType | undefined
     if (!interaction) return undefined
 
-    if (subscription) subscription.unsubscribe()
     if (!hasInteraction(interaction, [PRIMARY_CLICK, SECONDARY_CLICK]))
       return undefined
 
@@ -91,7 +90,9 @@ export default function useHandleClick({
           )
         }
       })
-    return undefined
+    return () => {
+      subscription.unsubscribe()
+    }
   }, [element, interaction, viewport])
 
   return undefined

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
@@ -96,7 +96,6 @@ export default function useHandleDrag({
     let dragType: DragType | undefined
 
     element?.removeEventListener('contextmenu', preventContextMenu)
-    if (subscription) subscription.unsubscribe()
     if (!hasInteraction(interaction, [PRIMARY_DRAG, SECONDARY_DRAG]))
       return undefined
 
@@ -152,6 +151,8 @@ export default function useHandleDrag({
         }
       })
 
-    return undefined
+    return () => {
+      subscription.unsubscribe()
+    }
   }, [element, interaction, onViewportChange])
 }

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
@@ -1,7 +1,6 @@
 import { useEffect } from 'react'
 import { fromEvent, Subscription } from 'rxjs'
 import { tap, switchMap, map, takeUntil } from 'rxjs/operators'
-import { Viewport } from 'cornerstone-core'
 import { Element, OnViewportChange } from '../../../types'
 import { formatCornerstoneViewport } from '../../../utils/common/formatViewport'
 import {
@@ -9,13 +8,7 @@ import {
   setViewport,
   CornerstoneViewport,
 } from '../../../utils/cornerstoneHelper'
-import {
-  Interaction,
-  Pan,
-  Adjust,
-  DragEvent,
-  ViewportInteraction,
-} from '../types'
+import { Interaction, DragEvent, ViewportInteraction } from '../types'
 import { MOUSE_BUTTON, PRIMARY_DRAG, SECONDARY_DRAG } from '../const'
 import { preventContextMenu, hasInteraction } from '../utils'
 import control from './control'
@@ -39,7 +32,7 @@ function handleInteraction({
   interaction: Interaction
   dragType: DragType
   element: Element
-  viewport: Viewport
+  viewport: CornerstoneViewport
   dragged: {
     x: number
     y: number
@@ -54,14 +47,14 @@ function handleInteraction({
     if (onViewportChange) {
       onViewportChange(prev => ({
         ...prev,
-        ...(control[eventType] as Pan | Adjust)?.(viewport, dragged),
+        ...control[eventType]?.(viewport, dragged),
       }))
     } else {
       setViewport(
         <HTMLDivElement>element,
         formatCornerstoneViewport(
           viewport,
-          (control[eventType] as Pan | Adjust)?.(viewport, dragged)
+          control[eventType]?.(viewport, dragged)
         )
       )
     }
@@ -135,9 +128,7 @@ export default function useHandleDrag({
         })
       )
       .subscribe(dragged => {
-        const viewport = getViewport(
-          <HTMLDivElement>element
-        ) as CornerstoneViewport
+        const viewport = getViewport(<HTMLDivElement>element)
 
         if (viewport && hasDragType(dragType) && interaction[dragType]) {
           handleInteraction({

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleWheel/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleWheel/index.ts
@@ -8,7 +8,7 @@ let subscription: Subscription
 export default function useHandleWheel({
   element,
   interaction,
-  onFrameChange,
+  onViewportChange,
 }: ViewportInteraction): void {
   useEffect(() => {
     if (!element) return undefined
@@ -16,17 +16,16 @@ export default function useHandleWheel({
 
     subscription = wheel$
       .pipe(
-        filter(() => onFrameChange !== undefined),
         filter(({ deltaY }) => deltaY !== 0),
         tap(e => {
           e.preventDefault()
         })
       )
-      .subscribe(({ deltaY }) => {
-        if (onFrameChange) onFrameChange(prev => prev + (deltaY > 0 ? 1 : -1))
+      .subscribe(({ deltaX, deltaY }) => {
+        if (interaction?.mouseWheel) interaction?.mouseWheel(deltaX, deltaY)
       })
     return () => {
       subscription.unsubscribe()
     }
-  }, [interaction, element, onFrameChange])
+  }, [interaction, element, onViewportChange])
 }

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleWheel/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleWheel/index.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+import { fromEvent, Subscription } from 'rxjs'
+import { filter, tap } from 'rxjs/operators'
+import { ViewportInteraction } from '../types'
+
+let subscription: Subscription
+
+export default function useHandleWheel({
+  element,
+  interaction,
+  onFrameChange,
+}: ViewportInteraction): void {
+  useEffect(() => {
+    if (!element) return undefined
+    const wheel$ = fromEvent<WheelEvent>(<HTMLDivElement>element, 'wheel')
+
+    subscription = wheel$
+      .pipe(
+        filter(() => onFrameChange !== undefined),
+        filter(({ deltaY }) => deltaY !== 0),
+        tap(e => {
+          e.preventDefault()
+        })
+      )
+      .subscribe(({ deltaY }) => {
+        if (onFrameChange) onFrameChange(prev => prev + (deltaY > 0 ? 1 : -1))
+      })
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [interaction, element, onFrameChange])
+}

--- a/packages/insight-viewer/src/hooks/useInteraction/useViewportInteraction.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useViewportInteraction.ts
@@ -8,12 +8,11 @@ export default function useViewportInteraction({
   interaction,
   viewport,
   onViewportChange,
-  onFrameChange,
 }: ViewportInteraction): void {
   useHandleWheel({
     element,
     interaction,
-    onFrameChange,
+    onViewportChange,
   })
 
   useHandleDrag({

--- a/packages/insight-viewer/src/hooks/useInteraction/useViewportInteraction.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useViewportInteraction.ts
@@ -1,13 +1,21 @@
 import { ViewportInteraction } from './types'
 import useHandleDrag from './useHandleDrag'
 import useHandleClick from './useHandleClick'
+import useHandleWheel from './useHandleWheel'
 
 export default function useViewportInteraction({
   element,
   interaction,
   viewport,
   onViewportChange,
+  onFrameChange,
 }: ViewportInteraction): void {
+  useHandleWheel({
+    element,
+    interaction,
+    onFrameChange,
+  })
+
   useHandleDrag({
     element,
     interaction,

--- a/packages/insight-viewer/src/hooks/useMultiframe/index.ts
+++ b/packages/insight-viewer/src/hooks/useMultiframe/index.ts
@@ -1,3 +1,4 @@
+import { SetStateAction } from 'react'
 import usePrefetch from './usePrefetch'
 import useFrame, { SetFrame } from './useFrame'
 import { HTTP } from '../../types'
@@ -24,9 +25,22 @@ export default function useMultiframe(
   })
   const { frame, setFrame } = useFrame(initialFrame ?? 0)
 
+  function handleFrame(arg: SetStateAction<number>) {
+    let frameIndex = 0
+
+    if (typeof arg === 'number') {
+      frameIndex = arg
+    } else {
+      frameIndex = arg(frame)
+    }
+
+    if (frameIndex < 0 || frameIndex > IMAGES.length - 1) return
+    setFrame(arg)
+  }
+
   return {
     image: IMAGES[frame],
     frame,
-    setFrame,
+    setFrame: handleFrame,
   }
 }

--- a/packages/insight-viewer/src/hooks/useMultiframe/useFrame.ts
+++ b/packages/insight-viewer/src/hooks/useMultiframe/useFrame.ts
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { useState, Dispatch, SetStateAction } from 'react'
 
-export type SetFrame = (n: number) => void
+export type SetFrame = Dispatch<SetStateAction<number>>
 
 export interface UseFrame {
   (f: number): {

--- a/packages/insight-viewer/src/index.ts
+++ b/packages/insight-viewer/src/index.ts
@@ -2,10 +2,11 @@ export { default } from './Viewer'
 export { default as useMultiframe } from './hooks/useMultiframe'
 export { default as useViewport } from './hooks/useViewport'
 export { default as useInteraction } from './hooks/useInteraction'
-export type {
-  Interaction,
-  SetInteraction,
-  WheelEvent,
-} from './hooks/useInteraction/types'
+export type { Interaction, SetInteraction } from './hooks/useInteraction/types'
 export type { Viewport, ViewerError } from './types'
-export type { DragEvent, Click, Drag } from './hooks/useInteraction/types'
+export type {
+  DragEvent,
+  Click,
+  Drag,
+  Wheel,
+} from './hooks/useInteraction/types'

--- a/packages/insight-viewer/src/utils/common/formatViewport.ts
+++ b/packages/insight-viewer/src/utils/common/formatViewport.ts
@@ -1,4 +1,4 @@
-import { CornerstoneViewport } from '../cornerstoneHelper'
+import { CornerstoneViewport } from '../cornerstoneHelper/types'
 import { Viewport } from '../../types'
 import { DefaultViewport } from '../../const'
 

--- a/packages/insight-viewer/src/utils/cornerstoneHelper/index.ts
+++ b/packages/insight-viewer/src/utils/cornerstoneHelper/index.ts
@@ -1,1 +1,2 @@
 export * from './utils'
+export type { CornerstoneImage, CornerstoneViewport } from './types'

--- a/packages/insight-viewer/src/utils/cornerstoneHelper/types.ts
+++ b/packages/insight-viewer/src/utils/cornerstoneHelper/types.ts
@@ -1,0 +1,4 @@
+import cornerstone from 'cornerstone-core'
+
+export type CornerstoneImage = cornerstone.Image
+export type CornerstoneViewport = cornerstone.Viewport

--- a/packages/insight-viewer/src/utils/cornerstoneHelper/utils.ts
+++ b/packages/insight-viewer/src/utils/cornerstoneHelper/utils.ts
@@ -1,4 +1,5 @@
-import cornerstone from 'cornerstone-core'
+import cornerstone, { Viewport } from 'cornerstone-core'
+import { formatCornerstoneViewport } from '../common/formatViewport'
 
 export type CornerstoneImage = cornerstone.Image
 export type CornerstoneViewport = cornerstone.Viewport
@@ -21,12 +22,16 @@ export function getCornerstone(): typeof cornerstone {
 
 export function displayImage(
   element: HTMLDivElement,
-  image: cornerstone.Image
+  image: cornerstone.Image,
+  viewportOption?: Partial<Viewport>
 ): {
   viewport: CornerstoneViewport
   image: CornerstoneImage
 } {
-  const viewport = cornerstone.getDefaultViewportForImage(element, image)
+  const defaultViewport = cornerstone.getDefaultViewportForImage(element, image)
+  const viewport = viewportOption
+    ? formatCornerstoneViewport(defaultViewport, viewportOption)
+    : defaultViewport
   cornerstone.displayImage(element, image, viewport)
 
   return {

--- a/packages/insight-viewer/src/utils/cornerstoneHelper/utils.ts
+++ b/packages/insight-viewer/src/utils/cornerstoneHelper/utils.ts
@@ -1,8 +1,6 @@
 import cornerstone, { Viewport } from 'cornerstone-core'
+import { CornerstoneImage, CornerstoneViewport } from './types'
 import { formatCornerstoneViewport } from '../common/formatViewport'
-
-export type CornerstoneImage = cornerstone.Image
-export type CornerstoneViewport = cornerstone.Viewport
 
 export function enable(element: HTMLDivElement): void {
   cornerstone.enable(element)


### PR DESCRIPTION
Ticket
---
https://app.asana.com/0/0/1200541905915503/f

Feature
---
멀티프레임 뷰어에서 마우스 휠로 프레임 이동
[demo](https://frontend-components-bby3l23uq-lunit.vercel.app/src/insight-viewer-demo/interaction/)
- 뷰어에서 프레임 이동 처리하기 위해 useMultiframe에서 반환한 setFrame을 뷰어의 onFrameChange prop으로 전달한다. https://github.com/lunit-io/frontend-components/commit/671d9046f6d92cb503e3945d9929c5a2346b2cd8
- useMultiframe hook의 setFrame은 멀티프레임 이미지 범위 안에서만 설정할 수 있도록 한다. https://github.com/lunit-io/frontend-components/commit/88d14af6f12590e3c2f70e76cc0822a49f7ba137
- useHandleWheel hook 추가 https://github.com/lunit-io/frontend-components/commit/aecfeb43a9c286fb7bfdddc4be7cafb73a9ef36c

Note
---
마우스 휠을 움직일 때 뷰포트 zoom 하는 동작은 이어서 하겠습니다.