### PR TITLE
fix(osd-react-renderer): added support for custom tileSource

### DIFF
--- a/packages/osd-react-renderer/src/elements/TiledImage.ts
+++ b/packages/osd-react-renderer/src/elements/TiledImage.ts
@@ -49,10 +49,14 @@ class TiledImage extends Base {
     const viewer = this._parent?.viewer
     if (!viewer) return
     viewer.close()
-    if (!this.props.tileMap && !this.props.dziMeta && !this.props.tileUrlBase) {
+    if (!this.props.tileSource && !this.props.tileUrlBase && this.props.url) {
       // Real-time tiling
       viewer.open(this.props.url)
-    } else if (this.props.tileUrlBase) {
+    } else if (
+      !this.props.tileSource &&
+      this.props.tileUrlBase &&
+      this.props.url
+    ) {
       // Real-time tiling with custom tile url
       loadDZIMeta(this.props.url).then(dziMeta => {
         const { format, ...tileSource } = dziMeta
@@ -65,22 +69,13 @@ class TiledImage extends Base {
         })
       })
       // viewer.open({ url: this.props.url, getTileUrl: this.props.getTileUrl })
-    } else if (this.props.tileMap && this.props.dziMeta) {
+    } else if (this.props.tileSource) {
       // Static(Glob) tiling
       // https://github.com/openseadragon/openseadragon/issues/1032#issuecomment-248323573
       // https://github.com/openseadragon/openseadragon/blob/master/test/modules/ajax-tiles.js
-      const customTileSource = {
-        ...this.props.dziMeta,
-        getTileUrl: () => this.props.url,
-        getTileAjaxHeader: (level: number, x: number, y: number) => ({
-          Range: this.props.tileMap && this.props.tileMap[`${level} ${x} ${y}`],
-        }),
-      }
-      viewer.open(customTileSource)
+      viewer.open(this.props.tileSource)
     } else {
-      throw new Error(
-        'Both tileIndex and dziMeta should be defined or not defined at the same time'
-      )
+      throw new Error('Either tileSource or url should be defined')
     }
   }
 }

--- a/packages/osd-react-renderer/src/types/index.ts
+++ b/packages/osd-react-renderer/src/types/index.ts
@@ -37,10 +37,9 @@ export interface OSDViewerRef {
 }
 
 export interface TiledImageProps extends NodeProps {
-  url: string
+  url?: string
   tileUrlBase?: string
-  dziMeta?: DZIMetaData
-  tileMap?: TileMap
+  tileSource?: OpenSeadragon.TileSource
 }
 
 export interface ViewportEventHandlers


### PR DESCRIPTION
## 📝 Description

- Use `tileSource` for tiling instead of `dziMeta` and `tileMap`.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

It is currently difficult to initialize TiledImage with custom tileSource(s). For example, AIoP oncology uses the following custom tileSource to load tile images from the server:
```ts
async function loadCustomTile(slidePath: string) {
  const { tiles_bin_url, tile_indices_url, dzi_meta_url } = await fetch(
    `${API_URL}${IMG_PREFIX}/public/slides/url${slidePath}`
  ).then((res) => res.json());
  const tileIndices = await fetch(tile_indices_url).then((res) => res.json());
  const { format, ...tileSource } = await loadDZIMeta(dzi_meta_url);
  return {
    ...tileSource,
    getTileUrl: () => tiles_bin_url,
    tileExists: (level, x, y) => tileIndices[`${level} ${x}_${y}`] !== undefined,
    getTileAjaxHeaders: (level, x, y) => ({
      Range: `bytes=${tileIndices[`${level} ${x}_${y}`]}`,
    }),
  };
}
```
but the header format in `getTileAjaxHeaders` is slightly different, and `tileExists` overriding is unavailable.
 
Issue Number: N/A

## 🚀 New behavior

- Users are able to craft their own custom `tileSource` and use it for `TiledImage` initialization.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

## 📝 Note (in Korean)

`url` prop이 optional로 변경되면서 `TiledImage.ts` - line 52 ~ 59 의 if 조건문이 약간 복잡해졌습니다.
좀 더 깔끔하게 조건문을 정리할 수 있는지 고민해봤는데 마땅히 좋은 생각이 떠오르지 않아서, 조언 주시면 감사하겠습니다!
