### PR TITLE
refactor(viewer-docs): modify draw props type Using Omit to Pick

### DIFF
--- a/apps/insight-viewer-docs/src/containers/UseOverlayContext/Heatmap/Heatmap.tsx
+++ b/apps/insight-viewer-docs/src/containers/UseOverlayContext/Heatmap/Heatmap.tsx
@@ -7,6 +7,16 @@ import { useRef, useEffect, CSSProperties, useMemo } from 'react'
 import { useOverlayContext, OverlayContext } from '@lunit/insight-viewer'
 import posMap from './posMap'
 
+interface HeatmapDrawProps
+  extends Pick<
+    OverlayContext,
+    'setToPixelCoordinateSystem' | 'enabledElement'
+  > {
+  baseCanvas: HTMLCanvasElement | null
+  heatmapCanvas: HTMLCanvasElement | undefined
+  heatmapData: ImageData | undefined
+}
+
 const threshold = 0.1
 
 const style: CSSProperties = {
@@ -96,11 +106,7 @@ function draw({
   heatmapData,
   setToPixelCoordinateSystem,
   enabledElement,
-}: {
-  baseCanvas: HTMLCanvasElement | null
-  heatmapCanvas: HTMLCanvasElement | undefined
-  heatmapData: ImageData | undefined
-} & Omit<OverlayContext, 'viewport' | 'pixelToCanvas' | 'pageToPixel'>) {
+}: HeatmapDrawProps) {
   if (!heatmapData || !baseCanvas || !heatmapCanvas) return
   const baseCanvasContext = baseCanvas.getContext('2d')
   clear(baseCanvas, baseCanvasContext)


### PR DESCRIPTION
## 📝 Description

- insight-viewer 의 OverlayContext cornerstone util function 추가, interface 변경에 따라
   insight-viewer-docs 의 Heatmap draw function props interface 도 변경해야하는 공수 발생 이슈가 있어
   이에 대한 조치 PR 입니다.
   
- 기존 Omit 으로 제외하는 방법에서 Pick 을 사용하는 방식으로 수정하였습니다.
   Omit 의 경우 OverlayContext interface 에 추가될 때마다 Omit List 에 추가해야하므로,
   Pick 을 통해 위 문제를 해결했습니다.

- code review
   - in svg Contour Viewer: https://github.com/lunit-io/frontend-components/pull/168#discussion_r774369492
   - in svg Contour Drawer: https://github.com/lunit-io/frontend-components/pull/175#discussion_r779193125

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

- OverlayContext 의 cornerstone util function 이 추가될 때마다 interface 역시 해당 util function 에 대한
   정의가 추가되며, 이에 따른 Omit 의 list 가 계속 늘어가게 됩니다.

Issue Number: https://github.com/lunit-io/frontend-components/issues/176

## 🚀 New behavior

- Omit 에서 Pick 을 사용하여 interface 를 정의했습니다.
   가독성을 위해 interface 를 따로 선언하는 방식으로 수정했습니다. 2f38b07

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
