### PR TITLE
Feature/initial default viewport

### DIFF
--- a/apps/insight-viewer-demo/cypress/integration/basic.spec.ts
+++ b/apps/insight-viewer-demo/cypress/integration/basic.spec.ts
@@ -1,11 +1,6 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
-import {
-  VIEWPORT_WIDTH,
-  VIEWPORT_HEIGHT,
-  LOADING,
-  INITIALIZED,
-} from '../support/const'
+import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, LOADING } from '../support/const'
 
 describe(
   'Basic Viewer',
@@ -21,16 +16,14 @@ describe(
     })
 
     it('shows loading progress', () => {
-      cy.get(LOADING).then(() => {
-        cy.percySnapshot()
-      })
+      cy.get(LOADING).should('be.exist')
+      cy.percySnapshot()
     })
 
     it('shows initial image', () => {
-      cy.get(INITIALIZED).then(() => {
-        cy.get('.image').should('have.text', 'image1')
-        cy.percySnapshot()
-      })
+      cy.get(LOADING).should('not.exist')
+      cy.get('.image').should('have.text', 'image1')
+      cy.percySnapshot()
     })
 
     it('shows second image', () => {

--- a/apps/insight-viewer-demo/cypress/integration/error.spec.ts
+++ b/apps/insight-viewer-demo/cypress/integration/error.spec.ts
@@ -1,6 +1,6 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
-import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, INITIALIZED } from '../support/const'
+import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, LOADING } from '../support/const'
 
 describe(
   'Custom error',
@@ -16,8 +16,8 @@ describe(
     })
 
     it('shows custom error', () => {
+      cy.get(LOADING).should('not.exist')
       cy.get('.custom-error').click()
-      cy.get(INITIALIZED).should('not.exist')
       cy.percySnapshot()
     })
   }

--- a/apps/insight-viewer-demo/cypress/integration/interaction.custom.spec.ts
+++ b/apps/insight-viewer-demo/cypress/integration/interaction.custom.spec.ts
@@ -1,6 +1,6 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
-import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, INITIALIZED } from '../support/const'
+import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, LOADING } from '../support/const'
 
 describe(
   'Interaction',
@@ -20,10 +20,13 @@ describe(
       cy.get('.reset').click()
     })
 
+    it('shows loading progress', () => {
+      cy.get(LOADING).should('be.exist')
+    })
+
     it('shows initial viewport', () => {
-      cy.get(INITIALIZED).then(() => {
-        cy.percySnapshot()
-      })
+      cy.get(LOADING).should('not.exist')
+      cy.percySnapshot()
     })
 
     describe('Custom Interaction', () => {

--- a/apps/insight-viewer-demo/cypress/integration/interaction.spec.ts
+++ b/apps/insight-viewer-demo/cypress/integration/interaction.spec.ts
@@ -1,6 +1,6 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
-import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, INITIALIZED } from '../support/const'
+import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, LOADING } from '../support/const'
 
 describe(
   'Interaction',
@@ -19,10 +19,13 @@ describe(
       cy.get('.reset').click()
     })
 
+    it('shows loading progress', () => {
+      cy.get(LOADING).should('be.exist')
+    })
+
     it('shows initial viewport', () => {
-      cy.get(INITIALIZED).then(() => {
-        cy.percySnapshot()
-      })
+      cy.get(LOADING).should('not.exist')
+      cy.percySnapshot()
     })
 
     describe('Base Interaction', () => {

--- a/apps/insight-viewer-demo/cypress/integration/multiframe.spec.ts
+++ b/apps/insight-viewer-demo/cypress/integration/multiframe.spec.ts
@@ -1,11 +1,6 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
-import {
-  VIEWPORT_WIDTH,
-  VIEWPORT_HEIGHT,
-  LOADING,
-  INITIALIZED,
-} from '../support/const'
+import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, LOADING } from '../support/const'
 
 describe(
   'Multiframe',
@@ -21,16 +16,14 @@ describe(
     })
 
     it('shows loading progress', () => {
-      cy.get(LOADING).then(() => {
-        cy.percySnapshot()
-      })
+      cy.get(LOADING).should('be.exist')
+      cy.percySnapshot()
     })
 
     it('shows initial viewer', () => {
-      cy.get(INITIALIZED).then(() => {
-        cy.get('.frame-number').should('have.text', '0')
-        cy.percySnapshot()
-      })
+      cy.get(LOADING).should('not.exist')
+      cy.get('.frame-number').should('have.text', '0')
+      cy.percySnapshot()
     })
 
     it('change frame to 5', () => {

--- a/apps/insight-viewer-demo/cypress/integration/overlay.spec.ts
+++ b/apps/insight-viewer-demo/cypress/integration/overlay.spec.ts
@@ -1,6 +1,6 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
-import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, INITIALIZED } from '../support/const'
+import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, LOADING } from '../support/const'
 
 describe(
   'Overlay',
@@ -15,10 +15,13 @@ describe(
       cy.visit('/overlay')
     })
 
+    it('shows loading progress', () => {
+      cy.get(LOADING).should('be.exist')
+    })
+
     it('shows overlay', () => {
-      cy.get(INITIALIZED).then(() => {
-        cy.percySnapshot()
-      })
+      cy.get(LOADING).should('not.exist')
+      cy.percySnapshot()
     })
   }
 )

--- a/apps/insight-viewer-demo/cypress/integration/viewport.spec.ts
+++ b/apps/insight-viewer-demo/cypress/integration/viewport.spec.ts
@@ -1,6 +1,6 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
-import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, INITIALIZED } from '../support/const'
+import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, LOADING } from '../support/const'
 import { INITIAL_VIEWPORT1 } from '../../src/containers/Viewport/const'
 
 describe(
@@ -16,27 +16,29 @@ describe(
       cy.visit('/viewport')
     })
 
-    it('shows initial viewport', () => {
-      cy.get('.viewer1')
-        .find(INITIALIZED)
-        .then(() => {
-          cy.get('.viewer1 .scale').should('have.text', INITIAL_VIEWPORT1.scale)
-          cy.get('.viewer1 .x').should('have.text', (0).toFixed(2))
-          cy.get('.viewer1 .y').should('have.text', (0).toFixed(2))
-          cy.get('.viewer1 .windowWidth').should(
-            'have.text',
-            INITIAL_VIEWPORT1.windowWidth.toFixed(2)
-          )
-          cy.get('.viewer1 .windowCenter').should(
-            'have.text',
-            INITIAL_VIEWPORT1.windowCenter.toFixed(2)
-          )
-          cy.get('.viewer1 .invert').should('have.text', 'false')
-          cy.get('.viewer1 .hflip').should('have.text', 'false')
-          cy.get('.viewer1 .vflip').should('have.text', 'false')
+    it('shows loading progress', () => {
+      cy.get(LOADING).should('be.exist')
+    })
 
-          cy.percySnapshot()
-        })
+    it('shows initial viewport', () => {
+      cy.get(LOADING).should('not.exist')
+      cy.get('[data-cy=true]').should('be.exist')
+      cy.get('.viewer1 .scale').should('have.text', INITIAL_VIEWPORT1.scale)
+      cy.get('.viewer1 .x').should('have.text', (0).toFixed(2))
+      cy.get('.viewer1 .y').should('have.text', (0).toFixed(2))
+      cy.get('.viewer1 .windowWidth').should(
+        'have.text',
+        INITIAL_VIEWPORT1.windowWidth.toFixed(2)
+      )
+      cy.get('.viewer1 .windowCenter').should(
+        'have.text',
+        INITIAL_VIEWPORT1.windowCenter.toFixed(2)
+      )
+      cy.get('.viewer1 .invert').should('have.text', 'false')
+      cy.get('.viewer1 .hflip').should('have.text', 'false')
+      cy.get('.viewer1 .vflip').should('have.text', 'false')
+
+      cy.percySnapshot()
     })
 
     describe('viewport update', () => {
@@ -133,10 +135,8 @@ describe(
       })
 
       it('changes viewport with keyboard', () => {
-        cy.get(INITIALIZED).then(() => {
-          cy.get('body').type('wwddd')
-          cy.percySnapshot()
-        })
+        cy.get('body').type('wwddd')
+        cy.percySnapshot()
       })
 
       it('changes multiple viewer viewport', () => {

--- a/apps/insight-viewer-demo/cypress/support/const.ts
+++ b/apps/insight-viewer-demo/cypress/support/const.ts
@@ -1,4 +1,3 @@
 export const VIEWPORT_WIDTH = 1600
 export const VIEWPORT_HEIGHT = 900
 export const LOADING = '[data-cy=loading]'
-export const INITIALIZED = '[data-cy=initialized]'

--- a/apps/insight-viewer-demo/public/mockServiceWorker.js
+++ b/apps/insight-viewer-demo/public/mockServiceWorker.js
@@ -242,7 +242,9 @@ If you wish to mock an error response, please refer to this guide: https://mswjs
 
 self.addEventListener('fetch', function (event) {
   const { request } = event
-
+  // Without it, resource remains in a "pending" status.
+  if (!request.url.split('/').includes('msw')) return
+ 
   // Bypass navigation requests.
   if (request.mode === 'navigate') {
     return

--- a/apps/insight-viewer-demo/src/components/OverlayLayer/index.tsx
+++ b/apps/insight-viewer-demo/src/components/OverlayLayer/index.tsx
@@ -26,15 +26,16 @@ export default function OverlayLayer({
           <span className="vflip">{`${vflip}`}</span>
         </ListItem>
         <ListItem>
-          translation: <span className="x">{x.toFixed(2)}</span> /{' '}
-          <span className="y">{y.toFixed(2)}</span>
+          translation: <span className="x">{x?.toFixed(2)}</span> /{' '}
+          <span className="y">{y?.toFixed(2)}</span>
         </ListItem>
         <ListItem>
           invert: <span className="invert">{`${invert}`}</span>
         </ListItem>
         <ListItem>
-          WW / WC: <span className="windowWidth">{windowWidth.toFixed(2)}</span>{' '}
-          / <span className="windowCenter">{windowCenter.toFixed(2)}</span>
+          WW / WC:{' '}
+          <span className="windowWidth">{windowWidth?.toFixed(2)}</span> /{' '}
+          <span className="windowCenter">{windowCenter?.toFixed(2)}</span>
         </ListItem>
       </UnorderedList>
     </Box>

--- a/apps/insight-viewer-demo/src/components/Wrapper/index.tsx
+++ b/apps/insight-viewer-demo/src/components/Wrapper/index.tsx
@@ -19,8 +19,10 @@ export function ViewerWrapper({
     )
 
   return (
-    <Box w={500} h={500} className={className ?? ''}>
-      {children}
+    <Box bg="black" w="100%" d="flex" justifyContent="center">
+      <Box w={500} h={500} className={className ?? ''}>
+        {children}
+      </Box>
     </Box>
   )
 }

--- a/apps/insight-viewer-demo/src/containers/Interaction/Base.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Base.tsx
@@ -5,6 +5,7 @@ import Viewer, {
   useMultiframe,
   Interaction,
   Wheel,
+  hasViewport,
 } from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 import Control from './Control'
@@ -61,13 +62,16 @@ export default function App(): JSX.Element {
 
   const handleScale: Wheel = (_, deltaY) => {
     if (deltaY !== 0)
-      setViewport(prev => ({
-        ...prev,
-        scale: Math.min(
-          Math.max(prev.scale + (deltaY > 0 ? 0.25 : -0.25), MIN_SCALE),
-          MAX_SCALE
-        ),
-      }))
+      setViewport(prev => {
+        if (!hasViewport(prev)) return prev
+        return {
+          ...prev,
+          scale: Math.min(
+            Math.max(prev.scale + (deltaY > 0 ? 0.25 : -0.25), MIN_SCALE),
+            MAX_SCALE
+          ),
+        }
+      })
   }
 
   const handler = {

--- a/apps/insight-viewer-demo/src/containers/Interaction/Base.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Base.tsx
@@ -5,7 +5,7 @@ import Viewer, {
   useMultiframe,
   Interaction,
   Wheel,
-  hasViewport,
+  isValidViewport,
 } from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 import Control from './Control'
@@ -63,7 +63,7 @@ export default function App(): JSX.Element {
   const handleScale: Wheel = (_, deltaY) => {
     if (deltaY !== 0)
       setViewport(prev => {
-        if (!hasViewport(prev)) return prev
+        if (!isValidViewport(prev)) return prev
         return {
           ...prev,
           scale: Math.min(

--- a/apps/insight-viewer-demo/src/containers/Interaction/Canvas.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Canvas.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Viewport } from '@lunit/insight-viewer'
+import { Viewport, hasViewport } from '@lunit/insight-viewer'
 
 const style: React.CSSProperties = {
   position: 'absolute',
@@ -35,7 +35,7 @@ function drawRect({ context, canvas, x, y, scale }: Prop) {
 }
 
 export default function Canvas({
-  viewport: { x, y, scale },
+  viewport,
 }: {
   viewport: Viewport
 }): JSX.Element {
@@ -51,14 +51,15 @@ export default function Canvas({
   }, [context])
 
   useEffect(() => {
-    drawRect({
-      context,
-      canvas: canvasRef.current,
-      x,
-      y,
-      scale,
-    })
-  }, [x, y, scale, context])
+    if (hasViewport(viewport))
+      drawRect({
+        context,
+        canvas: canvasRef.current,
+        x: viewport.x,
+        y: viewport.y,
+        scale: viewport.scale,
+      })
+  }, [context, viewport])
 
   return <canvas ref={canvasRef} style={style} />
 }

--- a/apps/insight-viewer-demo/src/containers/Interaction/Canvas.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Canvas.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Viewport, hasViewport } from '@lunit/insight-viewer'
+import { Viewport, isValidViewport } from '@lunit/insight-viewer'
 
 const style: React.CSSProperties = {
   position: 'absolute',
@@ -51,7 +51,7 @@ export default function Canvas({
   }, [context])
 
   useEffect(() => {
-    if (hasViewport(viewport))
+    if (isValidViewport(viewport))
       drawRect({
         context,
         canvas: canvasRef.current,

--- a/apps/insight-viewer-demo/src/containers/Interaction/Code.ts
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Code.ts
@@ -5,7 +5,7 @@ import Viewer, {
   useInteraction,
   Interaction,
   Wheel,
-  hasViewport,
+  isValidViewport,
 } from '@lunit/insight-viewer'
 
 export default function App() {
@@ -43,7 +43,7 @@ export default function App() {
   const handleZoom: Wheel = (_, deltaY) => {
     if (deltaY !== 0)
       setViewport(prev => {
-        if (!hasViewport(prev)) return prev
+        if (!isValidViewport(prev)) return prev
         return {
           ...prev,
           scale: Math.min(
@@ -106,7 +106,7 @@ export default function App() {
       delta.y
     )
     setViewport(prev => {
-      if (!hasViewport(prev)) return prev
+      if (!isValidViewport(prev)) return prev
       return {
         ...prev,
         x: prev.x + delta.x / prev.scale,
@@ -124,7 +124,7 @@ export default function App() {
       delta.y
     )
     setViewport(prev => {
-      if (!hasViewport(prev)) return prev
+      if (!isValidViewport(prev)) return prev
       return {
         ...prev,
         windowWidth: prev.windowWidth + delta.x / prev.scale,

--- a/apps/insight-viewer-demo/src/containers/Interaction/Code.ts
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Code.ts
@@ -5,6 +5,7 @@ import Viewer, {
   useInteraction,
   Interaction,
   Wheel,
+  hasViewport,
 } from '@lunit/insight-viewer'
 
 export default function App() {
@@ -41,13 +42,16 @@ export default function App() {
 
   const handleZoom: Wheel = (_, deltaY) => {
     if (deltaY !== 0)
-      setViewport(prev => ({
-        ...prev,
-        scale: Math.min(
-          Math.max(prev.scale + (deltaY > 0 ? 0.25 : -0.25), MIN_SCALE),
-          MAX_SCALE
-        ),
-      }))
+      setViewport(prev => {
+        if (!hasViewport(prev)) return prev
+        return {
+          ...prev,
+          scale: Math.min(
+            Math.max(prev.scale + (deltaY > 0 ? 0.25 : -0.25), MIN_SCALE),
+            MAX_SCALE
+          ),
+        }
+      })
   }
 
   const handler = {
@@ -101,11 +105,14 @@ export default function App() {
       delta.x,
       delta.y
     )
-    setViewport(prev => ({
-      ...prev,
-      x: prev.x + delta.x / prev.scale,
-      y: prev.y + delta.y / prev.scale,
-    }))
+    setViewport(prev => {
+      if (!hasViewport(prev)) return prev
+      return {
+        ...prev,
+        x: prev.x + delta.x / prev.scale,
+        y: prev.y + delta.y / prev.scale,
+      }
+    })
   }
 
   const customAdjust: Drag = ({ viewport, delta }) => {
@@ -116,11 +123,14 @@ export default function App() {
       delta.x,
       delta.y
     )
-    setViewport(prev => ({
-      ...prev,
-      windowWidth: prev.windowWidth + delta.x / prev.scale,
-      windowCenter: prev.windowCenter + delta.y / prev.scale,
-    }))
+    setViewport(prev => {
+      if (!hasViewport(prev)) return prev
+      return {
+        ...prev,
+        windowWidth: prev.windowWidth + delta.x / prev.scale,
+        windowCenter: prev.windowCenter + delta.y / prev.scale,
+      }
+    })
   }
 
   function handleCustomPan(e: React.ChangeEvent<HTMLInputElement>) {

--- a/apps/insight-viewer-demo/src/containers/Interaction/Custom.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Custom.tsx
@@ -8,7 +8,7 @@ import Viewer, {
   DragEvent,
   Drag,
   Click,
-  hasViewport,
+  isValidViewport,
 } from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 import Control from './Control'
@@ -47,7 +47,7 @@ export default function App(): JSX.Element {
     )
 
     setViewport(prev => {
-      if (!hasViewport(prev)) return prev
+      if (!isValidViewport(prev)) return prev
       return {
         ...prev,
         x: prev.x + delta.x / prev.scale,
@@ -65,7 +65,7 @@ export default function App(): JSX.Element {
       delta.y
     )
     setViewport(prev => {
-      if (!hasViewport(prev)) return prev
+      if (!isValidViewport(prev)) return prev
       return {
         ...prev,
         windowWidth: prev.windowWidth + delta.x / prev.scale,

--- a/apps/insight-viewer-demo/src/containers/Interaction/Custom.tsx
+++ b/apps/insight-viewer-demo/src/containers/Interaction/Custom.tsx
@@ -8,6 +8,7 @@ import Viewer, {
   DragEvent,
   Drag,
   Click,
+  hasViewport,
 } from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 import Control from './Control'
@@ -39,17 +40,20 @@ export default function App(): JSX.Element {
   const customPan: Drag = ({ viewport, delta }) => {
     consola.info(
       'pan',
-      viewport.translation.x,
-      viewport.translation.y,
+      viewport.translation?.x,
+      viewport.translation?.y,
       delta.x,
       delta.y
     )
 
-    setViewport(prev => ({
-      ...prev,
-      x: prev.x + delta.x / prev.scale,
-      y: prev.y + delta.y / prev.scale,
-    }))
+    setViewport(prev => {
+      if (!hasViewport(prev)) return prev
+      return {
+        ...prev,
+        x: prev.x + delta.x / prev.scale,
+        y: prev.y + delta.y / prev.scale,
+      }
+    })
   }
 
   const customAdjust: Drag = ({ viewport, delta }) => {
@@ -60,11 +64,14 @@ export default function App(): JSX.Element {
       delta.x,
       delta.y
     )
-    setViewport(prev => ({
-      ...prev,
-      windowWidth: prev.windowWidth + delta.x / prev.scale,
-      windowCenter: prev.windowCenter + delta.y / prev.scale,
-    }))
+    setViewport(prev => {
+      if (!hasViewport(prev)) return prev
+      return {
+        ...prev,
+        windowWidth: prev.windowWidth + delta.x / prev.scale,
+        windowCenter: prev.windowCenter + delta.y / prev.scale,
+      }
+    })
   }
 
   const primaryClick: Click = (offsetX, offsetY) => {
@@ -122,6 +129,12 @@ export default function App(): JSX.Element {
         <Box>
           <Control onChange={handleDrag} />
           <ClickControl onChange={handleClick} />
+          <Box mb={6}>
+            <Text>
+              offset: <span className="click-x">{x?.toFixed(2) ?? 0}</span> /{' '}
+              <span className="click-y">{y?.toFixed(2) ?? 0}</span>
+            </Text>
+          </Box>
           {typeof x === 'number' && typeof y === 'number' && (
             <Box mb={6}>
               <Text>

--- a/apps/insight-viewer-demo/src/containers/Viewport/Code.ts
+++ b/apps/insight-viewer-demo/src/containers/Viewport/Code.ts
@@ -1,5 +1,5 @@
 export const CODE = `\
-import Viewer, { useViewport, Viewport, hasViewport } from '@lunit/insight-viewer'
+import Viewer, { useViewport, Viewport, isValidViewport } from '@lunit/insight-viewer'
 
 export default function App() {
   const { viewport, setViewport, resetViewport } = useViewport({
@@ -10,7 +10,7 @@ export default function App() {
 
   function updateViewport() {
     setViewport(prev => {
-      if (!hasViewport(prev)) return prev
+      if (!isValidViewport(prev)) return prev
       return {
         ...prev,
         invert: false,
@@ -25,7 +25,7 @@ export default function App() {
     })
 
     // or
-    if (hasViewport(viewport))
+    if (isValidViewport(viewport))
       setViewport({
         ...viewport,
         hflip: e.target.checked,
@@ -37,7 +37,7 @@ export default function App() {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === 's') {
         setViewport((prev: Viewport) => {
-          if (!hasViewport(prev)) return prev
+          if (!isValidViewport(prev)) return prev
           return {
             ...prev,
             y: prev.y + 10,
@@ -46,7 +46,7 @@ export default function App() {
       }
       if (e.key === 'w') {
         setViewport((prev: Viewport) => {
-          if (!hasViewport(prev)) return prev
+          if (!isValidViewport(prev)) return prev
           return {
             ...prev,
             y: prev.y - 10,
@@ -55,7 +55,7 @@ export default function App() {
       }
       if (e.key === 'd') {
         setViewport((prev: Viewport) => {
-          if (!hasViewport(prev)) return prev
+          if (!isValidViewport(prev)) return prev
           return {
             ...prev,
             x: prev.x + 10,
@@ -64,7 +64,7 @@ export default function App() {
       }
       if (e.key === 'a') {
         setViewport((prev: Viewport) => {
-          if (!hasViewport(prev)) return prev
+          if (!isValidViewport(prev)) return prev
           return {
             ...prev,
             x: prev.x - 10,

--- a/apps/insight-viewer-demo/src/containers/Viewport/Code.ts
+++ b/apps/insight-viewer-demo/src/containers/Viewport/Code.ts
@@ -1,5 +1,5 @@
 export const CODE = `\
-import Viewer, { useViewport, Viewport } from '@lunit/insight-viewer'
+import Viewer, { useViewport, Viewport, hasViewport } from '@lunit/insight-viewer'
 
 export default function App() {
   const { viewport, setViewport, resetViewport } = useViewport({
@@ -9,51 +9,67 @@ export default function App() {
   })
 
   function updateViewport() {
-    setViewport(prev => ({
-      ...prev,
-      invert: false,
-      hflip: false,
-      vflip: true,
-      x: 10,
-      y: 0,
-      scale: 1,
-      windowWidth: 128,
-      windowCenter: 256
-    }))
+    setViewport(prev => {
+      if (!hasViewport(prev)) return prev
+      return {
+        ...prev,
+        invert: false,
+        hflip: false,
+        vflip: true,
+        x: 10,
+        y: 0,
+        scale: 1,
+        windowWidth: 128,
+        windowCenter: 256
+      }
+    })
 
     // or
-    setViewport({
-      ...viewport,
-      hflip: e.target.checked,
-    })
+    if (hasViewport(viewport))
+      setViewport({
+        ...viewport,
+        hflip: e.target.checked,
+      })
   }
 
   // update viewport with keyboard event
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === 's') {
-        setViewport((prev: Viewport) => ({
-          ...prev,
-          y: prev.y + 10,
-        }))
+        setViewport((prev: Viewport) => {
+          if (!hasViewport(prev)) return prev
+          return {
+            ...prev,
+            y: prev.y + 10,
+          }
+        })
       }
       if (e.key === 'w') {
-        setViewport((prev: Viewport) => ({
-          ...prev,
-          y: prev.y - 10,
-        }))
+        setViewport((prev: Viewport) => {
+          if (!hasViewport(prev)) return prev
+          return {
+            ...prev,
+            y: prev.y - 10,
+          }
+        })
       }
       if (e.key === 'd') {
-        setViewport((prev: Viewport) => ({
-          ...prev,
-          x: prev.x + 10,
-        }))
+        setViewport((prev: Viewport) => {
+          if (!hasViewport(prev)) return prev
+          return {
+            ...prev,
+            x: prev.x + 10,
+          }
+        })
       }
       if (e.key === 'a') {
-        setViewport((prev: Viewport) => ({
-          ...prev,
-          x: prev.x - 10,
-        }))
+        setViewport((prev: Viewport) => {
+          if (!hasViewport(prev)) return prev
+          return {
+            ...prev,
+            x: prev.x - 10,
+          }
+        })
       }
     }
 

--- a/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
@@ -1,6 +1,10 @@
-import { useEffect } from 'react'
+import { useEffect, useCallback } from 'react'
 import { Box, Text, Stack, Switch, Button } from '@chakra-ui/react'
-import Viewer, { useViewport, Viewport } from '@lunit/insight-viewer'
+import Viewer, {
+  useViewport,
+  Viewport,
+  hasViewport,
+} from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 import OverlayLayer from '../../components/OverlayLayer'
 import CustomProgress from '../../components/CustomProgress'
@@ -34,31 +38,33 @@ export default function App(): JSX.Element {
     resetViewport2()
   }
 
+  const updateViewport = useCallback(
+    (key: keyof Viewport, value: unknown) => {
+      setViewport((prev: Viewport) => {
+        if (!hasViewport(prev)) return prev
+        return {
+          ...prev,
+          [key]: value,
+        }
+      })
+    },
+    [setViewport]
+  )
+
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
+      if (!hasViewport(viewport)) return
       if (e.key === 's') {
-        setViewport((prev: Viewport) => ({
-          ...prev,
-          y: prev.y + 10,
-        }))
+        updateViewport('y', viewport.y + 10)
       }
       if (e.key === 'w') {
-        setViewport((prev: Viewport) => ({
-          ...prev,
-          y: prev.y - 10,
-        }))
+        updateViewport('y', viewport.y - 10)
       }
       if (e.key === 'd') {
-        setViewport((prev: Viewport) => ({
-          ...prev,
-          x: prev.x + 10,
-        }))
+        updateViewport('x', viewport.x + 10)
       }
       if (e.key === 'a') {
-        setViewport((prev: Viewport) => ({
-          ...prev,
-          x: prev.x - 10,
-        }))
+        updateViewport('x', viewport.x - 10)
       }
     }
 
@@ -67,7 +73,7 @@ export default function App(): JSX.Element {
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
     }
-  }, [setViewport])
+  }, [setViewport, viewport, updateViewport])
 
   return (
     <>
@@ -90,13 +96,10 @@ export default function App(): JSX.Element {
                     max="100"
                     step="10"
                     onChange={e => {
-                      setViewport(prev => ({
-                        ...prev,
-                        x: Number(e.target.value),
-                      }))
+                      updateViewport('x', Number(e.target.value))
                     }}
                     className="x-control"
-                    value={viewport.x}
+                    value={viewport?.x ?? 0}
                   />
                 </Box>
               </Box>
@@ -111,13 +114,10 @@ export default function App(): JSX.Element {
                     max="100"
                     step="10"
                     onChange={e => {
-                      setViewport(prev => ({
-                        ...prev,
-                        y: Number(e.target.value),
-                      }))
+                      updateViewport('y', Number(e.target.value))
                     }}
                     className="y-control"
-                    value={viewport.y}
+                    value={viewport?.y ?? 0}
                   />
                 </Box>
               </Box>
@@ -146,13 +146,10 @@ export default function App(): JSX.Element {
                     max="300"
                     step="10"
                     onChange={e => {
-                      setViewport(prev => ({
-                        ...prev,
-                        windowWidth: Number(e.target.value),
-                      }))
+                      updateViewport('windowWidth', Number(e.target.value))
                     }}
                     className="window-width-control"
-                    value={viewport.windowWidth}
+                    value={viewport?.windowWidth ?? 0}
                   />
                 </Box>
               </Box>
@@ -167,13 +164,10 @@ export default function App(): JSX.Element {
                     max="300"
                     step="10"
                     onChange={e => {
-                      setViewport(prev => ({
-                        ...prev,
-                        windowCenter: Number(e.target.value),
-                      }))
+                      updateViewport('windowCenter', Number(e.target.value))
                     }}
                     className="window-center-control"
-                    value={viewport.windowCenter}
+                    value={viewport?.windowCenter ?? 0}
                   />
                 </Box>
               </Box>
@@ -188,13 +182,10 @@ export default function App(): JSX.Element {
                     max="2"
                     step="0.1"
                     onChange={e => {
-                      setViewport(prev => ({
-                        ...prev,
-                        scale: Number(e.target.value),
-                      }))
+                      updateViewport('scale', Number(e.target.value))
                     }}
                     className="scale-control"
-                    value={viewport.scale}
+                    value={viewport?.scale ?? 0}
                   />
                 </Box>
               </Box>
@@ -207,12 +198,7 @@ export default function App(): JSX.Element {
               <Box>
                 invert{' '}
                 <Switch
-                  onChange={e =>
-                    setViewport({
-                      ...viewport,
-                      invert: e.target.checked,
-                    })
-                  }
+                  onChange={e => updateViewport('invert', e.target.checked)}
                   className="invert-control"
                   isChecked={viewport.invert}
                 />
@@ -220,27 +206,17 @@ export default function App(): JSX.Element {
               <Box>
                 hflip{' '}
                 <Switch
-                  onChange={e =>
-                    setViewport({
-                      ...viewport,
-                      hflip: e.target.checked,
-                    })
-                  }
+                  onChange={e => updateViewport('hflip', e.target.checked)}
                   className="hflip-control"
-                  isChecked={viewport.hflip}
+                  isChecked={viewport?.hflip ?? false}
                 />
               </Box>
               <Box>
                 vflip{' '}
                 <Switch
-                  onChange={e =>
-                    setViewport(prev => ({
-                      ...prev,
-                      vflip: e.target.checked,
-                    }))
-                  }
+                  onChange={e => updateViewport('vflip', e.target.checked)}
                   className="vflip-control"
-                  isChecked={viewport.vflip}
+                  isChecked={viewport?.vflip ?? false}
                 />
               </Box>
             </Stack>
@@ -251,7 +227,7 @@ export default function App(): JSX.Element {
               direction={isOneColumn ? 'column' : 'row'}
             >
               <Box>
-                <Box>x transition {viewport2.x}</Box>
+                <Box>x transition {viewport2?.x}</Box>
                 <Box>
                   <input
                     type="range"
@@ -261,18 +237,21 @@ export default function App(): JSX.Element {
                     max="100"
                     step="10"
                     onChange={e => {
-                      setViewport2(prev => ({
-                        ...prev,
-                        x: Number(e.target.value),
-                      }))
+                      setViewport2(prev => {
+                        if (!hasViewport(prev)) return prev
+                        return {
+                          ...prev,
+                          x: Number(e.target.value),
+                        }
+                      })
                     }}
                     className="x-control2"
-                    value={viewport2.x}
+                    value={viewport2?.x ?? 0}
                   />
                 </Box>
               </Box>
               <Box>
-                <Box>y transition {viewport2.y}</Box>
+                <Box>y transition {viewport2?.y}</Box>
                 <Box>
                   <input
                     type="range"
@@ -282,13 +261,16 @@ export default function App(): JSX.Element {
                     max="100"
                     step="10"
                     onChange={e => {
-                      setViewport2(prev => ({
-                        ...prev,
-                        y: Number(e.target.value),
-                      }))
+                      setViewport2(prev => {
+                        if (!hasViewport(prev)) return prev
+                        return {
+                          ...prev,
+                          y: Number(e.target.value),
+                        }
+                      })
                     }}
                     className="y-control2"
-                    value={viewport2.y}
+                    value={viewport2?.y ?? 0}
                   />
                 </Box>
               </Box>

--- a/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
@@ -3,7 +3,7 @@ import { Box, Text, Stack, Switch, Button } from '@chakra-ui/react'
 import Viewer, {
   useViewport,
   Viewport,
-  hasViewport,
+  isValidViewport,
 } from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 import OverlayLayer from '../../components/OverlayLayer'
@@ -41,7 +41,7 @@ export default function App(): JSX.Element {
   const updateViewport = useCallback(
     (key: keyof Viewport, value: unknown) => {
       setViewport((prev: Viewport) => {
-        if (!hasViewport(prev)) return prev
+        if (!isValidViewport(prev)) return prev
         return {
           ...prev,
           [key]: value,
@@ -53,7 +53,7 @@ export default function App(): JSX.Element {
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (!hasViewport(viewport)) return
+      if (!isValidViewport(viewport)) return
       if (e.key === 's') {
         updateViewport('y', viewport.y + 10)
       }
@@ -77,7 +77,7 @@ export default function App(): JSX.Element {
 
   return (
     <>
-      <Box data-cy={hasViewport(viewport)}>
+      <Box data-cy={isValidViewport(viewport)}>
         <Stack align="flex-start" spacing={isOneColumn ? '20px' : '20px'}>
           <Box mb={6}>
             <Stack
@@ -238,7 +238,7 @@ export default function App(): JSX.Element {
                     step="10"
                     onChange={e => {
                       setViewport2(prev => {
-                        if (!hasViewport(prev)) return prev
+                        if (!isValidViewport(prev)) return prev
                         return {
                           ...prev,
                           x: Number(e.target.value),
@@ -262,7 +262,7 @@ export default function App(): JSX.Element {
                     step="10"
                     onChange={e => {
                       setViewport2(prev => {
-                        if (!hasViewport(prev)) return prev
+                        if (!isValidViewport(prev)) return prev
                         return {
                           ...prev,
                           y: Number(e.target.value),

--- a/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
+++ b/apps/insight-viewer-demo/src/containers/Viewport/index.tsx
@@ -77,7 +77,7 @@ export default function App(): JSX.Element {
 
   return (
     <>
-      <Box>
+      <Box data-cy={hasViewport(viewport)}>
         <Stack align="flex-start" spacing={isOneColumn ? '20px' : '20px'}>
           <Box mb={6}>
             <Stack

--- a/packages/insight-viewer/src/Viewer/DICOMImageViewer.tsx
+++ b/packages/insight-viewer/src/Viewer/DICOMImageViewer.tsx
@@ -67,7 +67,7 @@ export function DICOMImageViewer({
   })
 
   useEffect(() => {
-    if (viewport) viewportRef.current = viewport
+    viewportRef.current = viewport
   }, [viewport])
 
   return (

--- a/packages/insight-viewer/src/components/LoadingProgress/index.tsx
+++ b/packages/insight-viewer/src/components/LoadingProgress/index.tsx
@@ -29,17 +29,21 @@ export default function LoadingProgress({
   })
 
   useEffect(() => {
+    let isCancelled = false
+
     subscription = loadingProgressMessage
       .getMessage()
       .subscribe(({ message, loaded }) => {
-        setState(prev => ({
-          ...prev,
-          progress: message,
-          initialized: loaded || false,
-        }))
+        if (!isCancelled)
+          setState(prev => ({
+            ...prev,
+            progress: message,
+            initialized: loaded || false,
+          }))
       })
 
     return () => {
+      isCancelled = true
       subscription.unsubscribe()
     }
   }, [])

--- a/packages/insight-viewer/src/components/LoadingProgress/index.tsx
+++ b/packages/insight-viewer/src/components/LoadingProgress/index.tsx
@@ -18,29 +18,24 @@ export default function LoadingProgress({
 }: {
   Progress: ProgressComponent
 }): JSX.Element {
-  const [{ progress, hidden, initialized }, setState] = useState<{
+  const [{ progress, hidden }, setState] = useState<{
     progress?: number
     hidden: boolean
-    initialized: boolean
   }>({
     progress: undefined,
     hidden: true,
-    initialized: false,
   })
 
   useEffect(() => {
     let isCancelled = false
 
-    subscription = loadingProgressMessage
-      .getMessage()
-      .subscribe(({ message, loaded }) => {
-        if (!isCancelled)
-          setState(prev => ({
-            ...prev,
-            progress: message,
-            initialized: loaded || false,
-          }))
-      })
+    subscription = loadingProgressMessage.getMessage().subscribe(message => {
+      if (!isCancelled)
+        setState(prev => ({
+          ...prev,
+          progress: message,
+        }))
+    })
 
     return () => {
       isCancelled = true
@@ -49,26 +44,19 @@ export default function LoadingProgress({
   }, [])
 
   useEffect(() => {
-    if (initialized) {
+    if (progress === 100) {
       setState(prev => ({ ...prev, hidden: true }))
     }
 
     if (progress === 0) {
       setState(prev => ({ ...prev, hidden: false }))
     }
-  }, [progress, initialized])
-
-  const viewerState = [
-    !hidden ? 'loading' : '',
-    initialized ? 'initialized' : '',
-  ]
-    .join(' ')
-    .trim()
+  }, [progress])
 
   return (
     <div
       style={style}
-      data-cy={viewerState} // For Cypress test.
+      data-cy={!hidden ? 'loading' : ''} // For Cypress test.
     >
       {!hidden && <Progress progress={progress ?? 0} />}
     </div>

--- a/packages/insight-viewer/src/hooks/useImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useImageLoader.ts
@@ -59,8 +59,8 @@ export default function useImageLoader({
             ? viewportRef?.current?._default
             : viewportRef?.current
         )
-        // This is for no content-length gzip image. At this time, Viewport has been initialized.
-        loadingProgressMessage.sendMessage(100, true)
+        // This is for no content-length gzip image. Normally, meaningless.
+        loadingProgressMessage.sendMessage(100)
         initialViewportMessage.sendMessage(defaultViewport)
 
         if (onViewportChange) {

--- a/packages/insight-viewer/src/hooks/useImageLoader.ts
+++ b/packages/insight-viewer/src/hooks/useImageLoader.ts
@@ -56,7 +56,7 @@ export default function useImageLoader({
           <HTMLDivElement>element,
           image,
           loadCountRef.current === 1
-            ? viewportRef?.current?._initial
+            ? viewportRef?.current?._default
             : viewportRef?.current
         )
         // This is for no content-length gzip image. At this time, Viewport has been initialized.

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleClick/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleClick/index.ts
@@ -6,7 +6,7 @@ import { Viewport } from '../../../types'
 import { MOUSE_BUTTON, PRIMARY_CLICK, SECONDARY_CLICK } from '../const'
 import { preventContextMenu, hasInteraction } from '../utils'
 import { getViewport } from '../../../utils/cornerstoneHelper'
-import { hasViewport } from '../../../utils/common'
+import { isValidViewport } from '../../../utils/common'
 
 let subscription: Subscription
 
@@ -23,7 +23,7 @@ function hasClickType(
 }
 
 function getCoord(element: Element, viewport?: Viewport) {
-  if (viewport && hasViewport(viewport)) {
+  if (viewport && isValidViewport(viewport)) {
     const { x, y } = viewport
 
     return {

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleClick/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleClick/index.ts
@@ -6,6 +6,7 @@ import { Viewport } from '../../../types'
 import { MOUSE_BUTTON, PRIMARY_CLICK, SECONDARY_CLICK } from '../const'
 import { preventContextMenu, hasInteraction } from '../utils'
 import { getViewport } from '../../../utils/cornerstoneHelper'
+import { hasViewport } from '../../../utils/common'
 
 let subscription: Subscription
 
@@ -22,7 +23,7 @@ function hasClickType(
 }
 
 function getCoord(element: Element, viewport?: Viewport) {
-  if (viewport) {
+  if (viewport && hasViewport(viewport)) {
     const { x, y } = viewport
 
     return {

--- a/packages/insight-viewer/src/hooks/useMultiframe/usePrefetch.ts
+++ b/packages/insight-viewer/src/hooks/useMultiframe/usePrefetch.ts
@@ -15,8 +15,7 @@ function PromiseAllWithProgress(
     p.then(() => {
       d += 1
       loadingProgressMessage.sendMessage(
-        Math.round((d * 100) / promiseArray.length),
-        d === promiseArray.length
+        Math.round((d * 100) / promiseArray.length)
       )
     })
   })

--- a/packages/insight-viewer/src/hooks/useViewport.ts
+++ b/packages/insight-viewer/src/hooks/useViewport.ts
@@ -2,20 +2,20 @@ import { useState } from 'react'
 import { Viewport, BasicViewport } from '../types'
 import { DefaultViewport } from '../const'
 
-export default function useViewport(initial?: Partial<BasicViewport>): {
+export default function useViewport(defaultViewport?: Partial<BasicViewport>): {
   viewport: Viewport
   setViewport: React.Dispatch<React.SetStateAction<Viewport>>
   resetViewport: () => void
 } {
   const [viewport, setViewport] = useState({
     ...DefaultViewport,
-    ...(initial ? { _initial: initial } : {}),
+    ...(defaultViewport ? { _default: defaultViewport } : {}),
   })
 
   function resetViewport() {
     setViewport({
       ...viewport,
-      _reset: initial,
+      _reset: defaultViewport,
     })
   }
 

--- a/packages/insight-viewer/src/hooks/useViewport.ts
+++ b/packages/insight-viewer/src/hooks/useViewport.ts
@@ -1,14 +1,12 @@
 import { useState } from 'react'
 import { Viewport, BasicViewport } from '../types'
-import { DefaultViewport } from '../const'
 
 export default function useViewport(defaultViewport?: Partial<BasicViewport>): {
   viewport: Viewport
   setViewport: React.Dispatch<React.SetStateAction<Viewport>>
   resetViewport: () => void
 } {
-  const [viewport, setViewport] = useState({
-    ...DefaultViewport,
+  const [viewport, setViewport] = useState<Viewport>({
     ...(defaultViewport ? { _default: defaultViewport } : {}),
   })
 

--- a/packages/insight-viewer/src/index.ts
+++ b/packages/insight-viewer/src/index.ts
@@ -3,7 +3,7 @@ export { default as useMultiframe } from './hooks/useMultiframe'
 export { default as useViewport } from './hooks/useViewport'
 export { default as useInteraction } from './hooks/useInteraction'
 export type { Interaction, SetInteraction } from './hooks/useInteraction/types'
-export { hasViewport } from './utils/common'
+export { isValidViewport } from './utils/common'
 export type { Viewport, ViewerError } from './types'
 export type {
   DragEvent,

--- a/packages/insight-viewer/src/index.ts
+++ b/packages/insight-viewer/src/index.ts
@@ -3,6 +3,7 @@ export { default as useMultiframe } from './hooks/useMultiframe'
 export { default as useViewport } from './hooks/useViewport'
 export { default as useInteraction } from './hooks/useInteraction'
 export type { Interaction, SetInteraction } from './hooks/useInteraction/types'
+export { hasViewport } from './utils/common'
 export type { Viewport, ViewerError } from './types'
 export type {
   DragEvent,

--- a/packages/insight-viewer/src/types/index.ts
+++ b/packages/insight-viewer/src/types/index.ts
@@ -29,7 +29,7 @@ export interface BasicViewport {
   windowCenter: number
 }
 export type Viewport = BasicViewport & {
-  _initial?: Partial<BasicViewport>
+  _default: Partial<BasicViewport>
   _reset?: Partial<BasicViewport>
 }
 

--- a/packages/insight-viewer/src/types/index.ts
+++ b/packages/insight-viewer/src/types/index.ts
@@ -28,8 +28,8 @@ export interface BasicViewport {
   windowWidth: number
   windowCenter: number
 }
-export type Viewport = BasicViewport & {
-  _default: Partial<BasicViewport>
+export type Viewport = Partial<BasicViewport> & {
+  _default?: Partial<BasicViewport>
   _reset?: Partial<BasicViewport>
 }
 

--- a/packages/insight-viewer/src/utils/common/index.ts
+++ b/packages/insight-viewer/src/utils/common/index.ts
@@ -5,7 +5,7 @@ export function handleError(e: Error): void {
   consola.error(e)
 }
 
-export function hasViewport(viewport: Viewport): viewport is BasicViewport {
+export function isValidViewport(viewport: Viewport): viewport is BasicViewport {
   return (
     viewport.scale !== undefined &&
     viewport.invert !== undefined &&

--- a/packages/insight-viewer/src/utils/common/index.ts
+++ b/packages/insight-viewer/src/utils/common/index.ts
@@ -1,5 +1,19 @@
 import consola from 'consola'
+import { Viewport, BasicViewport } from '../../types'
 
 export function handleError(e: Error): void {
   consola.error(e)
+}
+
+export function hasViewport(viewport: Viewport): viewport is BasicViewport {
+  return (
+    viewport.scale !== undefined &&
+    viewport.invert !== undefined &&
+    viewport.hflip !== undefined &&
+    viewport.vflip !== undefined &&
+    viewport.x !== undefined &&
+    viewport.y !== undefined &&
+    viewport.windowWidth !== undefined &&
+    viewport.windowCenter !== undefined
+  )
 }

--- a/packages/insight-viewer/src/utils/messageService/loadingProgress.ts
+++ b/packages/insight-viewer/src/utils/messageService/loadingProgress.ts
@@ -1,14 +1,8 @@
 import { Observable, Subject } from 'rxjs'
 
-interface Message {
-  message: number
-  loaded?: boolean
-}
-
-const subject = new Subject<Message>()
+const subject = new Subject<number>()
 
 export const loadingProgressMessage = {
-  sendMessage: (message: number, loaded = false): void =>
-    subject.next({ message, loaded }),
-  getMessage: (): Observable<Message> => subject.asObservable(),
+  sendMessage: (message: number): void => subject.next(message),
+  getMessage: (): Observable<number> => subject.asObservable(),
 }


### PR DESCRIPTION
Issue
---
https://app.asana.com/0/0/1200618278948823/f
뷰포트 상태정의 업데이트.

Feature
---
useViewport hook이 반환하는 viewport의 시작값은.

[AS-IS] 
의미 없는 placeholder로 기능한다.
```ts
{
  scale: 0,
  invert: false,
  hflip: false,
  vflip: false,
  x: 0,
  y: 0,
  windowWidth: 0,
  windowCenter: 0,
}
```
[TO-BE] 
이미지를 loadAndDisplay 하여 유저가 정의한 초기값 + cornerstone.js가 제공하는 뷰포트 값을 얻기 전에는 값이 없다.
하지만 _default, _reset 값도 필요하므로 뷰포트가 설정되기 전에는 undefined가 아닌, {} 이다.
- 사용자가 정의한 초기 뷰포트 상태명을 _initial에서 _default로 변경 https://github.com/lunit-io/frontend-components/commit/449ccd6cf5cad62f2fb064ba7d97b330afb92882
- Progress가 진행 중에 unmount 될 때 발생하는 오류 fix https://github.com/lunit-io/frontend-components/commit/57ae0759710c4438d6082c2e1e1e740d6ce52365
- Viewport 타입 정의 업데이트 https://github.com/lunit-io/frontend-components/commit/429e38625369a0c2ac7d4ada4d1f099ee16dba35
- BasicViewport(뷰어에서 prop으로 사용하는 뷰포트 타입)이 유효한지 체크하는 유틸리티 함수 추가 https://github.com/lunit-io/frontend-components/commit/66a07288dc024e74df1ab6a8b0ffec2acc38610a
- 뷰포트가 초기화되었는지 여부를 가리던 상태 제거하고 뷰포트가 있는지 여부로 판단한다.  https://github.com/lunit-io/frontend-components/commit/0cd4e6efc944078686aa3f3c75136afe487553ca 
