### PR TITLE
fix: handle errors on prefetch

### DIFF
--- a/packages/insight-viewer/src/hooks/useMultiframe/usePrefetch.ts
+++ b/packages/insight-viewer/src/hooks/useMultiframe/usePrefetch.ts
@@ -31,11 +31,13 @@ async function prefetch({
   images: string[]
 }) {
   try {
-    const loaders = images.map(image =>
-      loadImage(image, {
-        loader: getHttpClient(requestInterceptor),
-      })
-    )
+    const loaders = images
+      .map(image =>
+        loadImage(image, {
+          loader: getHttpClient(requestInterceptor),
+        }).catch(err => onError(err))
+      )
+      .filter((p): p is Promise<CornerstoneImage> => p !== undefined)
     return PromiseAllWithProgress(loaders)
   } catch (err) {
     onError(err)


### PR DESCRIPTION
다른 피처 작업해보다 발견한건데 `try catch`가 콜백 안의 에러를 잡지 못해서 `Uncaught (in promise)` 에러가 그대로 나고 있었네요.

일단 에러나면 onError() 제대로 호출한 다음 나머지 이미지만 불러오게끔 수정했습니다.

재현은 Multiframe 데모에서 존재하지 않는 이미지를 `IMAGES`에 넣어보시면 됩니다.
