### PR TITLE
fix(osd-react-renderer): fix a bug where changing the url of a tiledImage caused a crash

### DIFF
--- a/packages/osd-react-renderer/src/plugins/OpenSeadragonCanvasOverlay.js
+++ b/packages/osd-react-renderer/src/plugins/OpenSeadragonCanvasOverlay.js
@@ -53,6 +53,10 @@ import OpenSeadragon from 'openseadragon'
       self.resize()
       self._updateCanvas()
     })
+
+    this._viewer.addHandler('close', function () {
+      self._open = false
+    })
   }
 
   // ----------

--- a/packages/osd-react-renderer/src/plugins/OpenSeadragonTooltipOverlay.js
+++ b/packages/osd-react-renderer/src/plugins/OpenSeadragonTooltipOverlay.js
@@ -75,6 +75,14 @@ import OpenSeadragon from 'openseadragon'
         self._handleMousemove
       )
     })
+
+    this._viewer.addHandler('close', function () {
+      self._open = false
+      self._viewer.container.removeEventListener(
+        'mousemove',
+        self._handleMousemove
+      )
+    })
   }
 
   // ----------


### PR DESCRIPTION
## 📝 Description

- Add a `'close'` handler in `canvasOverlay` and `tooltipOverlay` to prevent from redrawing when the viewer is closed.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

<img src="https://user-images.githubusercontent.com/20144277/141708086-62022a4e-98df-4293-8ce9-b3881fa9f425.png" width="400" />

When the url of `tiledImage` changes, `Overlay.forceRedraw` method caused a runtime error as above. This issue is because it internally accesses to the current image, which is already destroyed. To be more specific, (1) changing the url triggers the viewer to be closed and opened again, (2) the image object is cleared by `Viewer.close()`, and (3) the overlay crashes because `var image1 = this._viewer.world.getItemAt(0)` would return undefined.

Issue Number: N/A

## 🚀 New behavior

`Overlay.forceRedraw` method does not crash when the url of `tiledImage` changes.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
