### PR TITLE
chore(root): trigger production github action on push to master

### DIFF
--- a/.github/workflows/insight-viewer-production.yml
+++ b/.github/workflows/insight-viewer-production.yml
@@ -1,7 +1,7 @@
 name: Deploy insight-viewer on production
 
 on:
-  pull_request:
+  push:
     branches:
       - master
     paths:


### PR DESCRIPTION
## 📝 Description

insight-viewer production github action을 기존 PR할 때 실행하는 대신 master 브랜치에 merge 할 때 실행하도록 바꾼다.
feature 브랜치를 push 할 때 feature action이 실행되는데, master에 PR을 하면서
feature 액션과 production 액션이 동시에 실행되기 때문.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

