### PR TITLE
Releases/osd react renderer

### DIFF
--- a/apps/osd-viewer-demo/CHANGELOG.md
+++ b/apps/osd-viewer-demo/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.7](https://github.com/lunit-io/frontend-components/compare/@lunit/osd-viewer-demo@1.0.0-alpha.6...@lunit/osd-viewer-demo@1.0.0-alpha.7) (2021-11-12)
+
+
+### Features
+
+* **osd-viewer-demo:** add a test case for custom tile url base ([9467c03](https://github.com/lunit-io/frontend-components/commit/9467c0328880f5f0b315759dfa384668e2cff6aa))
+
+
+
+
+
 # [1.0.0-alpha.6](https://github.com/lunit-io/frontend-components/compare/@lunit/osd-viewer-demo@1.0.0-alpha.5...@lunit/osd-viewer-demo@1.0.0-alpha.6) (2021-11-02)
 
 

--- a/apps/osd-viewer-demo/package.json
+++ b/apps/osd-viewer-demo/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@lunit/osd-viewer-demo",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.2.0",
-    "@lunit/osd-react-renderer": "^1.0.0-alpha.6",
+    "@lunit/osd-react-renderer": "^1.0.0-alpha.7",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/packages/osd-react-renderer/CHANGELOG.md
+++ b/packages/osd-react-renderer/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.7](https://github.com/lunit-io/frontend-components/compare/@lunit/osd-react-renderer@1.0.0-alpha.6...@lunit/osd-react-renderer@1.0.0-alpha.7) (2021-11-12)
+
+
+### Features
+
+* **osd-react-renderer:** add a way to customize base url for tile images ([f91fbbd](https://github.com/lunit-io/frontend-components/commit/f91fbbd7a10c6da507d698474c7b5db71291f2ea))
+
+
+
+
+
 # [1.0.0-alpha.6](https://github.com/lunit-io/frontend-components/compare/@lunit/osd-react-renderer@1.0.0-alpha.5...@lunit/osd-react-renderer@1.0.0-alpha.6) (2021-11-02)
 
 

--- a/packages/osd-react-renderer/package.json
+++ b/packages/osd-react-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunit/osd-react-renderer",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "description": "OpenSeadragon viewer component for React using react-reconciler package.",
   "homepage": "https://github.com/lunit-io/frontend-components/tree/master/packages/osd-react-renderer#readme",
   "license": "MIT",

--- a/packages/osd-react-renderer/package.json
+++ b/packages/osd-react-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunit/osd-react-renderer",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "OpenSeadragon viewer component for React using react-reconciler package.",
   "homepage": "https://github.com/lunit-io/frontend-components/tree/master/packages/osd-react-renderer#readme",
   "license": "MIT",


### PR DESCRIPTION
## 📝 Description

Released `@lunit/osd-react-renderer@1.0.0-alpha.8`
Note version went from alpha.6 to alpha.8 because of not building before publishing. Should consider adding a publish script that does the following in sequence:
* version bump: `yarn lerna version --ignore-changes 'packages/insight-viewer/**' 'apps/insight-viewer-docs/**'`
* build: `yarn workspace @lunit/osd-react-renderer run build`
* publish: `yarn lerna publish from-package`

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:
