### PR TITLE
Feature/viewport reset

### DIFF
--- a/apps/insight-viewer-demo/cypress/integration/interaction.custom.spec.ts
+++ b/apps/insight-viewer-demo/cypress/integration/interaction.custom.spec.ts
@@ -5,11 +5,12 @@ import { DEFAULT_SCALE } from '../../src/containers/Interaction/const'
 describe('Interaction', () => {
   before(() => {
     setup()
+    cy.visit('/interaction')
+    cy.get('.custom-tab').click()
   })
 
   beforeEach(() => {
-    cy.visit('/interaction')
-    cy.get('.custom-tab').click()
+    cy.get('.reset').click()
   })
 
   describe('Custom Interaction', () => {

--- a/apps/insight-viewer-demo/cypress/integration/interaction.spec.ts
+++ b/apps/insight-viewer-demo/cypress/integration/interaction.spec.ts
@@ -5,10 +5,11 @@ import { DEFAULT_SCALE } from '../../src/containers/Interaction/const'
 describe('Interaction', () => {
   before(() => {
     setup()
+    cy.visit('/interaction')
   })
 
   beforeEach(() => {
-    cy.visit('/interaction')
+    cy.get('.reset').click()
   })
 
   describe('Base Interaction', () => {

--- a/apps/insight-viewer-demo/src/containers/Interaction/Base.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Base.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '@chakra-ui/react'
+import { Box, Text, Button, Stack } from '@chakra-ui/react'
 import Viewer, {
   useInteraction,
   useViewport,
@@ -37,7 +37,7 @@ const MAX_SCALE = 3
 export default function App(): JSX.Element {
   const { image, frame, setFrame } = useMultiframe(IMAGES)
   const { interaction, setInteraction } = useInteraction()
-  const { viewport, setViewport } = useViewport({
+  const { viewport, setViewport, resetViewport } = useViewport({
     scale: DEFAULT_SCALE,
   })
 
@@ -85,21 +85,28 @@ export default function App(): JSX.Element {
     <Box w={700}>
       <Control onChange={handleChange} />
       <WheelControl onChange={handleWheel} />
+
       <Box mb={6}>
         <Text className="test">frame: {frame}</Text>
       </Box>
-      <Box w={500} h={500}>
-        <Viewer.Dicom
-          imageId={image}
-          interaction={interaction}
-          onViewportChange={setViewport}
-          viewport={viewport}
-          Progress={CustomProgress}
-        >
-          <OverlayLayer viewport={viewport} />
-          <Canvas viewport={viewport} />
-        </Viewer.Dicom>
-      </Box>
+      <Stack direction="row">
+        <Box w={500} h={500}>
+          <Viewer.Dicom
+            imageId={image}
+            interaction={interaction}
+            onViewportChange={setViewport}
+            viewport={viewport}
+            Progress={CustomProgress}
+          >
+            <OverlayLayer viewport={viewport} />
+            <Canvas viewport={viewport} />
+          </Viewer.Dicom>
+        </Box>
+        <Button colorScheme="blue" onClick={resetViewport} className="reset">
+          Reset
+        </Button>
+      </Stack>
+
       <Box w={900}>
         <CodeBlock code={BASE_CODE} />
       </Box>

--- a/apps/insight-viewer-demo/src/containers/Interaction/Base.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Base.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, Button, Stack } from '@chakra-ui/react'
+import { Box, Text, Button, Stack, HStack } from '@chakra-ui/react'
 import Viewer, {
   useInteraction,
   useViewport,
@@ -83,12 +83,21 @@ export default function App(): JSX.Element {
 
   return (
     <Box w={700}>
-      <Control onChange={handleChange} />
-      <WheelControl onChange={handleWheel} />
+      <HStack spacing="80px" align="flex-start">
+        <Box>
+          <Control onChange={handleChange} />
+          <WheelControl onChange={handleWheel} />
+          <Box mb={6}>
+            <Text className="test">frame: {frame}</Text>
+          </Box>
+        </Box>
+        <Box>
+          <Button colorScheme="blue" onClick={resetViewport} className="reset">
+            Reset
+          </Button>
+        </Box>
+      </HStack>
 
-      <Box mb={6}>
-        <Text className="test">frame: {frame}</Text>
-      </Box>
       <Stack direction="row">
         <Box w={500} h={500}>
           <Viewer.Dicom
@@ -102,9 +111,6 @@ export default function App(): JSX.Element {
             <Canvas viewport={viewport} />
           </Viewer.Dicom>
         </Box>
-        <Button colorScheme="blue" onClick={resetViewport} className="reset">
-          Reset
-        </Button>
       </Stack>
 
       <Box w={900}>

--- a/apps/insight-viewer-demo/src/containers/Interaction/Custom.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Custom.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Box, Text } from '@chakra-ui/react'
+import { Box, Text, Button, Stack } from '@chakra-ui/react'
 import consola from 'consola'
 import Viewer, {
   useInteraction,
@@ -23,7 +23,11 @@ const IMAGE_ID =
 export default function App(): JSX.Element {
   const [{ x, y }, setCoord] = useState({ x: 0, y: 0 })
   const { interaction, setInteraction } = useInteraction()
-  const { viewport: viewerViewport, setViewport } = useViewport({
+  const {
+    viewport: viewerViewport,
+    setViewport,
+    resetViewport,
+  } = useViewport({
     scale: DEFAULT_SCALE,
   })
 
@@ -112,17 +116,23 @@ export default function App(): JSX.Element {
           offset: {x.toFixed(2)} / {y.toFixed(2)}
         </Text>
       </Box>
-      <Box w={500} h={500}>
-        <Viewer.Dicom
-          imageId={IMAGE_ID}
-          interaction={interaction}
-          viewport={viewerViewport}
-          onViewportChange={setViewport}
-          Progress={CustomProgress}
-        >
-          <OverlayLayer viewport={viewerViewport} />
-        </Viewer.Dicom>
-      </Box>
+      <Stack direction="row">
+        <Box w={500} h={500}>
+          <Viewer.Dicom
+            imageId={IMAGE_ID}
+            interaction={interaction}
+            viewport={viewerViewport}
+            onViewportChange={setViewport}
+            Progress={CustomProgress}
+          >
+            <OverlayLayer viewport={viewerViewport} />
+          </Viewer.Dicom>
+        </Box>
+        <Button colorScheme="blue" onClick={resetViewport} className="reset">
+          Reset
+        </Button>
+      </Stack>
+
       <Box w={900}>
         <CodeBlock code={CUSTOM_CODE} />
       </Box>

--- a/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Box, Text, HStack, Switch } from '@chakra-ui/react'
+import { Box, Text, HStack, Switch, Button } from '@chakra-ui/react'
 import Viewer, { useViewport, Viewport } from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 import OverlayLayer from '../../components/OverlayLayer'
@@ -14,19 +14,31 @@ const IMAGE_ID2 =
   'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000010.dcm'
 
 export default function App(): JSX.Element {
-  const { viewport, setViewport } = useViewport({
+  const { viewport, setViewport, resetViewport } = useViewport({
     scale: 0.5,
     windowWidth: 90,
     windowCenter: 32,
   })
 
-  const { viewport: viewport2, setViewport: setViewport2 } = useViewport({
+  const {
+    viewport: viewport2,
+    setViewport: setViewport2,
+    resetViewport: resetViewport2,
+  } = useViewport({
     scale: 1,
     windowWidth: 150,
     windowCenter: 50,
   })
 
   const isMount = useIsMount()
+
+  function handleFirstReset() {
+    resetViewport()
+  }
+
+  function handleSecondReset() {
+    resetViewport2()
+  }
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -79,6 +91,7 @@ export default function App(): JSX.Element {
                     })
                   }
                   className="invert"
+                  isChecked={viewport.invert}
                 />
               </Box>
               <Box>
@@ -91,6 +104,7 @@ export default function App(): JSX.Element {
                     })
                   }
                   className="hflip"
+                  isChecked={viewport.hflip}
                 />
               </Box>
               <Box>
@@ -103,6 +117,7 @@ export default function App(): JSX.Element {
                     }))
                   }
                   className="vflip"
+                  isChecked={viewport.vflip}
                 />
               </Box>
             </HStack>
@@ -117,7 +132,6 @@ export default function App(): JSX.Element {
                     min="0"
                     max="100"
                     step="10"
-                    defaultValue={0}
                     onChange={e => {
                       setViewport(prev => ({
                         ...prev,
@@ -125,6 +139,7 @@ export default function App(): JSX.Element {
                       }))
                     }}
                     className="x-transition"
+                    value={viewport.x}
                   />
                 </Box>
               </Box>
@@ -138,7 +153,6 @@ export default function App(): JSX.Element {
                     min="0"
                     max="100"
                     step="10"
-                    defaultValue={0}
                     onChange={e => {
                       setViewport(prev => ({
                         ...prev,
@@ -146,6 +160,7 @@ export default function App(): JSX.Element {
                       }))
                     }}
                     className="y-transition"
+                    value={viewport.y}
                   />
                 </Box>
               </Box>
@@ -160,7 +175,6 @@ export default function App(): JSX.Element {
                 min="0.5"
                 max="2"
                 step="0.1"
-                defaultValue={1}
                 onChange={e => {
                   setViewport(prev => ({
                     ...prev,
@@ -168,6 +182,7 @@ export default function App(): JSX.Element {
                   }))
                 }}
                 className="zoom"
+                value={viewport.scale}
               />
             </Box>
             <HStack spacing="24px" mt={3}>
@@ -181,7 +196,6 @@ export default function App(): JSX.Element {
                     min="9"
                     max="171"
                     step="9"
-                    defaultValue={90}
                     onChange={e => {
                       setViewport(prev => ({
                         ...prev,
@@ -189,6 +203,7 @@ export default function App(): JSX.Element {
                       }))
                     }}
                     className="window-width"
+                    value={viewport.windowWidth}
                   />
                 </Box>
               </Box>
@@ -202,7 +217,6 @@ export default function App(): JSX.Element {
                     min="-48"
                     max="112"
                     step="16"
-                    defaultValue={32}
                     onChange={e => {
                       setViewport(prev => ({
                         ...prev,
@@ -210,9 +224,13 @@ export default function App(): JSX.Element {
                       }))
                     }}
                     className="window-center"
+                    value={viewport.windowCenter}
                   />
                 </Box>
               </Box>
+              <Button colorScheme="blue" onClick={handleFirstReset}>
+                Reset
+              </Button>
             </HStack>
           </Box>
           <Box mb={6}>
@@ -227,7 +245,6 @@ export default function App(): JSX.Element {
                     min="0"
                     max="100"
                     step="10"
-                    defaultValue={0}
                     onChange={e => {
                       setViewport2(prev => ({
                         ...prev,
@@ -235,6 +252,7 @@ export default function App(): JSX.Element {
                       }))
                     }}
                     className="x-transition2"
+                    value={viewport2.x}
                   />
                 </Box>
               </Box>
@@ -248,7 +266,6 @@ export default function App(): JSX.Element {
                     min="0"
                     max="100"
                     step="10"
-                    defaultValue={0}
                     onChange={e => {
                       setViewport2(prev => ({
                         ...prev,
@@ -256,9 +273,13 @@ export default function App(): JSX.Element {
                       }))
                     }}
                     className="y-transition2"
+                    value={viewport2.y}
                   />
                 </Box>
               </Box>
+              <Button colorScheme="blue" onClick={handleSecondReset}>
+                Reset
+              </Button>
             </HStack>
           </Box>
         </HStack>

--- a/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
@@ -78,49 +78,8 @@ export default function App(): JSX.Element {
   return (
     <>
       <Box w={1100}>
-        <HStack spacing="240px" align="flex-start">
+        <HStack spacing="110px" align="flex-start">
           <Box mb={6}>
-            <HStack spacing="24px">
-              <Box>
-                invert{' '}
-                <Switch
-                  onChange={e =>
-                    setViewport({
-                      ...viewport,
-                      invert: e.target.checked,
-                    })
-                  }
-                  className="invert"
-                  isChecked={viewport.invert}
-                />
-              </Box>
-              <Box>
-                hflip{' '}
-                <Switch
-                  onChange={e =>
-                    setViewport({
-                      ...viewport,
-                      hflip: e.target.checked,
-                    })
-                  }
-                  className="hflip"
-                  isChecked={viewport.hflip}
-                />
-              </Box>
-              <Box>
-                vflip{' '}
-                <Switch
-                  onChange={e =>
-                    setViewport(prev => ({
-                      ...prev,
-                      vflip: e.target.checked,
-                    }))
-                  }
-                  className="vflip"
-                  isChecked={viewport.vflip}
-                />
-              </Box>
-            </HStack>
             <HStack spacing="24px" mt={3}>
               <Box>
                 <Box>x transition</Box>
@@ -164,27 +123,11 @@ export default function App(): JSX.Element {
                   />
                 </Box>
               </Box>
+              <Button colorScheme="blue" onClick={handleFirstReset}>
+                Reset
+              </Button>
             </HStack>
 
-            <Box>zoom</Box>
-            <Box>
-              <input
-                type="range"
-                id="scale"
-                name="scale"
-                min="0.5"
-                max="2"
-                step="0.1"
-                onChange={e => {
-                  setViewport(prev => ({
-                    ...prev,
-                    scale: Number(e.target.value),
-                  }))
-                }}
-                className="zoom"
-                value={viewport.scale}
-              />
-            </Box>
             <HStack spacing="24px" mt={3}>
               <Box>
                 <Box>windowWidth</Box>
@@ -228,13 +171,72 @@ export default function App(): JSX.Element {
                   />
                 </Box>
               </Box>
-              <Button colorScheme="blue" onClick={handleFirstReset}>
-                Reset
-              </Button>
+            </HStack>
+            <HStack spacing="24px">
+              <Box>
+                <Box>zoom</Box>
+                <Box>
+                  <input
+                    type="range"
+                    id="scale"
+                    name="scale"
+                    min="0.5"
+                    max="2"
+                    step="0.1"
+                    onChange={e => {
+                      setViewport(prev => ({
+                        ...prev,
+                        scale: Number(e.target.value),
+                      }))
+                    }}
+                    className="zoom"
+                    value={viewport.scale}
+                  />
+                </Box>
+              </Box>
+              <Box>
+                invert{' '}
+                <Switch
+                  onChange={e =>
+                    setViewport({
+                      ...viewport,
+                      invert: e.target.checked,
+                    })
+                  }
+                  className="invert"
+                  isChecked={viewport.invert}
+                />
+              </Box>
+              <Box>
+                hflip{' '}
+                <Switch
+                  onChange={e =>
+                    setViewport({
+                      ...viewport,
+                      hflip: e.target.checked,
+                    })
+                  }
+                  className="hflip"
+                  isChecked={viewport.hflip}
+                />
+              </Box>
+              <Box>
+                vflip{' '}
+                <Switch
+                  onChange={e =>
+                    setViewport(prev => ({
+                      ...prev,
+                      vflip: e.target.checked,
+                    }))
+                  }
+                  className="vflip"
+                  isChecked={viewport.vflip}
+                />
+              </Box>
             </HStack>
           </Box>
           <Box mb={6}>
-            <HStack spacing="24px" mt={35}>
+            <HStack spacing="24px">
               <Box>
                 <Box>x transition</Box>
                 <Box>

--- a/packages/insight-viewer/src/Viewer/DICOMImageViewer.tsx
+++ b/packages/insight-viewer/src/Viewer/DICOMImageViewer.tsx
@@ -12,6 +12,7 @@ import useImageLoader from '../hooks/useImageLoader'
 import useViewportUpdate from '../hooks/useViewportUpdate'
 import { Interaction } from '../hooks/useInteraction/types'
 import useViewportInteraction from '../hooks/useInteraction/useViewportInteraction'
+import useInitialViewport from '../hooks/useInitialViewport'
 import { SetFrame } from '../hooks/useMultiframe/useFrame'
 import setWadoImageLoader from '../utils/cornerstoneHelper/setWadoImageLoader'
 import { DefaultProp } from './const'
@@ -37,6 +38,8 @@ export function DICOMImageViewer({
   const elRef = useRef<HTMLDivElement>(null)
   // eslint-disable-next-line no-underscore-dangle
   const viewportRef = useRef(viewport)
+  const initialViewporRef = useInitialViewport()
+
   // enable/disable cornerstone.js
   useCornerstone(elRef.current)
   // enable cornerstone.js image loader and load/display image
@@ -50,7 +53,12 @@ export function DICOMImageViewer({
     onViewportChange,
   })
   // update cornerstone viewport when viewport prop changes
-  useViewportUpdate(elRef.current, viewport)
+  useViewportUpdate({
+    element: elRef.current,
+    viewport,
+    initialViewport: initialViewporRef?.current,
+    onViewportChange,
+  })
   // update cornerstone viewport on user interaction
   useViewportInteraction({
     element: elRef.current,

--- a/packages/insight-viewer/src/hooks/useImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useImageLoader.ts
@@ -4,7 +4,10 @@ import {
   loadImage as cornerstoneLoadImage,
 } from '../utils/cornerstoneHelper'
 import getHttpClient from '../utils/httpClient'
-import { loadingProgressMessage } from '../utils/messageService'
+import {
+  loadingProgressMessage,
+  initialViewportMessage,
+} from '../utils/messageService'
 import { formatViewport } from '../utils/common/formatViewport'
 import {
   Element,
@@ -48,17 +51,18 @@ export default function useImageLoader({
         const image = await cornerstoneLoadImage(imageId, {
           loader: getHttpClient(requestInterceptor),
         })
+        // This is for no content-length gzip image. Normally meaningless.
         loadingProgressMessage.sendMessage(100)
 
-        const { viewport } = displayImage(
+        const { viewport, defaultViewport } = displayImage(
           <HTMLDivElement>element,
           image,
-
           loadCountRef.current === 1
             ? // eslint-disable-next-line no-underscore-dangle
               viewportRef?.current?._initial
             : viewportRef?.current
         )
+        initialViewportMessage.sendMessage(defaultViewport)
 
         if (onViewportChange) {
           onViewportChange(formatViewport(viewport))
@@ -86,5 +90,4 @@ export default function useImageLoader({
     requestInterceptor,
     viewportRef,
   ])
-  return undefined
 }

--- a/packages/insight-viewer/src/hooks/useInitialViewport.ts
+++ b/packages/insight-viewer/src/hooks/useInitialViewport.ts
@@ -1,0 +1,26 @@
+import { useRef, MutableRefObject, useEffect } from 'react'
+import { Subscription } from 'rxjs'
+import { initialViewportMessage } from '../utils/messageService'
+import { CornerstoneViewport } from '../utils/cornerstoneHelper'
+
+let subscription: Subscription
+
+export default function useInitialViewport(): MutableRefObject<
+  CornerstoneViewport | undefined
+> {
+  const initialViewporRef = useRef<CornerstoneViewport>()
+
+  useEffect(() => {
+    subscription = initialViewportMessage
+      .getMessage()
+      .subscribe((message: CornerstoneViewport) => {
+        initialViewporRef.current = message
+      })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  return initialViewporRef
+}

--- a/packages/insight-viewer/src/hooks/useViewport.ts
+++ b/packages/insight-viewer/src/hooks/useViewport.ts
@@ -1,20 +1,37 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { Viewport, BasicViewport } from '../types'
 import { DefaultViewport } from '../const'
 
-export default function useViewport(
-  initial?: Partial<BasicViewport>
-): {
+export default function useViewport(initial?: Partial<BasicViewport>): {
   viewport: Viewport
   setViewport: React.Dispatch<React.SetStateAction<Viewport>>
+  resetViewport: () => void
 } {
   const [viewport, setViewport] = useState({
     ...DefaultViewport,
     ...(initial ? { _initial: initial } : {}),
   })
+  const [initialViewport, setInitialViewport] = useState<Viewport>()
+  const countRef = useRef(0)
+
+  function resetViewport() {
+    if (initialViewport) {
+      setViewport(initialViewport)
+    }
+  }
+
+  // Viewport initial value
+  // 1. DefaultViewport: For preventing 'cannot read property of undefined' errors. { scale, invert... }
+  // 2. User-defined initial Viewport + image meta data from cornerstone.js.
+  //    This should be used as initial value for viewport reset.
+  useEffect(() => {
+    countRef.current += 1
+    if (countRef.current === 2) setInitialViewport(viewport)
+  }, [viewport])
 
   return {
     viewport,
     setViewport,
+    resetViewport,
   }
 }

--- a/packages/insight-viewer/src/hooks/useViewport.ts
+++ b/packages/insight-viewer/src/hooks/useViewport.ts
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect } from 'react'
+/* eslint-disable no-underscore-dangle */
+import { useState } from 'react'
 import { Viewport, BasicViewport } from '../types'
 import { DefaultViewport } from '../const'
 
@@ -11,23 +12,13 @@ export default function useViewport(initial?: Partial<BasicViewport>): {
     ...DefaultViewport,
     ...(initial ? { _initial: initial } : {}),
   })
-  const [initialViewport, setInitialViewport] = useState<Viewport>()
-  const countRef = useRef(0)
 
   function resetViewport() {
-    if (initialViewport) {
-      setViewport(initialViewport)
-    }
+    setViewport({
+      ...viewport,
+      _reset: initial,
+    })
   }
-
-  // Viewport initial value
-  // 1. DefaultViewport: For preventing 'cannot read property of undefined' errors. { scale, invert... }
-  // 2. User-defined initial Viewport + image meta data from cornerstone.js.
-  //    This should be used as initial value for viewport reset.
-  useEffect(() => {
-    countRef.current += 1
-    if (countRef.current === 2) setInitialViewport(viewport)
-  }, [viewport])
 
   return {
     viewport,

--- a/packages/insight-viewer/src/hooks/useViewportUpdate.ts
+++ b/packages/insight-viewer/src/hooks/useViewportUpdate.ts
@@ -1,19 +1,50 @@
+/* eslint-disable no-underscore-dangle */
 import { useEffect } from 'react'
-import { getViewport, setViewport } from '../utils/cornerstoneHelper'
-import { formatCornerstoneViewport } from '../utils/common/formatViewport'
-import { Element, Viewport } from '../types'
+import {
+  getViewport,
+  setViewport,
+  CornerstoneViewport,
+} from '../utils/cornerstoneHelper'
+import {
+  formatCornerstoneViewport,
+  formatViewport,
+} from '../utils/common/formatViewport'
+import { Element, Viewport, OnViewportChange } from '../types'
 
-export default function useViewportUpdate(
-  element: Element,
-  newViewport?: Viewport
-): void {
+interface Prop {
+  element: Element
+  viewport?: Viewport
+  initialViewport: CornerstoneViewport | undefined
+  onViewportChange?: OnViewportChange
+}
+
+export default function useViewportUpdate({
+  element,
+  viewport: newViewport,
+  initialViewport,
+  onViewportChange,
+}: Prop): void {
   useEffect(() => {
     if (!element || !newViewport) return
-    const viewport = getViewport(<HTMLDivElement>element)
-    if (viewport)
-      setViewport(
-        <HTMLDivElement>element,
-        formatCornerstoneViewport(viewport, newViewport)
-      )
-  }, [element, newViewport])
+
+    const willReset = newViewport?._reset && initialViewport
+    const viewport = willReset
+      ? initialViewport
+      : getViewport(<HTMLDivElement>element)
+
+    if (!viewport) return
+
+    setViewport(
+      <HTMLDivElement>element,
+      formatCornerstoneViewport(viewport, newViewport)
+    )
+
+    // When resetting, update Viewer's viewport prop
+    if (willReset && onViewportChange) {
+      onViewportChange({
+        ...formatViewport(initialViewport),
+        ...(newViewport?._reset ?? {}),
+      })
+    }
+  }, [element, newViewport, initialViewport, onViewportChange])
 }

--- a/packages/insight-viewer/src/types/index.ts
+++ b/packages/insight-viewer/src/types/index.ts
@@ -30,6 +30,7 @@ export interface BasicViewport {
 }
 export type Viewport = BasicViewport & {
   _initial?: Partial<BasicViewport>
+  _reset?: Partial<BasicViewport>
 }
 
 export interface HTTP {

--- a/packages/insight-viewer/src/utils/cornerstoneHelper/utils.ts
+++ b/packages/insight-viewer/src/utils/cornerstoneHelper/utils.ts
@@ -24,6 +24,7 @@ export function displayImage(
   viewportOption?: Partial<Viewport>
 ): {
   viewport: CornerstoneViewport
+  defaultViewport: CornerstoneViewport
   image: CornerstoneImage
 } {
   const defaultViewport = cornerstone.getDefaultViewportForImage(element, image)
@@ -34,6 +35,7 @@ export function displayImage(
 
   return {
     viewport,
+    defaultViewport,
     image,
   }
 }

--- a/packages/insight-viewer/src/utils/messageService/index.ts
+++ b/packages/insight-viewer/src/utils/messageService/index.ts
@@ -1,1 +1,2 @@
 export { loadingProgressMessage } from './loadingProgress'
+export { initialViewportMessage } from './initialViewport'

--- a/packages/insight-viewer/src/utils/messageService/initialViewport.ts
+++ b/packages/insight-viewer/src/utils/messageService/initialViewport.ts
@@ -1,0 +1,9 @@
+import { Observable, Subject } from 'rxjs'
+import { CornerstoneViewport } from '../cornerstoneHelper'
+
+const subject = new Subject<CornerstoneViewport>()
+
+export const initialViewportMessage = {
+  sendMessage: (message: CornerstoneViewport): void => subject.next(message),
+  getMessage: (): Observable<CornerstoneViewport> => subject.asObservable(),
+}

--- a/packages/insight-viewer/tsconfig.json
+++ b/packages/insight-viewer/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "typeRoots": [
-      "./node_modules/@types",
-      "./src/@types"
-    ]
+    "typeRoots": ["./node_modules/@types", "./src/@types"]
   },
+  "exclude": ["**/*.spec.ts"]
 }

--- a/packages/insight-viewer/tsconfig.test.json
+++ b/packages/insight-viewer/tsconfig.test.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.test.json"
+  "extends": "../../tsconfig.test.json",
+  "include": ["**/*.spec.ts"]
 }


### PR DESCRIPTION
Issue
---
https://app.asana.com/0/1200128631446379/1200588986603613/f

Feature
---
- 뷰포트 리셋하기
- cypress 테스트 teardown에서 뷰포트 리셋 https://github.com/lunit-io/frontend-components/commit/966ebd8d7f729d063aafbe04a56af33433608d77

**Viewport Reset**
뷰포트 리셋은 cornerstone.js가 이미지 로드/디스플레이 할 때의 디폴트 뷰포트 + 유저가 정의한 초기 뷰포트 값을 사용한다.

- 뷰어 사용자가 리셋 할 때, useViewport의 viewport에 _reset 상태를 추가하고 여기 initial 뷰포트 값을 저장한다. https://github.com/lunit-io/frontend-components/pull/76/commits/c039da7c2d67b4cb3764d7034c3849088bcd78e8
- useImageLoader hook에서는 이미지를 displayImage 할 때, defaultViewport 값을 저장한다.
  pub/sub로 저장 및 사용 https://github.com/lunit-io/frontend-components/pull/76/commits/06089f3f95f7e6ff12d26d787b259de7976c2ee4 https://github.com/lunit-io/frontend-components/pull/76/commits/c2de72b61c25f136fdadab82b3e240d324f58ae3
- useViewportUpdate: Viewer의 viewport prop이 바뀔 때마다 cornerstone의 뷰포트를 업데이트하는 hook이다. https://github.com/lunit-io/frontend-components/pull/76/commits/b005258ebd48a99cacc743ef6a51bbc1cbab8c50
  - Viewer의 viewport prop에 _reset이 있다: 뷰포트 리셋
    - cornerstone의 뷰포트를 업데이트 하되, 이미지 display 할 때 저장했던 defaultViewport 값으로 업데이트
    - Viewer의 viewport prop도 업데이트: 이 때 _reset에 저장되어 있던 initial 뷰포트 값 사용
  - Viewer의 viewport prop에 _reset이 없다: 일반 뷰포트 업데이트
    기존과 동일. cornerstone의 뷰포트 업데이트