### PR TITLE
fix(osd-react-renderer): fix crash error when switching tiledImage

### DIFF
--- a/packages/osd-react-renderer/src/plugins/OpenSeadragonCanvasOverlay.js
+++ b/packages/osd-react-renderer/src/plugins/OpenSeadragonCanvasOverlay.js
@@ -96,6 +96,7 @@ import OpenSeadragon from 'openseadragon'
     },
     // ----------
     resize: function () {
+      if (!this?._viewer?.world?.getItemAt(0)) return
       if (this._containerWidth !== this._viewer.container.clientWidth) {
         this._containerWidth = this._viewer.container.clientWidth
         this._canvasdiv.setAttribute('width', this._containerWidth)
@@ -120,6 +121,7 @@ import OpenSeadragon from 'openseadragon'
       this._viewportHeight = boundsRect.height * this.imgAspectRatio
     },
     _updateCanvas: function () {
+      if (!this?._viewer?.world?.getItemAt(0)) return
       var viewportZoom = this._viewer.viewport.getZoom(true)
       var image1 = this._viewer.world.getItemAt(0)
       var zoom = image1.viewportToImageZoom(viewportZoom)

--- a/packages/osd-react-renderer/src/plugins/OpenSeadragonTooltipOverlay.js
+++ b/packages/osd-react-renderer/src/plugins/OpenSeadragonTooltipOverlay.js
@@ -120,6 +120,7 @@ import OpenSeadragon from 'openseadragon'
     },
     // ----------
     resize: function () {
+      if (!this?._viewer?.world?.getItemAt(0)) return
       if (this._containerWidth !== this._viewer.container.clientWidth) {
         this._containerWidth = this._viewer.container.clientWidth
         this._canvasdiv.setAttribute('width', this._containerWidth)
@@ -148,6 +149,7 @@ import OpenSeadragon from 'openseadragon'
       this._open = false
     },
     _updateCanvas: function (event) {
+      if (!this?._viewer?.world?.getItemAt(0)) return
       var viewportZoom = this._viewer.viewport.getZoom(true)
       var image1 = this._viewer.world.getItemAt(0)
       var zoom = image1.viewportToImageZoom(viewportZoom)


### PR DESCRIPTION
## 📝 Description

> 1. fix an error when trying to change the source of tiledImage after any tiledImage is loaded on a viewport once.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

## 🚀 New behavior

> Please describe the behavior or changes this PR adds.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
