### PR TITLE
Feature/force redraw on redraw update

### DIFF
--- a/packages/osd-react-renderer/src/elements/CanvasOverlay.ts
+++ b/packages/osd-react-renderer/src/elements/CanvasOverlay.ts
@@ -46,8 +46,11 @@ class CanvasOverlay extends Base {
   }
 
   commitUpdate(props: CanvasOverlayProps): void {
+    const oldRedraw = this.props.onRedraw
     this.props = { ...defaultOptions, ...props }
-    this._setOnRedraw()
+    if (oldRedraw !== props.onRedraw) {
+      this._setOnRedraw()
+    }
   }
 
   private _setOnRedraw(): void {
@@ -59,6 +62,7 @@ class CanvasOverlay extends Base {
     this.overlay.onRedraw = () => {
       onRedraw(canvas, viewer)
     }
+    this.overlay.forceRedraw()
   }
 }
 export default CanvasOverlay

--- a/packages/osd-react-renderer/src/elements/TooltipOverlay.ts
+++ b/packages/osd-react-renderer/src/elements/TooltipOverlay.ts
@@ -57,10 +57,13 @@ class TooltipOverlay extends Base {
   }
 
   commitUpdate(props: TooltipOverlayProps): void {
+    const oldRedraw = this.props.onRedraw
     this.props = { ...defaultProps, ...props }
     this._overlay.redrawOnViewportChange =
       this.props.redrawOnViewportChange || true
-    this._setOnRedraw()
+    if (oldRedraw !== props.onRedraw) {
+      this._setOnRedraw()
+    }
   }
 
   private _setOnRedraw(): void {
@@ -77,6 +80,7 @@ class TooltipOverlay extends Base {
         originalEvent: e,
       })
     }
+    this.overlay.forceRedraw()
   }
 }
 export default TooltipOverlay

--- a/packages/osd-react-renderer/src/plugins/OpenSeadragonTooltipOverlay.js
+++ b/packages/osd-react-renderer/src/plugins/OpenSeadragonTooltipOverlay.js
@@ -93,6 +93,12 @@ import OpenSeadragon from 'openseadragon'
       this._canvas.width = this._canvas.width
       // this._canvas.getContext('2d').clearRect(0, 0, this._containerWidth, this._containerHeight);
     },
+    forceRedraw: function () {
+      if (this._open) {
+        this.resize()
+        this._updateCanvas()
+      }
+    },
     destroy: function () {
       this._canvasdiv.removeChild(this._canvas)
       this._viewer.canvas.removeChild(this._canvasdiv)
@@ -128,12 +134,6 @@ import OpenSeadragon from 'openseadragon'
       this._viewportHeight = boundsRect.height * this.imgAspectRatio
     },
     tooltipLocation: new OpenSeadragon.Point(0, 0),
-    redrawCanvas: function () {
-      if (this._open) {
-        this.resize()
-        this._updateCanvas()
-      }
-    },
     reset: function () {
       this._open = false
     },


### PR DESCRIPTION
## 📝 Description

Force overlays to redraw when onRedraw function is updated

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

When onRedraw function is updated, overlays don't necessarily redraw right away.

Issue Number: N/A

## 🚀 New behavior

Force overlays to redraw when onRedraw function is updated

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
