### PR TITLE
Feat/osd custom img url

### DIFF
--- a/apps/osd-viewer-demo/src/App.tsx
+++ b/apps/osd-viewer-demo/src/App.tsx
@@ -190,6 +190,7 @@ function App() {
       <Container>
         <Links>
           <NavLink to="/">HOME</NavLink>
+          <NavLink to="/test-custom">CUSTOM IMG URL</NavLink>
           <NavLink to="/no-overlay">NO OVERLAY</NavLink>
           <NavLink to="/test">TEST</NavLink>
         </Links>
@@ -222,6 +223,14 @@ function App() {
                 <canvasOverlay
                   ref={canvasOverlayRef}
                   onRedraw={handleUpdatedCanvasOverlayRedraw}
+                />
+              </OSDViewer>
+            </Route>
+            <Route exact path="/test-custom">
+              <OSDViewer options={VIEWER_OPTIONS} ref={osdViewerRef}>
+                <tiledImage
+                  url="https://pdl1.api.dev.scope.lunit.io/slides/dzi/metadata?file=mrxs_test/SIZE_TEST_2.mrxs"
+                  tileUrlBase="https://pdl1.api.dev.scope.lunit.io/slides/images/dzi/mrxs_test/SIZE_TEST_2.mrxs"
                 />
               </OSDViewer>
             </Route>

--- a/packages/osd-react-renderer/src/elements/TiledImage.ts
+++ b/packages/osd-react-renderer/src/elements/TiledImage.ts
@@ -2,6 +2,31 @@ import OpenSeadragon from 'openseadragon'
 import { TiledImageProps } from '../types'
 import Base from './Base'
 
+async function loadDZIMeta(url: string) {
+  const body = await fetch(url).then(response => response.text())
+  const parser = new DOMParser()
+  const dziMetaDoc = parser.parseFromString(body, 'application/xml')
+  const errorNode = dziMetaDoc.querySelector('parsererror')
+  if (errorNode) {
+    throw new Error('Tile metadata load failed')
+  } else {
+    const imageNode = dziMetaDoc.querySelector('Image')
+    const sizeNode = imageNode?.querySelector('Size')
+    const format = imageNode?.getAttribute('Format')
+    const tileSize = Number(imageNode?.getAttribute('TileSize'))
+    const tileOverlap = Number(imageNode?.getAttribute('Overlap'))
+    const width = Number(sizeNode?.getAttribute('Width'))
+    const height = Number(sizeNode?.getAttribute('Height'))
+    return {
+      tileSize,
+      tileOverlap,
+      width,
+      height,
+      format,
+    }
+  }
+}
+
 class TiledImage extends Base {
   props: TiledImageProps
 
@@ -24,9 +49,22 @@ class TiledImage extends Base {
     const viewer = this._parent?.viewer
     if (!viewer) return
     viewer.close()
-    if (!this.props.tileMap && !this.props.dziMeta) {
+    if (!this.props.tileMap && !this.props.dziMeta && !this.props.tileUrlBase) {
       // Real-time tiling
       viewer.open(this.props.url)
+    } else if (this.props.tileUrlBase) {
+      // Real-time tiling with custom tile url
+      loadDZIMeta(this.props.url).then(dziMeta => {
+        const { format, ...tileSource } = dziMeta
+        viewer.open({
+          ...tileSource,
+          getTileUrl: (level: number, x: number, y: number) =>
+            `${this.props.tileUrlBase}_files/${level}/${x}_${y}.${
+              format || 'jpeg'
+            }`,
+        })
+      })
+      // viewer.open({ url: this.props.url, getTileUrl: this.props.getTileUrl })
     } else if (this.props.tileMap && this.props.dziMeta) {
       // Static(Glob) tiling
       // https://github.com/openseadragon/openseadragon/issues/1032#issuecomment-248323573

--- a/packages/osd-react-renderer/src/types/index.ts
+++ b/packages/osd-react-renderer/src/types/index.ts
@@ -38,6 +38,7 @@ export interface OSDViewerRef {
 
 export interface TiledImageProps extends NodeProps {
   url: string
+  tileUrlBase?: string
   dziMeta?: DZIMetaData
   tileMap?: TileMap
 }


### PR DESCRIPTION
## 📝 Description

Added a capability for setting a custom base URL for tile images

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

There's no way to customize base URL for tile images

Issue Number: N/A

## 🚀 New behavior

Now you can set a base url by passing one via `tileUrlBase` prop on `tiledImage` host component. (per changes to the new slide image server's url scheme)

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

