### PR TITLE
Test/update percy testing related view setting

### DIFF
--- a/apps/insight-viewer-docs/cypress/integration/basic.spec.ts
+++ b/apps/insight-viewer-docs/cypress/integration/basic.spec.ts
@@ -15,11 +15,6 @@ describe(
       setup()
     })
 
-    it('shows loading progress', () => {
-      cy.get($LOADED).should('be.not.exist')
-      cy.percySnapshot()
-    })
-
     it('shows initial image', () => {
       cy.get($LOADED).should('be.exist')
       cy.get('.image').should('have.text', 'image1')

--- a/apps/insight-viewer-docs/cypress/integration/multiframe.spec.ts
+++ b/apps/insight-viewer-docs/cypress/integration/multiframe.spec.ts
@@ -1,6 +1,6 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
-import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, $LOADED } from '../support/const'
+import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT } from '../support/const'
 
 describe(
   'Multiframe',
@@ -13,11 +13,6 @@ describe(
     before(() => {
       setup()
       cy.visit('/multi-frame')
-    })
-
-    it('shows loading progress', () => {
-      cy.get($LOADED).should('be.not.exist')
-      cy.percySnapshot()
     })
 
     it('shows initial viewer', () => {

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,6 +16,8 @@ module.exports = {
         // Insert custom scopes below:
         'root',
         'release',
+        'viewer',
+        'viewer-docs',
       ],
     ],
     'scope-empty': [2, 'never'],


### PR DESCRIPTION
Issue
---
https://app.asana.com/0/1200128631446379/1200814657674778/f

Feature
---
- Percy 스크린샷 테스트에서 Progress 상태 확인하지 않기
  빙글빙글 돌기 때문에 테스트마다 스크린샷이 다를 수 있어 의미가 없다.
- commitlint의 프로젝트 명이 너무 길어(insight-viewer, insight-viewer-docs), 별칭 추가(viewer, viewer-docs)