### PR TITLE
Feature/SVG drawer component

### DIFF
--- a/apps/insight-viewer-docs/src/containers/UseOverlayContext/Heatmap/Heatmap.tsx
+++ b/apps/insight-viewer-docs/src/containers/UseOverlayContext/Heatmap/Heatmap.tsx
@@ -100,7 +100,7 @@ function draw({
   baseCanvas: HTMLCanvasElement | null
   heatmapCanvas: HTMLCanvasElement | undefined
   heatmapData: ImageData | undefined
-} & Omit<OverlayContext, 'viewport' | 'pixelToCanvas'>) {
+} & Omit<OverlayContext, 'viewport' | 'pixelToCanvas' | 'pageToPixel'>) {
   if (!heatmapData || !baseCanvas || !heatmapCanvas) return
   const baseCanvasContext = baseCanvas.getContext('2d')
   clear(baseCanvas, baseCanvasContext)

--- a/packages/insight-viewer/package.json
+++ b/packages/insight-viewer/package.json
@@ -36,12 +36,14 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
+    "@types/point-in-polygon": "^1.1.1",
     "consola": "2.15.3",
     "cornerstone-core": "^2.3.0",
     "cornerstone-wado-image-loader": "^3.3.1",
     "cornerstone-web-image-loader": "^2.1.1",
     "dicom-parser": "^1.8.7",
     "ky": "^0.27.0",
+    "point-in-polygon": "^1.1.0",
     "react-resize-detector": "^6.7.0",
     "rxjs": "^7.0.0",
     "uid": "^2.0.0"

--- a/packages/insight-viewer/package.json
+++ b/packages/insight-viewer/package.json
@@ -36,7 +36,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@types/point-in-polygon": "^1.1.1",
     "consola": "2.15.3",
     "cornerstone-core": "^2.3.0",
     "cornerstone-wado-image-loader": "^3.3.1",
@@ -53,6 +52,7 @@
     "@types/cornerstone-core": "^2.3.0",
     "@types/jest": "^26.0.24",
     "@types/react": "^17.0.3",
+    "@types/point-in-polygon": "^1.1.1",
     "eslint-import-resolver-node": "^0.3.4",
     "jest": "^26.6.3",
     "microbundle": "^0.13.0",

--- a/packages/insight-viewer/src/Viewer/SvgContourDrawer/SvgContourDrawer.styles.ts
+++ b/packages/insight-viewer/src/Viewer/SvgContourDrawer/SvgContourDrawer.styles.ts
@@ -1,0 +1,29 @@
+import { CSSProperties } from 'react'
+
+type ContourStyleType = 'default' | 'highlight'
+type ContourStyle = { [styleType in ContourStyleType]?: CSSProperties }
+
+export const svgStyle: ContourStyle = {
+  default: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+  },
+}
+
+export const polyline: ContourStyle = {
+  default: {
+    fill: 'rgba(255, 244, 0, 0.2)',
+    strokeWidth: '5px',
+    stroke: 'rgb(255, 224, 0)',
+  },
+  highlight: {
+    stroke: '#ffffff',
+    strokeWidth: '5px',
+    strokeDasharray: '10, 10',
+    strokeDashoffset: '1000',
+    fill: 'transparent',
+  },
+}

--- a/packages/insight-viewer/src/Viewer/SvgContourDrawer/SvgContourDrawer.types.ts
+++ b/packages/insight-viewer/src/Viewer/SvgContourDrawer/SvgContourDrawer.types.ts
@@ -8,13 +8,6 @@ export interface SvgContourDrawerProps<T extends Contour> {
   contours: T[]
 
   /**
-   * Whether the drawing function is enabled
-   *
-   * When inputting as HTMLElement, MouseEvent is handled using the HTMLElement
-   */
-  draw?: boolean | HTMLElement | null
-
-  /**
    * When Mouse Over on a Contour
    * Required to determine focusedContour
    */
@@ -28,9 +21,6 @@ export interface SvgContourDrawerProps<T extends Contour> {
 
   className?: string
   style?: CSSProperties
-
-  /** In the process of drawing, you can deactivate the animation expressed on the line */
-  animateStroke?: boolean
 
   /** Access Device Settings */
   device?:

--- a/packages/insight-viewer/src/Viewer/SvgContourDrawer/SvgContourDrawer.types.ts
+++ b/packages/insight-viewer/src/Viewer/SvgContourDrawer/SvgContourDrawer.types.ts
@@ -1,0 +1,42 @@
+import { CSSProperties } from 'react'
+import { Contour, Point } from '../../types'
+
+export interface SvgContourDrawerProps<T extends Contour> {
+  width?: number
+  height?: number
+
+  contours?: T[]
+
+  /**
+   * Whether the drawing function is enabled
+   *
+   * When inputting as HTMLElement, MouseEvent is handled using the HTMLElement
+   */
+  draw?: boolean | HTMLElement | null
+
+  /**
+   * When Mouse Over on a Contour
+   * Required to determine focusedContour
+   */
+  onFocus: (contour: T | null) => void
+
+  /** When drawing is complete and a new contour occurs */
+  onAdd: (polygon: Point[]) => void
+
+  /** Needed to delete a specific contour by clicking on it */
+  onRemove: (contour: T) => void
+
+  className?: string
+  style?: CSSProperties
+
+  /** In the process of drawing, you can deactivate the animation expressed on the line */
+  animateStroke?: boolean
+
+  /** Access Device Settings */
+  device?:
+    | 'all'
+    | 'mouse-only'
+    | 'touch-only'
+    | 'stylus-only'
+    | 'mouse-and-stylus'
+}

--- a/packages/insight-viewer/src/Viewer/SvgContourDrawer/SvgContourDrawer.types.ts
+++ b/packages/insight-viewer/src/Viewer/SvgContourDrawer/SvgContourDrawer.types.ts
@@ -22,7 +22,10 @@ export interface SvgContourDrawerProps<T extends Contour> {
   className?: string
   style?: CSSProperties
 
-  /** Access Device Settings */
+  /**
+   * Access Device Settings
+   * Only the function for mouse is implemented, and it is not applied
+   */
   device?:
     | 'all'
     | 'mouse-only'

--- a/packages/insight-viewer/src/Viewer/SvgContourDrawer/SvgContourDrawer.types.ts
+++ b/packages/insight-viewer/src/Viewer/SvgContourDrawer/SvgContourDrawer.types.ts
@@ -5,7 +5,7 @@ export interface SvgContourDrawerProps<T extends Contour> {
   width?: number
   height?: number
 
-  contours?: T[]
+  contours: T[]
 
   /**
    * Whether the drawing function is enabled

--- a/packages/insight-viewer/src/Viewer/SvgContourDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/SvgContourDrawer/index.tsx
@@ -7,14 +7,12 @@ import { SvgContourDrawerProps } from './SvgContourDrawer.types'
 import useSvgContourDrawing from '../../hooks/useSvgContourDrawing'
 
 export function SvgContourDrawer<T extends Contour>({
-  draw,
   style,
   width,
   height,
   device,
   contours,
   className,
-  animateStroke,
   onAdd,
   onFocus,
   onRemove,
@@ -22,10 +20,8 @@ export function SvgContourDrawer<T extends Contour>({
   const svgRef = useRef<SVGSVGElement>(null)
   const [polygon] = useSvgContourDrawing({
     svgElement: svgRef,
-    draw,
     device,
     contours,
-    animateStroke,
     onAdd,
     onFocus,
     onRemove,

--- a/packages/insight-viewer/src/Viewer/SvgContourDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/SvgContourDrawer/index.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import React, { useRef } from 'react'
+import { useOverlayContext } from '../../contexts'
+import { Contour, Point } from '../../types'
+import { svgStyle, polyline } from './SvgContourDrawer.styles'
+import { SvgContourDrawerProps } from './SvgContourDrawer.types'
+import useSvgContourDrawing from '../../hooks/useSvgContourDrawing'
+
+export function SvgContourDrawer<T extends Contour>({
+  draw,
+  style,
+  width,
+  height,
+  device,
+  contours,
+  className,
+  animateStroke,
+  onAdd,
+  onFocus,
+  onRemove,
+}: SvgContourDrawerProps<T>): JSX.Element {
+  const svgRef = useRef<SVGSVGElement>(null)
+  const [polygon] = useSvgContourDrawing({
+    svgElement: svgRef,
+    draw,
+    device,
+    contours,
+    animateStroke,
+    onAdd,
+    onFocus,
+    onRemove,
+  })
+  const { pixelToCanvas } = useOverlayContext()
+
+  const transformedPoints: Point[] = polygon.map(point => pixelToCanvas(point))
+  const polygonPoints = transformedPoints.map(([x, y]) => `${x},${y}`).join(' ')
+
+  return (
+    <svg
+      ref={svgRef}
+      width={width}
+      height={height}
+      style={{ ...svgStyle.default, ...style }}
+      className={className}
+    >
+      {polygon && polygon.length > 0 && (
+        <>
+          <polyline style={polyline.default} points={polygonPoints} />
+          <polyline style={polyline.highlight} points={polygonPoints} />
+        </>
+      )}
+    </svg>
+  )
+}

--- a/packages/insight-viewer/src/Viewer/SvgContourDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/SvgContourDrawer/index.tsx
@@ -28,7 +28,7 @@ export function SvgContourDrawer<T extends Contour>({
   })
   const { pixelToCanvas } = useOverlayContext()
 
-  const transformedPoints: Point[] = polygon.map(point => pixelToCanvas(point))
+  const transformedPoints: Point[] = polygon.map(pixelToCanvas)
   const polygonPoints = transformedPoints.map(([x, y]) => `${x},${y}`).join(' ')
 
   return (

--- a/packages/insight-viewer/src/Viewer/SvgContourViewer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/SvgContourViewer/index.tsx
@@ -18,9 +18,7 @@ function svgContoursDraw<T extends Contour>({
   return contours.map(contour => {
     const { polygon, label, id, labelPosition: _labelPosition } = contour
     const isFocusedPolygon = polygon === focusedContour?.polygon
-    const transformedPoints: Point[] = polygon.map(point =>
-      pixelToCanvas(point)
-    )
+    const transformedPoints: Point[] = polygon.map(pixelToCanvas)
 
     const polygonAttributes =
       typeof polygonAttrs === 'function'

--- a/packages/insight-viewer/src/components/ViewerWrapper/index.tsx
+++ b/packages/insight-viewer/src/components/ViewerWrapper/index.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useEffect } from 'react'
 import { WithChildren, ProgressComponent, OnViewportChange } from '../../types'
 import { getViewport } from '../../utils/cornerstoneHelper'
-import { formatViewport } from '../../utils/common/formatViewport'
+import { formatViewerViewport } from '../../utils/common/formatViewport'
 import LoadingProgress from '../LoadingProgress'
 import useResize from './useResize'
 
@@ -28,7 +28,7 @@ const Forwarded = forwardRef<
     // update Viewer's viewport prop to change
     if (onViewportChange) {
       const viewport = getViewport(resizeRef.current)
-      onViewportChange(formatViewport(viewport))
+      onViewportChange(formatViewerViewport(viewport))
     }
   }, [width, height, resizeRef, imageEnabled, onViewportChange])
 

--- a/packages/insight-viewer/src/contexts/index.tsx
+++ b/packages/insight-viewer/src/contexts/index.tsx
@@ -6,6 +6,7 @@ import {
   PixelCoordinate,
 } from '../utils/cornerstoneHelper/types'
 import {
+  pageToPixel as pageToPixelUtil,
   pixelToCanvas as pixelToCanvasUtil,
   setToPixelCoordinateSystem as setToPixelCoordinateSystemUtil,
   getEnabledElement,
@@ -15,6 +16,7 @@ export interface OverlayContext {
   enabledElement: EnabledElement | null
   setToPixelCoordinateSystem: (context: CanvasRenderingContext2D) => void
   pixelToCanvas: (point: Point) => Point
+  pageToPixel: (point: Point) => Point
   viewport: Viewport
 }
 
@@ -22,6 +24,7 @@ const contextDefaultValue: OverlayContext = {
   enabledElement: null,
   setToPixelCoordinateSystem: () => {},
   pixelToCanvas: () => ({} as Point),
+  pageToPixel: () => ({} as Point),
   viewport: BASE_VIEWPORT,
 }
 const Context = createContext<OverlayContext>(contextDefaultValue)
@@ -61,7 +64,19 @@ export function OverlayContextProvider({
       _pixelCoordinateBrand: 'pixel',
     }
     const { x, y } = pixelToCanvasUtil(enabledElement.element, pixelCoordinate)
+    return [x, y]
+  }
 
+  function pageToPixel([xPosition, yPosition]: Point): Point {
+    if (!enabledElement?.element) {
+      throw new Error(ERROR_MESSAGE.ENABLED_ELEMENT_NOT_READY)
+    }
+
+    const { x, y } = pageToPixelUtil(
+      enabledElement.element,
+      xPosition,
+      yPosition
+    )
     return [x, y]
   }
 
@@ -83,6 +98,7 @@ export function OverlayContextProvider({
       value={{
         setToPixelCoordinateSystem,
         pixelToCanvas,
+        pageToPixel,
         enabledElement,
         viewport,
       }}

--- a/packages/insight-viewer/src/hooks/useSvgContourDrawing/index.ts
+++ b/packages/insight-viewer/src/hooks/useSvgContourDrawing/index.ts
@@ -1,0 +1,187 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import { useState, useEffect } from 'react'
+import { UseSvgContourDrawingProps } from './types'
+import { Contour, Point } from '../../types'
+import { useOverlayContext } from '../../contexts'
+import { hitTestContours } from '../../utils/common/hitTestContours'
+
+const setPreProcessEvent = (event: MouseEvent | KeyboardEvent) => {
+  event.preventDefault()
+  event.stopPropagation()
+  event.stopImmediatePropagation()
+}
+
+function useSvgContourDrawing<T extends Contour>({
+  svgElement,
+  contours,
+  onAdd,
+  onFocus,
+  onRemove,
+}: UseSvgContourDrawingProps<T>): Point[][] {
+  const [polygon, setPolygon] = useState<Point[]>([])
+  const [focusedContour, setFocusedContour] = useState<T | null>(null)
+  const [isDrawingMode, setIsDrawingMode] = useState<boolean>(false)
+
+  const { pageToPixel, enabledElement } = useOverlayContext()
+
+  useEffect(() => {
+    if (!svgElement || !enabledElement) return
+
+    const handleMouseMoveToDraw = (event: MouseEvent) => {
+      setPreProcessEvent(event)
+
+      if (polygon.length > 0 && isDrawingMode) {
+        const pixelPosition: Point = pageToPixel([event.pageX, event.pageY])
+
+        setPolygon(prevState => [...prevState, pixelPosition])
+      }
+    }
+
+    const handleMouseUpToEndDraw = (event: MouseEvent) => {
+      setPreProcessEvent(event)
+      deactiveMouseDrawEvents()
+      activateInitialEvents()
+
+      onAdd(polygon)
+      setPolygon([])
+      setIsDrawingMode(false)
+    }
+
+    const handleMouseLeaveToCancelDraw = (event: MouseEvent) => {
+      setPreProcessEvent(event)
+      deactiveMouseDrawEvents()
+      activateInitialEvents()
+
+      setPolygon([])
+      setIsDrawingMode(false)
+    }
+
+    const handleKeyDownToCancelMouseDraw = (event: KeyboardEvent) => {
+      if (event.code === 'Escape') {
+        setPreProcessEvent(event)
+        deactiveMouseDrawEvents()
+        activateInitialEvents()
+
+        setPolygon([])
+        setIsDrawingMode(false)
+      }
+    }
+
+    const handleMouseDownToStartDraw = (event: MouseEvent) => {
+      setPreProcessEvent(event)
+      deactivateInitialEvents()
+      activeMouseDrawEvents()
+
+      const pixelPosition: Point = pageToPixel([event.pageX, event.pageY])
+      setPolygon([pixelPosition])
+      setIsDrawingMode(true)
+    }
+
+    const handleMouseMoveToFindFocus = (event: MouseEvent) => {
+      event.stopPropagation()
+
+      if (contours.length === 0) return
+
+      const pixelPosition: Point = pageToPixel([event.pageX, event.pageY])
+      const focusedContourElement = hitTestContours(contours, pixelPosition)
+
+      setFocusedContour(focusedContourElement)
+      onFocus(focusedContourElement)
+    }
+
+    const handleClickToRemove = (event: MouseEvent) => {
+      event.stopPropagation()
+
+      if (!focusedContour || isDrawingMode) return
+      onRemove(focusedContour)
+    }
+
+    const activateInitialEvents = () => {
+      if (!enabledElement || !enabledElement.element) return
+
+      enabledElement.element.addEventListener(
+        'mousemove',
+        handleMouseMoveToFindFocus
+      )
+      enabledElement.element.addEventListener(
+        'mousedown',
+        handleMouseDownToStartDraw
+      )
+      enabledElement.element.addEventListener('click', handleClickToRemove)
+    }
+
+    const deactivateInitialEvents = () => {
+      if (!enabledElement || !enabledElement.element) return
+
+      enabledElement.element.removeEventListener(
+        'mousemove',
+        handleMouseMoveToFindFocus
+      )
+      enabledElement.element.removeEventListener(
+        'mousedown',
+        handleMouseDownToStartDraw
+      )
+      enabledElement.element.removeEventListener('click', handleClickToRemove)
+    }
+
+    const activeMouseDrawEvents = () => {
+      if (!enabledElement || !enabledElement.element) return
+
+      enabledElement.element.addEventListener(
+        'mousemove',
+        handleMouseMoveToDraw
+      )
+      enabledElement.element.addEventListener('mouseup', handleMouseUpToEndDraw)
+      enabledElement.element.addEventListener(
+        'mouseleave',
+        handleMouseLeaveToCancelDraw
+      )
+      window.addEventListener('keydown', handleKeyDownToCancelMouseDraw)
+    }
+
+    const deactiveMouseDrawEvents = () => {
+      if (!enabledElement || !enabledElement.element) return
+
+      enabledElement.element.removeEventListener(
+        'mousemove',
+        handleMouseMoveToDraw
+      )
+      enabledElement.element.removeEventListener(
+        'mouseup',
+        handleMouseUpToEndDraw
+      )
+      enabledElement.element.removeEventListener(
+        'mouseleave',
+        handleMouseLeaveToCancelDraw
+      )
+      window.removeEventListener('keydown', handleKeyDownToCancelMouseDraw)
+    }
+
+    if (polygon.length > 0) {
+      activeMouseDrawEvents()
+    } else {
+      activateInitialEvents()
+    }
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      deactivateInitialEvents()
+      deactiveMouseDrawEvents()
+    }
+  }, [
+    contours,
+    svgElement,
+    polygon,
+    isDrawingMode,
+    focusedContour,
+    enabledElement,
+    onAdd,
+    onFocus,
+    onRemove,
+    pageToPixel,
+  ])
+
+  return [polygon]
+}
+
+export default useSvgContourDrawing

--- a/packages/insight-viewer/src/hooks/useSvgContourDrawing/index.ts
+++ b/packages/insight-viewer/src/hooks/useSvgContourDrawing/index.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react'
 import { UseSvgContourDrawingProps } from './types'
 import { Contour, Point } from '../../types'
 import { useOverlayContext } from '../../contexts'
-import { hitTestContours } from '../../utils/common/hitTestContours'
+import { checkFocusedContour } from '../../utils/common/checkFocusedContour'
 
 const setPreProcessEvent = (event: MouseEvent | KeyboardEvent) => {
   event.preventDefault()
@@ -83,7 +83,7 @@ function useSvgContourDrawing<T extends Contour>({
       if (contours.length === 0) return
 
       const pixelPosition: Point = pageToPixel([event.pageX, event.pageY])
-      const focusedContourElement = hitTestContours(contours, pixelPosition)
+      const focusedContourElement = checkFocusedContour(contours, pixelPosition)
 
       setFocusedContour(focusedContourElement)
       onFocus(focusedContourElement)

--- a/packages/insight-viewer/src/hooks/useSvgContourDrawing/types.ts
+++ b/packages/insight-viewer/src/hooks/useSvgContourDrawing/types.ts
@@ -1,0 +1,17 @@
+import { Point, Contour } from '../../types'
+
+export interface UseSvgContourDrawingProps<T extends Contour> {
+  svgElement: React.RefObject<SVGSVGElement> | null
+  draw?: boolean | HTMLElement | null
+  device?:
+    | 'all'
+    | 'mouse-only'
+    | 'touch-only'
+    | 'stylus-only'
+    | 'mouse-and-stylus'
+  contours: T[]
+  animateStroke?: boolean
+  onAdd: (polygon: Point[]) => void
+  onFocus: (contour: T | null) => void
+  onRemove: (contour: T) => void
+}

--- a/packages/insight-viewer/src/hooks/useSvgContourDrawing/types.ts
+++ b/packages/insight-viewer/src/hooks/useSvgContourDrawing/types.ts
@@ -2,7 +2,6 @@ import { Point, Contour } from '../../types'
 
 export interface UseSvgContourDrawingProps<T extends Contour> {
   svgElement: React.RefObject<SVGSVGElement> | null
-  draw?: boolean | HTMLElement | null
   device?:
     | 'all'
     | 'mouse-only'
@@ -10,7 +9,6 @@ export interface UseSvgContourDrawingProps<T extends Contour> {
     | 'stylus-only'
     | 'mouse-and-stylus'
   contours: T[]
-  animateStroke?: boolean
   onAdd: (polygon: Point[]) => void
   onFocus: (contour: T | null) => void
   onRemove: (contour: T) => void

--- a/packages/insight-viewer/src/index.ts
+++ b/packages/insight-viewer/src/index.ts
@@ -1,5 +1,6 @@
 export { InsightViewer as default } from './Viewer'
 export { SvgContourViewer } from './Viewer/SvgContourViewer'
+export { SvgContourDrawer } from './Viewer/SvgContourDrawer'
 export { useMultipleImages } from './hooks/useMultipleImages'
 export { useViewport } from './hooks/useViewport'
 export { useInteraction } from './hooks/useInteraction'

--- a/packages/insight-viewer/src/utils/common/checkFocusedContour.ts
+++ b/packages/insight-viewer/src/utils/common/checkFocusedContour.ts
@@ -1,7 +1,7 @@
 import pointInPolygon from 'point-in-polygon'
 import { Contour, Point } from '../../types'
 
-export function hitTestContours<T extends Contour>(
+export function checkFocusedContour<T extends Contour>(
   contours: T[],
   cursor: Point
 ): T | null {

--- a/packages/insight-viewer/src/utils/common/hitTestContours.ts
+++ b/packages/insight-viewer/src/utils/common/hitTestContours.ts
@@ -1,0 +1,13 @@
+import pointInPolygon from 'point-in-polygon'
+import { Contour, Point } from '../../types'
+
+export function hitTestContours<T extends Contour>(
+  contours: T[],
+  cursor: Point
+): T | null {
+  const result: T | undefined = contours.find(contour =>
+    pointInPolygon(cursor, contour.polygon)
+  )
+
+  return result || null
+}

--- a/packages/insight-viewer/src/utils/cornerstoneHelper/utils.ts
+++ b/packages/insight-viewer/src/utils/cornerstoneHelper/utils.ts
@@ -91,3 +91,11 @@ export function getDefaultViewportForImage(
 ): ReturnType<typeof cornerstone.getDefaultViewportForImage> {
   return cornerstone.getDefaultViewportForImage(element, image)
 }
+
+export function pageToPixel(
+  element: HTMLElement,
+  pageX: number,
+  pageY: number
+): PixelCoordinate {
+  return cornerstone.pageToPixel(element, pageX, pageY)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4311,6 +4311,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/point-in-polygon@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/point-in-polygon/-/point-in-polygon-1.1.1.tgz#6459c3d895fe585f2b5c46ff6715b886af4ed2eb"
+  integrity sha512-DDl4uxqbpRsBYg+youv7AbWsED4eycsPiSD+AaB+NAkFjHKHTuij55K29R8rFgqeoeazi/5syNW5J2uNnpS+Ow==
+
 "@types/polylabel@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/polylabel/-/polylabel-1.0.5.tgz#9262f269de36f1e9248aeb9dee0ee9d10065e043"
@@ -13885,6 +13890,11 @@ pnp-webpack-plugin@1.6.4:
   integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
   dependencies:
     ts-pnp "^1.1.6"
+
+point-in-polygon@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/point-in-polygon/-/point-in-polygon-1.1.0.tgz#b0af2616c01bdee341cbf2894df643387ca03357"
+  integrity sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==
 
 polylabel@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## 📝 Description

- Svg Drawer component 를 추가했습니다.
  viewer-docs 에는 아직 추가되지 않았으며, 다음 PR 때 포함시킬 예정입니다. 
  useContour 및 docs 작업까지 포함할 경우 작업 단위가 광범위하여,
 ` Svg Drawer component -> useContour & viewer-docs` 순으로 올리겠습니다.
  
- Svg Drawer component 구현을 위한 Event handler hook 과 util function, Component 까지
   구현된 PR 입니다.
 
 - svg component의 구현 방식에 대한 의견을 취합 후, 
    기존 구조처럼 `Viewer`, `Drawer`, `useContour hook` 으로 분리하는 방법으로 구현했습니다.
    
    이 외의 다소 많은 분리에 의해 사용의 불편함이 있는 [CircleViewer](https://frontend-components-git-master-ssen.vercel.app/#/insight-viewer/circleviewer), [LineViewer](https://frontend-components-git-master-ssen.vercel.app/#/insight-viewer/lineviewer) 와 같은 경우
    하나로 병합한 후 mode 전달을 통해, 진행할 것 같습니다.
    
## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🚀 New behavior

- focus contour 을 찾기 위해 사용되는 pageToPixel cornerstone util function 을 추가했습니다. eed1196

- 외부에서 사용 가능하도록 pageToPixel util function 을 OverlayContextProvider context 에 추가하였습니다. cf85c92

- SvgContourDrawer component props interface 를 추가했습니다. a3f3941
   contours 에 optional type 을 삭제하였습니다. b8b3010
   
- SvgContourDrawer 의 polyline 의 style 을 추가했습니다. d8550ed

- focus contour 을 찾기 위해 point-in-poplygon package 를 추가했습니다. 7b93403

- focus contour 을 찾기 위한 checkFocusedContour util function 을 추가했습니다. f319a38

- UseSvgContourDrawing props type 을 추가했습니다. 10c2861
   (draw, device 의 optional 은 아직 관련 기능이 추가되지 않아 optional 로 두었습니다.)
   
- useSvgContourDrawing hook 을 추가했습니다. b70e6a7
  (이벤트 관련 함수 관리 hook 입니다.)
  
- SvgContourDrawer component 을 추가했습니다. fefb118

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

## Comments

- useSvgContourDrawing hook 의 경우 event handling 이 어려웠습니다.
   activeMouseDrawEvents (drawing 관련 events 활성화) 와
   deactivateInitialEvents (기본 focus, delete 기능 활성화) 간 스위칭하는 기준점을
   정하는 과정이 생각보다 오래 걸렸네요. 
   (우선 useContour hook 추가 후 각 event 기능 사용 시 정상 동작하는 것은 확인했습니다.)
   (테스트 기능들: focus, delete, draw)
