### PR TITLE
Feature/expose file from use dicom file hook #139

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,6 +77,10 @@ module.exports = {
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': ['error'],
     '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    // Eslint says all enums in Typescript app are "already declared in the upper scope"
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md#how-to-use
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
   },
   overrides: [
     {

--- a/apps/insight-viewer-docs/src/containers/DicomfileViewer/Code.ts
+++ b/apps/insight-viewer-docs/src/containers/DicomfileViewer/Code.ts
@@ -8,7 +8,7 @@ const style = {
 }
 
 export default function App() {
-  const { imageId, setImageIdByFile } = useDicomFile()
+  const { imageId, file, setImageIdByFile } = useDicomFile()
   const { image } = useImage({
     dicomfile: imageId,
   })
@@ -19,7 +19,7 @@ export default function App() {
         type="file"
         accept="application/dicom"
         onChange={setImageIdByFile}
-      />
+      /> {file?.name}
       <div style={style}> // Wrapper size is required because InsightViewer's width/height is '100%'.
         <InsightViewer image={image} />
       </div>

--- a/apps/insight-viewer-docs/src/containers/DicomfileViewer/index.tsx
+++ b/apps/insight-viewer-docs/src/containers/DicomfileViewer/index.tsx
@@ -7,7 +7,7 @@ import { CODE_SANDBOX } from '../../const'
 import { CODE } from './Code'
 
 export default function DicomfileViewer(): JSX.Element {
-  const { imageId, setImageIdByFile } = useDicomFile()
+  const { imageId, file, setImageIdByFile } = useDicomFile()
   const { image } = useImage({
     dicomfile: imageId,
   })
@@ -15,7 +15,7 @@ export default function DicomfileViewer(): JSX.Element {
   return (
     <>
       <Box mb={6}>
-        <FileInput onChange={setImageIdByFile} />
+        <FileInput onChange={setImageIdByFile} /> {file?.name}
       </Box>
       <ViewerWrapper>
         <InsightViewer image={image} />

--- a/packages/insight-viewer/src/hooks/useDicomFile/index.ts
+++ b/packages/insight-viewer/src/hooks/useDicomFile/index.ts
@@ -1,12 +1,15 @@
 import { useState } from 'react'
 import { getDicomFileImageId } from '../../utils/cornerstoneHelper/getDicomFileImageId'
 
-export function useDicomFile(): {
+interface State {
   imageId: string
-  setImageIdByFile: (file: File) => void
   file: File | undefined
-} {
-  const [{ imageId, file }, setState] = useState({
+}
+
+export function useDicomFile(): {
+  setImageIdByFile: (file: File) => void
+} & State {
+  const [{ imageId, file }, setState] = useState<State>({
     imageId: '',
     file: undefined,
   })
@@ -15,7 +18,7 @@ export function useDicomFile(): {
     getDicomFileImageId(f).then(imgId => {
       setState({
         imageId: imgId,
-        file,
+        file: f,
       })
     })
   }

--- a/packages/insight-viewer/src/hooks/useDicomFile/index.ts
+++ b/packages/insight-viewer/src/hooks/useDicomFile/index.ts
@@ -4,17 +4,25 @@ import { getDicomFileImageId } from '../../utils/cornerstoneHelper/getDicomFileI
 export function useDicomFile(): {
   imageId: string
   setImageIdByFile: (file: File) => void
+  file: File | undefined
 } {
-  const [imageId, setImageId] = useState<string>('')
+  const [{ imageId, file }, setState] = useState({
+    imageId: '',
+    file: undefined,
+  })
 
-  function setImageIdByFile(file: File) {
-    getDicomFileImageId(file).then(imgId => {
-      setImageId(imgId ?? '')
+  function setImageIdByFile(f: File) {
+    getDicomFileImageId(f).then(imgId => {
+      setState({
+        imageId: imgId,
+        file,
+      })
     })
   }
 
   return {
     imageId,
     setImageIdByFile,
+    file,
   }
 }

--- a/packages/insight-viewer/src/types/index.ts
+++ b/packages/insight-viewer/src/types/index.ts
@@ -40,17 +40,17 @@ export type ImageLoaderScheme =
   typeof IMAGE_LOADER_SCHEME[keyof typeof IMAGE_LOADER_SCHEME]
 export type ImageId =
   | {
-      [IMAGE_LOADER_SCHEME.WADO]: string | string[]
+      [IMAGE_LOADER_SCHEME.WADO]: string | string[] | undefined
       [IMAGE_LOADER_SCHEME.DICOMFILE]?: never
       [IMAGE_LOADER_SCHEME.WEB]?: never
     }
   | {
       [IMAGE_LOADER_SCHEME.WADO]?: never
-      [IMAGE_LOADER_SCHEME.DICOMFILE]: string | string[]
+      [IMAGE_LOADER_SCHEME.DICOMFILE]: string | string[] | undefined
       [IMAGE_LOADER_SCHEME.WEB]?: never
     }
   | {
       [IMAGE_LOADER_SCHEME.WADO]?: never
       [IMAGE_LOADER_SCHEME.DICOMFILE]?: never
-      [IMAGE_LOADER_SCHEME.WEB]: string | string[]
+      [IMAGE_LOADER_SCHEME.WEB]: string | string[] | undefined
     }


### PR DESCRIPTION
## 📝 Description

- @lunit/insight-view의 useDicomFile()로부터 file expose 하기
  dicom 파일을 업로드하여 뷰어에서 사용하는 경우, 업로드한 File 또는 file.name이 필요한 경우가 있다.
- @lunit/insight-view의 useImage/useMultipleImages에서 이미지 아이디를 받을 때, 이미지 아이디가 undefined인 경우를 허용하도록 한다. 현재는 string만 허용.
  dicom 파일을 업로드하여 뷰어에서 사용하는 경우 useDicomFile() hook을 사용하는 데, 이 때 이미지 아이디가 undefined인 경우가 있을 수 있다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior
### useDicomFile
```tsx
const { imageId, setImageIdByFile } = useDicomFile()
```
### useImage/useMultipleImages의 ImageId 타입
```ts
export type ImageId =
  | {
      [IMAGE_LOADER_SCHEME.WADO]: string | string[]
      [IMAGE_LOADER_SCHEME.DICOMFILE]?: never
      [IMAGE_LOADER_SCHEME.WEB]?: never
    }
  | {
      [IMAGE_LOADER_SCHEME.WADO]?: never
      [IMAGE_LOADER_SCHEME.DICOMFILE]: string | string[]
      [IMAGE_LOADER_SCHEME.WEB]?: never
    }
  | {
      [IMAGE_LOADER_SCHEME.WADO]?: never
      [IMAGE_LOADER_SCHEME.DICOMFILE]?: never
      [IMAGE_LOADER_SCHEME.WEB]: string | string[]
    }
```

Issue Number: https://app.asana.com/0/1200128631446379/1201300199733500/f

## 🚀 New behavior

### useDicomFile
```tsx
const { imageId, file, setImageIdByFile } = useDicomFile()
```
### useImage/useMultipleImages의 ImageId 타입
```ts
export type ImageId =
  | {
      [IMAGE_LOADER_SCHEME.WADO]: string | string[] | undefined
      [IMAGE_LOADER_SCHEME.DICOMFILE]?: never
      [IMAGE_LOADER_SCHEME.WEB]?: never
    }
  | {
      [IMAGE_LOADER_SCHEME.WADO]?: never
      [IMAGE_LOADER_SCHEME.DICOMFILE]: string | string[] | undefined
      [IMAGE_LOADER_SCHEME.WEB]?: never
    }
  | {
      [IMAGE_LOADER_SCHEME.WADO]?: never
      [IMAGE_LOADER_SCHEME.DICOMFILE]?: never
      [IMAGE_LOADER_SCHEME.WEB]: string | string[] | undefined
    }
```