### PR TITLE
Test/e2e testing related update

### DIFF
--- a/apps/insight-viewer-docs/config.js
+++ b/apps/insight-viewer-docs/config.js
@@ -1,5 +1,7 @@
 const config = {
   IS_DEV: process.env.NODE_ENV === 'development',
+  IS_CYPRESS:
+    typeof window !== 'undefined' && typeof window.Cypress !== 'undefined',
 }
 
 export default config

--- a/apps/insight-viewer-docs/cypress/integration/basic.spec.ts
+++ b/apps/insight-viewer-docs/cypress/integration/basic.spec.ts
@@ -1,6 +1,7 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
-import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, $LOADED } from '../support/const'
+import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT } from '../support/const'
+import { IMAGES } from '../../src/const'
 
 describe(
   'Basic Viewer',
@@ -16,22 +17,22 @@ describe(
     })
 
     it('shows initial image', () => {
-      cy.get($LOADED).should('be.exist')
-      cy.get('.image').should('have.text', 'image1')
+      cy.get('[data-cy-loaded=success]').should('be.exist') // image is loaded successfully
+      cy.get('[data-cy-image').contains(IMAGES[0]) // check loaded image url
       cy.percySnapshot()
     })
 
     it('shows second image', () => {
-      cy.get($LOADED).should('be.exist')
       cy.get('.button2').click()
-      cy.get('.image').should('have.text', 'image2')
+      cy.get('[data-cy-loaded=success]').should('be.exist')
+      cy.get('[data-cy-image]').contains(IMAGES[5])
       cy.percySnapshot()
     })
 
     it('shows third image', () => {
-      cy.get($LOADED).should('be.exist')
       cy.get('.button3').click()
-      cy.get('.image').should('have.text', 'image3')
+      cy.get('[data-cy-loaded=success]').should('be.exist')
+      cy.get('[data-cy-image]').contains(IMAGES[10])
       cy.percySnapshot()
     })
   }

--- a/apps/insight-viewer-docs/cypress/integration/basic.spec.ts
+++ b/apps/insight-viewer-docs/cypress/integration/basic.spec.ts
@@ -6,7 +6,7 @@ describe(
   'Basic Viewer',
   {
     viewportWidth: VIEWPORT_WIDTH,
-    viewportHeight: VIEWPORT_HEIGHT,
+    viewportHeight: VIEWPORT_HEIGHT + 500, // page is vertical long
     scrollBehavior: false,
   },
   () => {

--- a/apps/insight-viewer-docs/cypress/integration/error.spec.ts
+++ b/apps/insight-viewer-docs/cypress/integration/error.spec.ts
@@ -1,10 +1,6 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
-import {
-  VIEWPORT_WIDTH,
-  VIEWPORT_HEIGHT,
-  LOADING_STATE,
-} from '../support/const'
+import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT } from '../support/const'
 
 describe(
   'Custom error',
@@ -20,9 +16,10 @@ describe(
     })
 
     it('shows custom error', () => {
-      cy.get(LOADING_STATE).should('not.exist')
       cy.get('.custom-error').click()
-      cy.percySnapshot()
+      cy.on('window:alert', msg => {
+        expect(msg).to.contains('error 404')
+      })
     })
   }
 )

--- a/apps/insight-viewer-docs/cypress/integration/interaction.custom.spec.ts
+++ b/apps/insight-viewer-docs/cypress/integration/interaction.custom.spec.ts
@@ -32,17 +32,14 @@ describe(
             x: 200,
             y: -50,
           }
-          const origX = Cypress.$('.x').text()
-          const origY = Cypress.$('.y').text()
-
           cy.get('.primary-drag-pan').click()
           cy.get('.cornerstone-canvas-wrapper').dragCanvas({
             x: value.x,
             y: value.y,
             button: 0,
           })
-          cy.get('.x').should('not.have.text', origX)
-          cy.get('.y').should('not.have.text', origY)
+          cy.get('[data-cy-x]').contains(value.x)
+          cy.get('[data-cy-y]').contains(value.y)
           cy.percySnapshot()
         })
 
@@ -51,17 +48,14 @@ describe(
             x: 10,
             y: 250,
           }
-          const origWW = Cypress.$('.windowWidth').text()
-          const origWC = Cypress.$('.windowCenter').text()
-
           cy.get('.primary-drag-adjust').click()
           cy.get('.cornerstone-canvas-wrapper').dragCanvas({
             x: value.x,
             y: value.y,
             button: 0,
           })
-          cy.get('.windowWidth').should('not.have.text', origWW)
-          cy.get('.windowCenter').should('not.have.text', origWC)
+          cy.get('[data-cy-window-width]').contains(100.0)
+          cy.get('[data-cy-window-center]').contains(282.0)
           cy.percySnapshot()
         })
 
@@ -70,10 +64,10 @@ describe(
             x: 250,
             y: 350,
           }
-          const origX = Cypress.$('.x').text()
-          const origY = Cypress.$('.y').text()
-          const origWW = Cypress.$('.windowWidth').text()
-          const origWC = Cypress.$('.windowCenter').text()
+          const origX = Cypress.$('[data-cy-x]').text()
+          const origY = Cypress.$('[data-cy-y]').text()
+          const origWW = Cypress.$('[data-cy-window-width]').text()
+          const origWC = Cypress.$('[data-cy-window-center]').text()
 
           cy.get('.primary-drag-none').click()
           cy.get('.cornerstone-canvas-wrapper').dragCanvas({
@@ -81,10 +75,10 @@ describe(
             y: value.y,
             button: 0,
           })
-          cy.get('.x').should('have.text', origX)
-          cy.get('.y').should('have.text', origY)
-          cy.get('.windowWidth').should('have.text', origWW)
-          cy.get('.windowCenter').should('have.text', origWC)
+          cy.get('[data-cy-x]').contains(origX)
+          cy.get('[data-cy-y]').contains(origY)
+          cy.get('[data-cy-window-width]').contains(origWW)
+          cy.get('[data-cy-window-center]').contains(origWC)
           cy.percySnapshot()
         })
       })
@@ -95,17 +89,14 @@ describe(
             x: 50,
             y: 180,
           }
-          const origX = Cypress.$('.x').text()
-          const origY = Cypress.$('.y').text()
-
           cy.get('.secondary-drag-pan').click()
           cy.get('.cornerstone-canvas-wrapper').dragCanvas({
             x: value.x,
             y: value.y,
             button: 2,
           })
-          cy.get('.x').should('not.have.text', origX)
-          cy.get('.y').should('not.have.text', origY)
+          cy.get('[data-cy-x]').contains(value.x)
+          cy.get('[data-cy-y]').contains(value.y)
           cy.percySnapshot()
         })
 
@@ -114,17 +105,14 @@ describe(
             x: 250,
             y: 400,
           }
-          const origWW = Cypress.$('.windowWidth').text()
-          const origWC = Cypress.$('.windowCenter').text()
-
           cy.get('.secondary-drag-adjust').click()
           cy.get('.cornerstone-canvas-wrapper').dragCanvas({
             x: value.x,
             y: value.y,
             button: 2,
           })
-          cy.get('.windowWidth').should('not.have.text', origWW)
-          cy.get('.windowCenter').should('not.have.text', origWC)
+          cy.get('[data-cy-window-width]').contains(340.0)
+          cy.get('[data-cy-window-center]').contains(432.0)
           cy.percySnapshot()
         })
 
@@ -133,10 +121,10 @@ describe(
             x: -50,
             y: -30,
           }
-          const origX = Cypress.$('.x').text()
-          const origY = Cypress.$('.y').text()
-          const origWW = Cypress.$('.windowWidth').text()
-          const origWC = Cypress.$('.windowCenter').text()
+          const origX = Cypress.$('[data-cy-x]').text()
+          const origY = Cypress.$('[data-cy-y]').text()
+          const origWW = Cypress.$('[data-cy-window-width]').text()
+          const origWC = Cypress.$('[data-cy-window-center]').text()
 
           cy.get('.secondary-drag-none').click()
           cy.get('.cornerstone-canvas-wrapper').dragCanvas({
@@ -144,10 +132,10 @@ describe(
             y: value.y,
             button: 0,
           })
-          cy.get('.x').should('have.text', origX)
-          cy.get('.y').should('have.text', origY)
-          cy.get('.windowWidth').should('have.text', origWW)
-          cy.get('.windowCenter').should('have.text', origWC)
+          cy.get('[data-cy-x]').contains(origX)
+          cy.get('[data-cy-y]').contains(origY)
+          cy.get('[data-cy-window-width]').contains(origWW)
+          cy.get('[data-cy-window-center]').contains(origWC)
           cy.percySnapshot()
         })
       })
@@ -164,8 +152,8 @@ describe(
             y: CLIENT_Y,
             button: 0,
           })
-          cy.get('.click-x').should('be.visible')
-          cy.get('.click-y').should('be.visible')
+          cy.get('[data-cy-click-x]').contains(-150.0)
+          cy.get('[data-cy-click-y]').contains(261.0)
           cy.percySnapshot()
         })
 
@@ -183,8 +171,8 @@ describe(
             y: CLIENT_Y,
             button: 0,
           })
-          cy.get('.click-x').should('be.visible')
-          cy.get('.click-y').should('be.visible')
+          cy.get('[data-cy-click-x]').contains(-290.0)
+          cy.get('[data-cy-click-y]').contains(231.0)
           cy.percySnapshot()
         })
       })
@@ -201,8 +189,8 @@ describe(
             y: CLIENT_Y,
             button: 0,
           })
-          cy.get('.click-x').should('be.visible')
-          cy.get('.click-y').should('be.visible')
+          cy.get('[data-cy-click-x]').contains(299.0)
+          cy.get('[data-cy-click-y]').contains(489.0)
           cy.percySnapshot()
         })
 
@@ -220,8 +208,8 @@ describe(
             y: CLIENT_Y,
             button: 0,
           })
-          cy.get('.click-x').should('be.visible')
-          cy.get('.click-y').should('be.visible')
+          cy.get('[data-cy-click-x]').contains(439.0)
+          cy.get('[data-cy-click-y]').contains(549.0)
           cy.percySnapshot()
         })
       })

--- a/apps/insight-viewer-docs/cypress/integration/interaction.spec.ts
+++ b/apps/insight-viewer-docs/cypress/integration/interaction.spec.ts
@@ -31,17 +31,14 @@ describe(
             x: 200,
             y: -50,
           }
-          const origX = Cypress.$('.x').text()
-          const origY = Cypress.$('.y').text()
-
           cy.get('.primary-drag-pan').click()
           cy.get('.cornerstone-canvas-wrapper').dragCanvas({
             x: value.x,
             y: value.y,
             button: 0,
           })
-          cy.get('.x').should('not.have.text', origX)
-          cy.get('.y').should('not.have.text', origY)
+          cy.get('[data-cy-x]').contains(value.x)
+          cy.get('[data-cy-y]').contains(value.y)
           cy.percySnapshot()
         })
 
@@ -50,18 +47,14 @@ describe(
             x: 10,
             y: 250,
           }
-          const origWW = Cypress.$('.windowWidth').text()
-          const origWC = Cypress.$('.windowCenter').text()
-
           cy.get('.primary-drag-adjust').click()
           cy.get('.cornerstone-canvas-wrapper').dragCanvas({
             x: value.x,
             y: value.y,
             button: 0,
           })
-
-          cy.get('.windowWidth').should('not.have.text', origWW)
-          cy.get('.windowCenter').should('not.have.text', origWC)
+          cy.get('[data-cy-window-width]').contains(100.0)
+          cy.get('[data-cy-window-center]').contains(282.0)
           cy.percySnapshot()
         })
 
@@ -70,10 +63,10 @@ describe(
             x: 250,
             y: 350,
           }
-          const origX = Cypress.$('.x').text()
-          const origY = Cypress.$('.y').text()
-          const origWW = Cypress.$('.windowWidth').text()
-          const origWC = Cypress.$('.windowCenter').text()
+          const origX = Cypress.$('[data-cy-x]').text()
+          const origY = Cypress.$('[data-cy-y]').text()
+          const origWW = Cypress.$('[data-cy-window-width]').text()
+          const origWC = Cypress.$('[data-cy-window-center]').text()
 
           cy.get('.primary-drag-none').click()
           cy.get('.cornerstone-canvas-wrapper').dragCanvas({
@@ -81,10 +74,10 @@ describe(
             y: value.y,
             button: 0,
           })
-          cy.get('.x').should('have.text', origX)
-          cy.get('.y').should('have.text', origY)
-          cy.get('.windowWidth').should('have.text', origWW)
-          cy.get('.windowCenter').should('have.text', origWC)
+          cy.get('[data-cy-x]').contains(origX)
+          cy.get('[data-cy-y]').contains(origY)
+          cy.get('[data-cy-window-width]').contains(origWW)
+          cy.get('[data-cy-window-center]').contains(origWC)
           cy.percySnapshot()
         })
 
@@ -94,17 +87,14 @@ describe(
               x: 50,
               y: 180,
             }
-            const origX = Cypress.$('.x').text()
-            const origY = Cypress.$('.y').text()
-
             cy.get('.secondary-drag-pan').click()
             cy.get('.cornerstone-canvas-wrapper').dragCanvas({
               x: value.x,
               y: value.y,
               button: 2,
             })
-            cy.get('.x').should('not.have.text', origX)
-            cy.get('.y').should('not.have.text', origY)
+            cy.get('[data-cy-x]').contains(value.x)
+            cy.get('[data-cy-y]').contains(value.y)
             cy.percySnapshot()
           })
 
@@ -113,18 +103,14 @@ describe(
               x: 250,
               y: 400,
             }
-            const origWW = Cypress.$('.windowWidth').text()
-            const origWC = Cypress.$('.windowCenter').text()
-
             cy.get('.secondary-drag-adjust').click()
             cy.get('.cornerstone-canvas-wrapper').dragCanvas({
               x: value.x,
               y: value.y,
               button: 2,
             })
-
-            cy.get('.windowWidth').should('not.have.text', origWW)
-            cy.get('.windowCenter').should('not.have.text', origWC)
+            cy.get('[data-cy-window-width]').contains(340.0)
+            cy.get('[data-cy-window-center]').contains(432.0)
             cy.percySnapshot()
           })
 
@@ -133,10 +119,10 @@ describe(
               x: -50,
               y: -30,
             }
-            const origX = Cypress.$('.x').text()
-            const origY = Cypress.$('.y').text()
-            const origWW = Cypress.$('.windowWidth').text()
-            const origWC = Cypress.$('.windowCenter').text()
+            const origX = Cypress.$('[data-cy-x]').text()
+            const origY = Cypress.$('[data-cy-y]').text()
+            const origWW = Cypress.$('[data-cy-window-width]').text()
+            const origWC = Cypress.$('[data-cy-window-center]').text()
 
             cy.get('.secondary-drag-none').click()
             cy.get('.cornerstone-canvas-wrapper').dragCanvas({
@@ -144,10 +130,10 @@ describe(
               y: value.y,
               button: 0,
             })
-            cy.get('.x').should('have.text', origX)
-            cy.get('.y').should('have.text', origY)
-            cy.get('.windowWidth').should('have.text', origWW)
-            cy.get('.windowCenter').should('have.text', origWC)
+            cy.get('[data-cy-x]').contains(origX)
+            cy.get('[data-cy-y]').contains(origY)
+            cy.get('[data-cy-window-width]').contains(origWW)
+            cy.get('[data-cy-window-center]').contains(origWC)
             cy.percySnapshot()
           })
         })
@@ -186,25 +172,23 @@ describe(
           describe('scale', () => {
             it('scale up', () => {
               const frameNumber = 5
-              const origScale = Cypress.$('.scale').text()
 
               cy.get('.mousewheel-scale').click()
               cy.get('.cornerstone-canvas-wrapper')
                 .trigger('mouseover')
                 .mousewheel(1, frameNumber)
-              cy.get('.scale').should('not.have.text', origScale)
+              cy.get('[data-cy-scale]').contains(2.25)
               cy.percySnapshot()
             })
 
             it('scale down', () => {
               const frameNumber = 2
-              const origScale = Cypress.$('.scale').text()
 
               cy.get('.mousewheel-scale').click()
               cy.get('.cornerstone-canvas-wrapper')
                 .trigger('mouseover')
                 .mousewheel(-1, frameNumber)
-              cy.get('.scale').should('not.have.text', origScale)
+              cy.get('[data-cy-scale]').contains(0.5)
               cy.percySnapshot()
             })
           })

--- a/apps/insight-viewer-docs/cypress/integration/multiframe.spec.ts
+++ b/apps/insight-viewer-docs/cypress/integration/multiframe.spec.ts
@@ -1,6 +1,7 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
 import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT } from '../support/const'
+import { IMAGES } from '../../src/const'
 
 describe(
   'Multiframe',
@@ -18,18 +19,21 @@ describe(
     it('shows initial viewer', () => {
       cy.get('[data-cy-all-loaded=success]').should('be.exist')
       cy.get('.frame-number').should('have.text', '0')
+      cy.get('[data-cy-image]').contains(IMAGES[0])
       cy.percySnapshot()
     })
 
     it('change frame to 5', () => {
       cy.get('.frame-control').controlledInputChange(5)
       cy.get('.frame-number').should('have.text', '5')
+      cy.get('[data-cy-image]').contains(IMAGES[5])
       cy.percySnapshot()
     })
 
     it('change frame to 10', () => {
       cy.get('.frame-control').controlledInputChange(10)
       cy.get('.frame-number').should('have.text', '10')
+      cy.get('[data-cy-image]').contains(IMAGES[10])
       cy.percySnapshot()
     })
   }

--- a/apps/insight-viewer-docs/cypress/integration/overlay.spec.ts
+++ b/apps/insight-viewer-docs/cypress/integration/overlay.spec.ts
@@ -17,6 +17,14 @@ describe(
 
     it('shows overlay', () => {
       cy.get($LOADED).should('be.exist')
+      cy.get('[data-cy-scale]').contains(0.9765625)
+      cy.get('[data-cy-hflip]').contains('false')
+      cy.get('[data-cy-vflip]').contains('false')
+      cy.get('[data-cy-x]').contains(0.0)
+      cy.get('[data-cy-y]').contains(0.0)
+      cy.get('[data-cy-invert]').contains('false')
+      cy.get('[data-cy-window-width]').contains(90.0)
+      cy.get('[data-cy-window-center]').contains(32.0)
       cy.percySnapshot()
     })
   }

--- a/apps/insight-viewer-docs/cypress/integration/viewport.spec.ts
+++ b/apps/insight-viewer-docs/cypress/integration/viewport.spec.ts
@@ -19,21 +19,20 @@ describe(
     it('shows initial viewport', () => {
       cy.get($LOADED).should('be.exist')
       cy.get('[data-cy-viewport=true]').should('be.exist')
-      cy.get('.viewer1 .scale').should('have.text', INITIAL_VIEWPORT1.scale)
-      cy.get('.viewer1 .x').should('have.text', (0).toFixed(2))
-      cy.get('.viewer1 .y').should('have.text', (0).toFixed(2))
-      cy.get('.viewer1 .windowWidth').should(
-        'have.text',
-        INITIAL_VIEWPORT1.windowWidth.toFixed(2)
-      )
-      cy.get('.viewer1 .windowCenter').should(
-        'have.text',
-        INITIAL_VIEWPORT1.windowCenter.toFixed(2)
-      )
-      cy.get('.viewer1 .invert').should('have.text', 'false')
-      cy.get('.viewer1 .hflip').should('have.text', 'false')
-      cy.get('.viewer1 .vflip').should('have.text', 'false')
-
+      cy.get('.viewer1')
+        .find('[data-cy-scale]')
+        .contains(INITIAL_VIEWPORT1.scale)
+      cy.get('.viewer1').find('[data-cy-x]').contains((0).toFixed(2))
+      cy.get('.viewer1').find('[data-cy-y]').contains((0).toFixed(2))
+      cy.get('.viewer1')
+        .find('[data-cy-window-width]')
+        .contains(INITIAL_VIEWPORT1.windowWidth.toFixed(2))
+      cy.get('.viewer1')
+        .find('[data-cy-window-center]')
+        .contains(INITIAL_VIEWPORT1.windowCenter.toFixed(2))
+      cy.get('.viewer1').find('[data-cy-invert]').contains('false')
+      cy.get('.viewer1').find('[data-cy-hflip]').contains('false')
+      cy.get('.viewer1').find('[data-cy-vflip]').contains('false')
       cy.percySnapshot()
     })
 
@@ -44,54 +43,58 @@ describe(
 
       it('shows inverted viewport', () => {
         cy.get('.invert-control').click()
-        cy.get('.viewer1 .invert').should('have.text', 'true')
+        cy.get('.viewer1').find('[data-cy-invert]').contains('true')
         cy.percySnapshot()
       })
 
       it('shows hflipped viewport', () => {
         cy.get('.hflip-control').click()
-        cy.get('.viewer1 .hflip').should('have.text', 'true')
+        cy.get('.viewer1').find('[data-cy-hflip]').contains('true')
         cy.percySnapshot()
       })
 
       it('shows vflipped viewport', () => {
         cy.get('.vflip-control').click()
-        cy.get('.viewer1 .vflip').should('have.text', 'true')
+        cy.get('.viewer1').find('[data-cy-vflip]').contains('true')
         cy.percySnapshot()
       })
 
       it('shows x-transitioned viewport', () => {
         const value = 20
         cy.get('.x-control').controlledInputChange(value)
-        cy.get('.viewer1 .x').should('have.text', value.toFixed(2))
+        cy.get('.viewer1').find('[data-cy-x]').contains(value.toFixed(2))
         cy.percySnapshot()
       })
 
       it('shows y-transitioned viewport', () => {
         const value = 50
         cy.get('.y-control').controlledInputChange(value)
-        cy.get('.viewer1 .y').should('have.text', value.toFixed(2))
+        cy.get('.viewer1').find('[data-cy-y]').contains(value.toFixed(2))
         cy.percySnapshot()
       })
 
       it('shows zoomed viewport', () => {
         const value = 2
         cy.get('.scale-control').controlledInputChange(value)
-        cy.get('.viewer1 .scale').should('have.text', value)
+        cy.get('.viewer1').find('[data-cy-scale]').contains(value)
         cy.percySnapshot()
       })
 
       it('shows window-width viewport', () => {
         const value = 240
         cy.get('.window-width-control').controlledInputChange(value)
-        cy.get('.viewer1 .windowWidth').should('have.text', value.toFixed(2))
+        cy.get('.viewer1')
+          .find('[data-cy-window-width]')
+          .contains(value.toFixed(2))
         cy.percySnapshot()
       })
 
       it('shows window-center viewport', () => {
         const value = 150
         cy.get('.window-center-control').controlledInputChange(value)
-        cy.get('.viewer1 .windowCenter').should('have.text', value.toFixed(2))
+        cy.get('.viewer1')
+          .find('[data-cy-window-center]')
+          .contains(value.toFixed(2))
         cy.percySnapshot()
       })
 
@@ -114,19 +117,16 @@ describe(
           value.windowCenter
         )
 
-        cy.get('.viewer1 .invert').should('have.text', value.invert)
-        cy.get('.viewer1 .vflip').should('have.text', value.vflip)
-        cy.get('.viewer1 .x').should('have.text', value.x.toFixed(2))
-        cy.get('.viewer1 .scale').should('have.text', value.scale)
-        cy.get('.viewer1 .windowWidth').should(
-          'have.text',
-          value.windowWidth.toFixed(2)
-        )
-        cy.get('.viewer1 .windowCenter').should(
-          'have.text',
-          value.windowCenter.toFixed(2)
-        )
-
+        cy.get('.viewer1').find('[data-cy-invert]').contains(value.invert)
+        cy.get('.viewer1').find('[data-cy-vflip]').contains(value.vflip)
+        cy.get('.viewer1').find('[data-cy-x]').contains(value.x.toFixed(2))
+        cy.get('.viewer1').find('[data-cy-scale]').contains(value.scale)
+        cy.get('.viewer1')
+          .find('[data-cy-window-width]')
+          .contains(value.windowWidth.toFixed(2))
+        cy.get('.viewer1')
+          .find('[data-cy-window-center]')
+          .contains(value.windowCenter.toFixed(2))
         cy.percySnapshot()
       })
 
@@ -148,10 +148,10 @@ describe(
         cy.get('.x-control2').controlledInputChange(value.x2)
         cy.get('.y-control2').controlledInputChange(value.y2)
 
-        cy.get('.viewer1 .x').should('have.text', value.x.toFixed(2))
-        cy.get('.viewer1 .y').should('have.text', value.y.toFixed(2))
-        cy.get('.viewer2 .x').should('have.text', value.x2.toFixed(2))
-        cy.get('.viewer2 .y').should('have.text', value.y2.toFixed(2))
+        cy.get('.viewer1').find('[data-cy-x]').contains(value.x.toFixed(2))
+        cy.get('.viewer1').find('[data-cy-y]').contains(value.y.toFixed(2))
+        cy.get('.viewer2').find('[data-cy-x]').contains(value.x2.toFixed(2))
+        cy.get('.viewer2').find('[data-cy-y]').contains(value.y2.toFixed(2))
         cy.percySnapshot()
       })
     })

--- a/apps/insight-viewer-docs/cypress/support/commands.ts
+++ b/apps/insight-viewer-docs/cypress/support/commands.ts
@@ -103,10 +103,10 @@ Cypress.Commands.add(
     const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
       window.HTMLInputElement.prototype,
       'value'
-    ).set
+    )?.set
 
-    const changeInputValue = ($range: unknown) => (newValue: number) => {
-      nativeInputValueSetter.call($range[0], newValue)
+    const changeInputValue = ($range: JQuery) => (newValue: number) => {
+      nativeInputValueSetter?.call($range[0], newValue)
       $range[0].dispatchEvent(new Event('change', { bubbles: true }))
     }
 

--- a/apps/insight-viewer-docs/cypress/tsconfig.json
+++ b/apps/insight-viewer-docs/cypress/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "es5",
     "lib": ["es2015", "dom"],
     "types": ["node", "cypress"],
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "isolatedModules": false
   },
   "include": ["**/*.ts"]
 }

--- a/apps/insight-viewer-docs/cypress/tsconfig.json
+++ b/apps/insight-viewer-docs/cypress/tsconfig.json
@@ -5,5 +5,6 @@
     "lib": ["es2015", "dom"],
     "types": ["node", "cypress"],
     "downlevelIteration": true
-  }
+  },
+  "include": ["**/*.ts"]
 }

--- a/apps/insight-viewer-docs/src/components/CodeBlock/index.tsx
+++ b/apps/insight-viewer-docs/src/components/CodeBlock/index.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react'
+import { Box } from '@chakra-ui/react'
 import Prism from 'prismjs'
 import 'prismjs/themes/prism-tomorrow.css'
 import { WithChildren } from '../../types'
+import config from '../../../config'
 
 export default function CodeBlock({
   code,
@@ -13,10 +15,10 @@ export default function CodeBlock({
   }, [])
 
   return (
-    <div className="Code">
+    <Box className="Code" display={config.IS_CYPRESS ? 'none' : 'block'}>
       <pre>
         <code className="language-javascript">{code}</code>
       </pre>
-    </div>
+    </Box>
   )
 }

--- a/apps/insight-viewer-docs/src/components/Layout/index.tsx
+++ b/apps/insight-viewer-docs/src/components/Layout/index.tsx
@@ -5,6 +5,7 @@ import Nav from '../Nav'
 import { NextChakraLink } from '../NextChakraLink'
 import { WithChildren } from '../../types'
 import { LINKS } from '../Nav/const'
+import config from '../../../config'
 
 const SIDE_WIDTH = '240px'
 
@@ -26,7 +27,11 @@ export default function Layout({ children }: WithChildren): JSX.Element {
         <Box pt={6}>
           <header>
             <Flex direction="row">
-              <Flex width={SIDE_WIDTH} pt={2}>
+              <Flex
+                width={SIDE_WIDTH}
+                pt={2}
+                display={config.IS_CYPRESS ? 'none' : 'flex'}
+              >
                 <NextChakraLink href="/" pt="2px">
                   <Logo h="1.5rem" pointerEvents="none" />
                 </NextChakraLink>
@@ -46,7 +51,10 @@ export default function Layout({ children }: WithChildren): JSX.Element {
 
         <Box pt={6}>
           <Flex>
-            <Box width={SIDE_WIDTH}>
+            <Box
+              width={SIDE_WIDTH}
+              display={config.IS_CYPRESS ? 'none' : 'block'}
+            >
               <Nav />
             </Box>
             <Box w="100%">{children}</Box>

--- a/apps/insight-viewer-docs/src/components/OverlayLayer/index.tsx
+++ b/apps/insight-viewer-docs/src/components/OverlayLayer/index.tsx
@@ -19,23 +19,22 @@ export default function OverlayLayer({
     >
       <UnorderedList>
         <ListItem>
-          scale: <span className="scale">{scale}</span>
+          scale: <span data-cy-scale>{scale}</span>
         </ListItem>
         <ListItem>
-          hflip/vflip: <span className="hflip">{`${hflip}`}</span> /{' '}
-          <span className="vflip">{`${vflip}`}</span>
+          hflip/vflip: <span data-cy-hflip>{`${hflip}`}</span> /{' '}
+          <span data-cy-vflip>{`${vflip}`}</span>
         </ListItem>
         <ListItem>
-          translation: <span className="x">{x?.toFixed(2)}</span> /{' '}
-          <span className="y">{y?.toFixed(2)}</span>
+          translation: <span data-cy-x>{x?.toFixed(2)}</span> /{' '}
+          <span data-cy-y>{y?.toFixed(2)}</span>
         </ListItem>
         <ListItem>
-          invert: <span className="invert">{`${invert}`}</span>
+          invert: <span data-cy-invert>{`${invert}`}</span>
         </ListItem>
         <ListItem>
-          WW / WC:{' '}
-          <span className="windowWidth">{windowWidth?.toFixed(2)}</span> /{' '}
-          <span className="windowCenter">{windowCenter?.toFixed(2)}</span>
+          WW / WC: <span data-cy-window-width>{windowWidth?.toFixed(2)}</span> /{' '}
+          <span data-cy-window-center>{windowCenter?.toFixed(2)}</span>
         </ListItem>
       </UnorderedList>
     </Box>

--- a/apps/insight-viewer-docs/src/containers/Basic/ImageSelectableViewer.tsx
+++ b/apps/insight-viewer-docs/src/containers/Basic/ImageSelectableViewer.tsx
@@ -19,7 +19,7 @@ export default function ImageSelectableViewer(): JSX.Element {
       <Box mb={3}>
         <Text>
           <b data-cy-loaded={loadingState}>{loadingState}</b>
-          {image && <span> ({image.imageId})</span>}
+          {image && <span data-cy-image> ({image.imageId})</span>}
         </Text>
       </Box>
 

--- a/apps/insight-viewer-docs/src/containers/Basic/useImageSelect.tsx
+++ b/apps/insight-viewer-docs/src/containers/Basic/useImageSelect.tsx
@@ -48,7 +48,7 @@ export default function useImageSelect(): {
           image 3
         </Button>
         <Text pt={2}>
-          selected: <span className="image">{selected}</span>
+          selected: <span>{selected}</span>
         </Text>
       </Stack>
     )

--- a/apps/insight-viewer-docs/src/containers/Error/Custom.tsx
+++ b/apps/insight-viewer-docs/src/containers/Error/Custom.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback } from 'react'
-import { Box, Text } from '@chakra-ui/react'
+import { useCallback } from 'react'
+import { Box } from '@chakra-ui/react'
 import InsightViewer, { ViewerError, useImage } from '@lunit/insight-viewer'
 import CodeBlock from '../../components/CodeBlock'
 import { ViewerWrapper } from '../../components/Wrapper'
@@ -9,10 +9,9 @@ import { WRONG_IMAGE } from '../../const'
 const IMAGE_ID = WRONG_IMAGE
 
 export default function Custom(): JSX.Element {
-  const [error, setError] = useState('')
-
   const customError = useCallback((e: ViewerError) => {
-    setError(`!!! ${e.message} ${e.status}`)
+    // eslint-disable-next-line no-alert
+    alert(`error ${e.status}`)
   }, [])
 
   const { image } = useImage({
@@ -25,7 +24,7 @@ export default function Custom(): JSX.Element {
       <ViewerWrapper>
         <InsightViewer image={image} />
       </ViewerWrapper>
-      <Text>{error}</Text>
+
       <Box>
         <CodeBlock code={CUSTOM_CODE} />
       </Box>

--- a/apps/insight-viewer-docs/src/containers/Interaction/Custom.tsx
+++ b/apps/insight-viewer-docs/src/containers/Interaction/Custom.tsx
@@ -120,8 +120,8 @@ export default function App(): JSX.Element {
           <ClickControl onChange={handleClick} />
           <Box mb={6}>
             <Text>
-              offset: <span className="click-x">{x?.toFixed(2) ?? 0}</span> /{' '}
-              <span className="click-y">{y?.toFixed(2) ?? 0}</span>
+              offset: <span data-cy-click-x>{x?.toFixed(2) ?? 0}</span> /{' '}
+              <span data-cy-click-y>{y?.toFixed(2) ?? 0}</span>
             </Text>
           </Box>
         </Box>

--- a/apps/insight-viewer-docs/src/containers/MultiFrame/Base.tsx
+++ b/apps/insight-viewer-docs/src/containers/MultiFrame/Base.tsx
@@ -53,7 +53,9 @@ export default function Base(): JSX.Element {
       <Box mb={3}>
         <Text>
           <b>{loadingStates[frame]}</b>
-          {images[frame] && <span> ({images[frame].imageId})</span>}
+          {images[frame] && (
+            <span data-cy-image> ({images[frame].imageId})</span>
+          )}
         </Text>
       </Box>
       <ViewerWrapper>

--- a/apps/insight-viewer-docs/src/pages/_app.tsx
+++ b/apps/insight-viewer-docs/src/pages/_app.tsx
@@ -5,11 +5,12 @@ import Head from 'next/head'
 import dynamic from 'next/dynamic'
 import { Chakra } from '../components/Chakra'
 import '../styles/globals.css'
+import config from '../../config'
 
 const Layout = dynamic(() => import('../components/Layout'), { ssr: false })
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-if (typeof window !== 'undefined' && !(window as any).Cypress) {
+if (typeof window !== 'undefined' && !config.IS_CYPRESS) {
   const { worker } = require('../mocks/browser')
 
   worker.start({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3202,7 +3202,7 @@
     "@types/set-cookie-parser" "^2.4.0"
     set-cookie-parser "^2.4.6"
 
-"@mswjs/interceptors@^0.12.3":
+"@mswjs/interceptors@^0.12.6":
   version "0.12.6"
   resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.12.6.tgz#0afb7c91e14875a1127ae5181d0eae31d50a9276"
   integrity sha512-+1jaUpKEWXP4Yed4Lj9RftroZStw0NsEvEFjwJgc941xcaiTDYyBON4kpBY32RWd7UsW/xGE1piy8qt0Gfiqyw==


### PR DESCRIPTION
## 📝 Description

> Insight viewer docs test 코드/환경 변경사항

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [x] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

> Please describe the current behavior that you are modifying, or link to a relevant issue.
- E2E 비주얼 테스트에 불필요한 UI가 있다: 사이드바, 코드블록
<img width="1328" alt="스크린샷 2021-08-31 오후 5 22 35" src="https://user-images.githubusercontent.com/81394944/131468580-62dcde57-bff5-4808-bc0c-48ec9c9c62ba.png">

- cypress 디렉토리 파일들에 타입스크립트 오류 발생
  - 'Chainable<JQuery<HTMLElement>>' 형식에 'controlledInputChange' 속성이 없습니다.
  - '--isolatedModules'에서는 'commands.ts'을(를) 컴파일할 수 없는데 전역 스크립트 파일로 간주되기 때문입니다. 모듈로 만들려면 가져오기, 내보내기 또는 빈 'export {}' 문을 추가하세요.ts(1208)
- Cypress viewport 속성 테스트를 위한 선택자로 className 사용
- 스냅샷 테스트 전에 데이터 체크가 빠진 경우가 있다.

Issue Number: https://app.asana.com/0/1200128631446379/1200888206919844/f

## 🚀 New behavior

> Please describe the behavior or changes this PR adds.
- E2E 비주얼 테스트에 불필요한 UI를 숨긴다.
<img width="1323" alt="스크린샷 2021-08-31 오후 5 21 52" src="https://user-images.githubusercontent.com/81394944/131468676-e8bc42e5-7974-41d0-b8c3-dbfcad750afd.png">

- 커스텀 에러 스냅샷 테스트를 Cypress alert 확인 테스트로 대체
- cypress 디렉토리 파일들에 타입스크립트 오류나는 현상 해결 https://github.com/lunit-io/frontend-components/commit/1b1fbb86c7b2a0a01f35824c326bfd5224dfa660 https://github.com/lunit-io/frontend-components/commit/76465836bf21a7d8cfead1de4f6479a93046a246
- Cypress viewport 속성 테스트를 위한 선택자로 data attribute 사용
- 스냅샷 테스트 전에 Cypress로 뷰포트 데이터를 먼저 확인한다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
