### PR TITLE
Feature/fix package publish bug #185

### DIFF
--- a/.github/workflows/insight-viewer-feature.yml
+++ b/.github/workflows/insight-viewer-feature.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Yarn build
         id: yarn-build
-        run: yarn doc:insight-viewer
+        run: yarn build
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/insight-viewer-production.yml
+++ b/.github/workflows/insight-viewer-production.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Run tests
         uses: percy/exec-action@v0.3.1
         with:
-          custom-command: 'yarn test:insight-viewer'
+          custom-command: 'yarn test'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
       - name: Build
-        run: yarn doc:insight-viewer
+        run: yarn build
         working-directory: ${{ env.WORKDIR }}
 
       - name: Configure AWS Credentials

--- a/.github/workflows/insight-viewer-staging.yml
+++ b/.github/workflows/insight-viewer-staging.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Run tests
         uses: percy/exec-action@v0.3.1
         with:
-          custom-command: 'yarn test:insight-viewer'
+          custom-command: 'yarn test'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
       - name: Build
-        run: yarn doc:insight-viewer
+        run: yarn build
         working-directory: ${{ env.WORKDIR }}
 
       - name: Configure AWS Credentials

--- a/apps/insight-viewer-docs/src/containers/Contour/index.tsx
+++ b/apps/insight-viewer-docs/src/containers/Contour/index.tsx
@@ -1,0 +1,46 @@
+import { Box } from '@chakra-ui/react'
+import InsightViewer, { useImage } from '@lunit/insight-viewer'
+import ContourComponent from '@lunit/insight-viewer/contour'
+import { ViewerWrapper } from '../../components/Wrapper'
+import CodeBlock from '../../components/CodeBlock'
+import { IMAGES } from '../../const'
+
+const CODE = `\
+import InsightViewer, { useImage } from '@lunit/insight-viewer'
+import Contour from '@lunit/insight-viewer/contour'
+
+export default function App() {
+  const { image } = useImage({
+    wadouri: IMAGE_ID,
+  })
+  
+  return (
+    <Wrapper>
+      <InsightViewer image={image}>
+        <Contour />
+      </InsightViewer>
+    </Wrapper>
+  )
+}
+`
+
+function Contour(): JSX.Element {
+  const { loadingState, image } = useImage({
+    wadouri: IMAGES[0],
+  })
+
+  return (
+    <Box data-cy-loaded={loadingState}>
+      <ViewerWrapper>
+        <InsightViewer image={image}>
+          <ContourComponent />
+        </InsightViewer>
+      </ViewerWrapper>
+      <Box>
+        <CodeBlock code={CODE} />
+      </Box>
+    </Box>
+  )
+}
+
+export default Contour

--- a/apps/insight-viewer-docs/src/pages/contour.tsx
+++ b/apps/insight-viewer-docs/src/pages/contour.tsx
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic'
+
+const DynamicComponentWithNoSSR = dynamic(
+  () => import('../containers/Contour'),
+  {
+    ssr: false,
+  }
+)
+
+export default DynamicComponentWithNoSSR

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "node-filter-async": "^2.0.0",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
+    "scripty": "^2.0.0",
     "typescript": "^4.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,9 +16,8 @@
   },
   "scripts": {
     "test": "lerna run test",
-    "test:insight-viewer": "lerna run --scope @lunit/insight-viewer test && lerna run --scope @lunit/insight-viewer-docs test",
-    "doc:insight-viewer": "lerna run --scope @lunit/insight-viewer build && lerna run --scope @lunit/insight-viewer-docs doc",
-    "publish:insight-viewer": "lerna run --scope @lunit/insight-viewer publish",
+    "build": "lerna run --scope @lunit/insight-viewer build && lerna run --scope @lunit/insight-viewer-docs doc",
+    "publish": "lerna run --scope @lunit/insight-viewer publish",
     "postinstall": "husky install"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "test": "lerna run test",
     "build": "lerna run --scope @lunit/insight-viewer build && lerna run --scope @lunit/insight-viewer-docs doc",
-    "publish": "lerna run --scope @lunit/insight-viewer publish",
+    "publish": "lerna publish",
+    "prepublish": "scripty",
     "postinstall": "husky install"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   },
   "scripts": {
     "test": "lerna run test",
-    "build": "lerna run --scope @lunit/insight-viewer build && lerna run --scope @lunit/insight-viewer-docs doc",
+    "build": "scripty",
     "publish": "lerna publish",
     "prepublish": "scripty",
-    "postinstall": "husky install"
+    "postinstall": "husky install",
+    "local-publish": "scripty",
+    "local-unpublish": "scripty"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",

--- a/packages/insight-viewer/package.json
+++ b/packages/insight-viewer/package.json
@@ -30,9 +30,7 @@
     "dev": "scripty",
     "compile": "scripty",
     "clean": "scripty",
-    "test": "scripty",
-    "prepublish": "scripty",
-    "publish": "scripty"
+    "test": "scripty"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/insight-viewer/package.json
+++ b/packages/insight-viewer/package.json
@@ -4,6 +4,7 @@
   "description": "cornerstone 라이브러리를 기반으로 Dicom Image를 다루기 위한 여러 Component들을 제공한다.",
   "source": "src/index.ts",
   "main": "dist/index.js",
+  "module": "dist/index.esm.js",
   "exports": {
     ".": "./dist/index.esm.js",
     "./contour": "./dist/contour.esm.js"

--- a/packages/insight-viewer/package.json
+++ b/packages/insight-viewer/package.json
@@ -33,7 +33,8 @@
     "test": "scripty"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "directory": "dist"
   },
   "dependencies": {
     "consola": "2.15.3",

--- a/packages/insight-viewer/package.json
+++ b/packages/insight-viewer/package.json
@@ -54,15 +54,14 @@
     "@babel/core": "^7.13.14",
     "@types/cornerstone-core": "^2.3.0",
     "@types/jest": "^26.0.24",
-    "@types/polylabel": "^1.0.5",
     "@types/node": "^17.0.7",
     "@types/point-in-polygon": "^1.1.1",
+    "@types/polylabel": "^1.0.5",
     "@types/react": "^17.0.3",
     "eslint-import-resolver-node": "^0.3.4",
     "jest": "^26.6.3",
     "microbundle": "^0.13.0",
     "react-is": "^17.0.2",
-    "scripty": "^2.0.0",
     "ts-jest": "^26.5.4"
   },
   "peerDependencies": {

--- a/packages/insight-viewer/scripts/compile
+++ b/packages/insight-viewer/scripts/compile
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 echo "┏━━━ 📦 COMPILE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-microbundle src/*.ts --jsx React.createElement --tsconfig tsconfig.build.json -f esm,cjs
+microbundle src/cjs/*.ts --jsx React.createElement --tsconfig tsconfig.build.json -f cjs &&
+microbundle src/*.ts --jsx React.createElement --tsconfig tsconfig.build.json -f esm

--- a/packages/insight-viewer/scripts/prepublish
+++ b/packages/insight-viewer/scripts/prepublish
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-echo "┏━━━ 🧨 PREPUBLISH ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-yarn run build
-cp ./README.md ./dist/README.md
-cp ./CHANGELOG.md ./dist/CHANGELOG.md
-cp ./LICENSE ./dist/LICENSE
-node ./SetupPackage.js

--- a/packages/insight-viewer/scripts/publish
+++ b/packages/insight-viewer/scripts/publish
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-echo "┏━━━ 🚀 PUBLISH ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-yarn lerna version
-cd dist && yarn lerna publish

--- a/packages/insight-viewer/src/cjs/contour.ts
+++ b/packages/insight-viewer/src/cjs/contour.ts
@@ -1,0 +1,3 @@
+import Contour from '../components/Contour'
+
+export default Contour

--- a/packages/insight-viewer/src/cjs/index.ts
+++ b/packages/insight-viewer/src/cjs/index.ts
@@ -1,0 +1,37 @@
+import { InsightViewer } from '../Viewer'
+import { SvgContourViewer } from '../Viewer/SvgContourViewer'
+import { SvgContourDrawer } from '../Viewer/SvgContourDrawer'
+import { useMultipleImages } from '../hooks/useMultipleImages'
+import { useViewport } from '../hooks/useViewport'
+import { useInteraction } from '../hooks/useInteraction'
+import { useContour } from '../hooks/useContour'
+import { useImage } from '../hooks/useImage'
+import { useFrame } from '../hooks/useFrame'
+import { useDicomFile } from '../hooks/useDicomFile'
+import { useOverlayContext } from '../contexts'
+
+export type { Interaction, SetInteraction } from '../hooks/useInteraction/types'
+export type { Viewport, ViewerError, Contours, Contour, Point } from '../types'
+export type {
+  DragEvent,
+  Click,
+  Drag,
+  Wheel,
+} from '../hooks/useInteraction/types'
+
+export type { OverlayContext } from '../contexts'
+
+Object.assign(InsightViewer, {
+  SvgContourViewer,
+  SvgContourDrawer,
+  useMultipleImages,
+  useViewport,
+  useInteraction,
+  useContour,
+  useImage,
+  useFrame,
+  useDicomFile,
+  useOverlayContext,
+})
+
+export default InsightViewer

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "┏━━━ BUILD ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+lerna run --scope @lunit/insight-viewer build && lerna run --scope @lunit/insight-viewer-docs doc

--- a/scripts/local-publish
+++ b/scripts/local-publish
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "┏━━━ LOCAL PUBLISH ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+lerna publish --no-git-tag-version --no-push --registry=\"http://localhost:4873/\"

--- a/scripts/local-unpublish
+++ b/scripts/local-unpublish
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "┏━━━ LOCAL PUBLISH ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+lerna exec -- npm unpublish --registry=\"http://localhost:4873/\" \"\@lunit/insight-viewer\@\$VERSION\"

--- a/scripts/local-unpublish
+++ b/scripts/local-unpublish
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo "┏━━━ LOCAL PUBLISH ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "┏━━━ LOCAL UNPUBLISH ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 lerna exec -- npm unpublish --registry=\"http://localhost:4873/\" \"\@lunit/insight-viewer\@\$VERSION\"

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+echo "┏━━━ PREPUBLISH ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+yarn run build
+cp ./packages/insight-viewer/README.md ./packages/insight-viewer/dist/README.md
+cp ./packages/insight-viewer/CHANGELOG.md ./packages/insight-viewer/dist/CHANGELOG.md
+cp ./packages/insight-viewer/LICENSE ./packages/insight-viewer/dist/LICENSE
+node ./packages/insight-viewer/SetupPackage.js

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -4,4 +4,4 @@ yarn run build
 cp ./packages/insight-viewer/README.md ./packages/insight-viewer/dist/README.md
 cp ./packages/insight-viewer/CHANGELOG.md ./packages/insight-viewer/dist/CHANGELOG.md
 cp ./packages/insight-viewer/LICENSE ./packages/insight-viewer/dist/LICENSE
-node ./packages/insight-viewer/SetupPackage.js
+node ./packages/insight-viewer/setupPackage.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -6935,10 +6935,22 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@7.1.7, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@7.1.7, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.0.3:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"


### PR DESCRIPTION
## 📝 Description
ISSUE: https://github.com/lunit-io/frontend-components/issues/185
https://github.com/lunit-io/frontend-components/pull/173 caused two problems.
### 1
The PR is to expose the sub package from the subpath, e.g. @lunit/insight-viewer/contour.
To do this, I changed the package publishing path from the package root to the dist directory.
Here the mistake is to confuse npm publish with lerna publish.
I ran the command from the package root.
```bash
cd dist && yarn lerna publish
```
But I should have published from the workspace root with lerna command, because the project is managed with Lerna and Yarn workspace.
Lerna allow to customize the published subdirectory with publishConfig.directory, so I set the publish directory to /dist. https://github.com/lunit-io/frontend-components/pull/190/commits/64f77528a213e485cf8723fb13c2467940670096

### 2
The @lunit/insight-viewer package is built with the microbundle which is a wrapper around [rollup](https://rollupjs.org/guide/en).

Whenever I build the package, this message comes up ‘Mixed default and named exports changes default export’.  But the build process succeeds, so I ignored it.

After https://github.com/lunit-io/frontend-components/pull/173, the default export of @lunit/insight-viewer does not work.
The related issue is https://github.com/developit/microbundle/issues/712#issuecomment-683794530
I created /cjs for producing CommonJS bundles. https://github.com/lunit-io/frontend-components/pull/190/commits/d115298d94f601b488d0b0c52a8fcba40dc41bbd

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

### 1. node_modules/@lunit/insight-viewer
<img width="250" alt="ttt" src="https://user-images.githubusercontent.com/81394944/150641107-b64772b9-6cf9-474e-8840-81b292c0cb49.png">

### 2. @lunit/insight-viewer' exports Object as default 

![image](https://user-images.githubusercontent.com/81394944/150641313-93f18e13-1903-4642-9664-220ffc8b34c5.png)


## 🚀 New behavior
I created a private local npm registry with [Verdaccio](https://verdaccio.org/).
And I published and tested the @lunit/insight-viewer package locally.
For publishing/unpublishing the npm package locally for testing, I added the extra npm scripts in package.json  https://github.com/lunit-io/frontend-components/pull/190/commits/1387856489def55e92c15eaf490b745b7878a636
```bash
$ yarn local-publish 
$ VERSION=${VERSION_NUMBER} yarn local-unpublish # VERSION=5.1.0-alpha.14 yarn run local-unpublish
```

###  1. node_modules/@lunit/insight-viewer

<img width="357" alt="sdsd" src="https://user-images.githubusercontent.com/81394944/150640925-0db44277-d3d1-4299-b71b-3dac7bc33b93.png">

### 2. @lunit/insight-viewer' exports Insight Viewer React Component as default 

<img width="317" alt="eeee" src="https://user-images.githubusercontent.com/81394944/150641266-cdcad7d1-60d3-4fcc-908f-f881e2b4f7d3.png">

## TO-DO
Test Workflows are needed. 
배포하기 전 로컬 테스트, 배포 후 실제로 다운로드 받아 테스트 하는 프로세스가 필요하네요. cc: @myjung-lunit @LTakhyunKim 
- Making sure that the local npm package with local registry works as expected before release PR
- Making sure that the npm package works as expected after publishing on npm

## NOTE

The way [effector](https://github.com/effector/effector ) exports subpackages looks good.
```
- /src
- /packages
```
The files in packages just points to files/src like this.
```ts
export * from '../../src/effector'
```
The npm modules are published from /packages.