### PR TITLE
fix(osd-react-renderer): fix min / max zoom level is not applied

### DIFF
--- a/packages/osd-react-renderer/src/elements/Viewport.ts
+++ b/packages/osd-react-renderer/src/elements/Viewport.ts
@@ -7,8 +7,8 @@ import {
 } from '../types'
 import { hasOwnProperty } from '../utils/object'
 
-const DEFAULT_MIN_ZOOM: number = 0.3125
-const DEFAULT_MAX_ZOOM: number = 160
+const DEFAULT_MIN_ZOOM = 0.3125
+const DEFAULT_MAX_ZOOM = 160
 
 declare module 'openseadragon' {
   interface Viewport {
@@ -65,7 +65,7 @@ class Viewport extends Base {
     if (!parent) {
       return
     }
-    const checkEventHandler = update == 'add' ? 'addHandler' : 'removeHandler'
+    const checkEventHandler = update === 'add' ? 'addHandler' : 'removeHandler'
     Object.keys(this.eventHandlers).forEach(key => {
       if (!hasOwnProperty(ViewerEventHandlers, key)) {
         return

--- a/packages/osd-react-renderer/src/elements/Viewport.ts
+++ b/packages/osd-react-renderer/src/elements/Viewport.ts
@@ -34,8 +34,8 @@ class Viewport extends Base {
     this.eventHandlers = Viewport.extractEventHandlers(props)
     this.viewer.viewport.zoomTo(props.zoom, props.refPoint)
     this.viewer.viewport.setRotation(props.rotation)
-    this.viewer.viewport.maxZoomLevel = DEFAULT_MAX_ZOOM
-    this.viewer.viewport.minZoomLevel = 0.1
+    this.viewer.viewport.maxZoomLevel = props.maxZoomLevel || DEFAULT_MAX_ZOOM
+    this.viewer.viewport.minZoomLevel = props.minZoomLevel || DEFAULT_MIN_ZOOM
   }
 
   commitUpdate(props: ViewportProps): void {


### PR DESCRIPTION
## 📝 Description

This PR fixes an issue where the min / max zoom level is not applied.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

The minimum and maximum zoom level of a viewport is fixed to 0.1 / 160, even if the customized level is given from the user.

Issue Number: N/A

## 🚀 New behavior

Given min / max zoom level is applied properly.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

## 🗒️ Note (in Korean)

1. eslint 규칙으로 에러가 발생해서 이 부분을 수정했는데, 이게 제 로컬 환경에서 lint 설정이 잘못되어 있어서 발생한건지 잘 모르겠네요. 
2. 바쁘신 와중에 코드 리뷰를 위해 시간 내어주셔서 감사합니다, 수정 필요한 부분이 있으면 코멘트 부탁드립니다! 🙇‍♂️ 