### PR TITLE
Fix/osd crash on destroy

### DIFF
--- a/apps/osd-viewer-demo/src/App.tsx
+++ b/apps/osd-viewer-demo/src/App.tsx
@@ -193,6 +193,7 @@ function App() {
           <NavLink to="/test-custom">CUSTOM IMG URL</NavLink>
           <NavLink to="/no-overlay">NO OVERLAY</NavLink>
           <NavLink to="/test">TEST</NavLink>
+          <NavLink to="/destroy">TEST DESTROY</NavLink>
         </Links>
         <Switch>
           <OSDContainer>

--- a/packages/osd-react-renderer/src/plugins/OpenSeadragonCanvasOverlay.js
+++ b/packages/osd-react-renderer/src/plugins/OpenSeadragonCanvasOverlay.js
@@ -55,7 +55,9 @@ import OpenSeadragon from 'openseadragon'
     })
 
     this._viewer.addHandler('close', function () {
-      self._open = false
+      if (self) {
+        self._open = false
+      }
     })
   }
 

--- a/packages/osd-react-renderer/src/plugins/OpenSeadragonTooltipOverlay.js
+++ b/packages/osd-react-renderer/src/plugins/OpenSeadragonTooltipOverlay.js
@@ -77,11 +77,13 @@ import OpenSeadragon from 'openseadragon'
     })
 
     this._viewer.addHandler('close', function () {
-      self._open = false
-      self._viewer.container.removeEventListener(
-        'mousemove',
-        self._handleMousemove
-      )
+      if (self) {
+        self._open = false
+        self._viewer.container.removeEventListener(
+          'mousemove',
+          self._handleMousemove
+        )
+      }
     })
   }
 

--- a/packages/osd-react-renderer/src/plugins/OpenSeadragonTooltipOverlay.js
+++ b/packages/osd-react-renderer/src/plugins/OpenSeadragonTooltipOverlay.js
@@ -77,7 +77,7 @@ import OpenSeadragon from 'openseadragon'
     })
 
     this._viewer.addHandler('close', function () {
-      if (self) {
+      if (self && self._viewer) {
         self._open = false
         self._viewer.container.removeEventListener(
           'mousemove',


### PR DESCRIPTION
## 📝 Description

Fixing a crash that can happen when OSDViewer is unmounted (ReactOSDDOM.destroy is called)

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

There's a crash when OSDViewer is unmounted (ReactOSDDOM.destroy is called) while tooltip overlay is used

Issue Number: N/A

## 🚀 New behavior

No longer crashes

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

