### PR TITLE
Feature/multiple viewer interaction

### DIFF
--- a/apps/insight-viewer-docs/src/containers/Interaction/Base.tsx
+++ b/apps/insight-viewer-docs/src/containers/Interaction/Base.tsx
@@ -1,125 +1,13 @@
-import { Box, Text, Button, Stack } from '@chakra-ui/react'
-import InsightViewer, {
-  useInteraction,
-  useViewport,
-  useMultipleImages,
-  useFrame,
-  Interaction,
-  Wheel,
-} from '@lunit/insight-viewer'
-import CodeBlock from '../../components/CodeBlock'
-import Control from './Control'
-import WheelControl from './Control/Wheel'
-import OverlayLayer from '../../components/OverlayLayer'
-import CustomProgress from '../../components/CustomProgress'
-import { ViewerWrapper } from '../../components/Wrapper'
-import { BASE_CODE } from './Code'
-import Canvas from './Canvas'
-import { IMAGES, CODE_SANDBOX } from '../../const'
+import { Stack } from '@chakra-ui/react'
 
-const MIN_FRAME = 0
-const MAX_FRAME = IMAGES.length - 1
-const MIN_SCALE = 0.178
-const MAX_SCALE = 3
+import Image1 from './Image1'
+import Image2 from './Image2'
 
-export default function App(): JSX.Element {
-  const { loadingStates, images } = useMultipleImages({
-    wadouri: IMAGES,
-  })
-  const { frame, setFrame } = useFrame({
-    initial: 0,
-    max: images.length - 1,
-  })
-  const { interaction, setInteraction } = useInteraction()
-  const { viewport, setViewport, resetViewport } = useViewport({
-    scale: 1,
-  })
-
-  function handleChange(type: string) {
-    return (value: string) => {
-      setInteraction((prev: Interaction) => ({
-        ...prev,
-        [type]: value === 'none' ? undefined : value,
-      }))
-    }
-  }
-
-  const handleFrame: Wheel = (_, deltaY) => {
-    if (deltaY !== 0)
-      setFrame(prev =>
-        Math.min(Math.max(prev + (deltaY > 0 ? 1 : -1), MIN_FRAME), MAX_FRAME)
-      )
-  }
-
-  const handleScale: Wheel = (_, deltaY) => {
-    if (deltaY !== 0)
-      setViewport(prev => ({
-        ...prev,
-        scale: Math.min(
-          Math.max(prev.scale + (deltaY > 0 ? 0.25 : -0.25), MIN_SCALE),
-          MAX_SCALE
-        ),
-      }))
-  }
-
-  const handler = {
-    frame: handleFrame,
-    scale: handleScale,
-  }
-
-  function handleWheel(value: string) {
-    setInteraction((prev: Interaction) => ({
-      ...prev,
-      mouseWheel:
-        value === 'none' ? undefined : handler[value as keyof typeof handler],
-    }))
-  }
-
+export default function SingleFrame(): JSX.Element {
   return (
-    <Box data-cy-loaded={loadingStates[frame]}>
-      <Stack direction="row" spacing="80px" align="flex-start">
-        <Box>
-          <Control onChange={handleChange} />
-          <WheelControl onChange={handleWheel} />
-          <Box mb={6}>
-            <Text className="test">
-              frame: <span className="frame">{frame}</span>
-            </Text>
-          </Box>
-        </Box>
-        <Box>
-          <Button
-            colorScheme="blue"
-            onClick={resetViewport}
-            className="reset"
-            mb="0px"
-          >
-            Reset
-          </Button>
-        </Box>
-      </Stack>
-
-      <Stack direction="row">
-        <ViewerWrapper>
-          <InsightViewer
-            image={images[frame]}
-            interaction={interaction}
-            onViewportChange={setViewport}
-            viewport={viewport}
-            Progress={CustomProgress}
-          >
-            <OverlayLayer viewport={viewport} />
-            <Canvas viewport={viewport} />
-          </InsightViewer>
-        </ViewerWrapper>
-      </Stack>
-
-      <Box>
-        <CodeBlock
-          code={BASE_CODE}
-          codeSandbox={CODE_SANDBOX.builtInInteraction}
-        />
-      </Box>
-    </Box>
+    <Stack direction="row" spacing="24px">
+      <Image1 />
+      <Image2 />
+    </Stack>
   )
 }

--- a/apps/insight-viewer-docs/src/containers/Interaction/Image1.tsx
+++ b/apps/insight-viewer-docs/src/containers/Interaction/Image1.tsx
@@ -1,0 +1,125 @@
+import { Box, Text, Button, Stack } from '@chakra-ui/react'
+import InsightViewer, {
+  useInteraction,
+  useViewport,
+  useMultipleImages,
+  useFrame,
+  Interaction,
+  Wheel,
+} from '@lunit/insight-viewer'
+import CodeBlock from '../../components/CodeBlock'
+import Control from './Control'
+import WheelControl from './Control/Wheel'
+import OverlayLayer from '../../components/OverlayLayer'
+import CustomProgress from '../../components/CustomProgress'
+import { ViewerWrapper } from '../../components/Wrapper'
+import { BASE_CODE } from './Code'
+import Canvas from './Canvas'
+import { IMAGES, CODE_SANDBOX } from '../../const'
+
+const MIN_FRAME = 0
+const MAX_FRAME = IMAGES.length - 1
+const MIN_SCALE = 0.178
+const MAX_SCALE = 3
+
+export default function App(): JSX.Element {
+  const { loadingStates, images } = useMultipleImages({
+    wadouri: IMAGES,
+  })
+  const { frame, setFrame } = useFrame({
+    initial: 0,
+    max: images.length - 1,
+  })
+  const { interaction, setInteraction } = useInteraction()
+  const { viewport, setViewport, resetViewport } = useViewport({
+    scale: 1,
+  })
+
+  function handleChange(type: string) {
+    return (value: string) => {
+      setInteraction((prev: Interaction) => ({
+        ...prev,
+        [type]: value === 'none' ? undefined : value,
+      }))
+    }
+  }
+
+  const handleFrame: Wheel = (_, deltaY) => {
+    if (deltaY !== 0)
+      setFrame(prev =>
+        Math.min(Math.max(prev + (deltaY > 0 ? 1 : -1), MIN_FRAME), MAX_FRAME)
+      )
+  }
+
+  const handleScale: Wheel = (_, deltaY) => {
+    if (deltaY !== 0)
+      setViewport(prev => ({
+        ...prev,
+        scale: Math.min(
+          Math.max(prev.scale + (deltaY > 0 ? 0.25 : -0.25), MIN_SCALE),
+          MAX_SCALE
+        ),
+      }))
+  }
+
+  const handler = {
+    frame: handleFrame,
+    scale: handleScale,
+  }
+
+  function handleWheel(value: string) {
+    setInteraction((prev: Interaction) => ({
+      ...prev,
+      mouseWheel:
+        value === 'none' ? undefined : handler[value as keyof typeof handler],
+    }))
+  }
+
+  return (
+    <Box data-cy-loaded={loadingStates[frame]}>
+      <Stack direction="row" spacing="80px" align="flex-start">
+        <Box>
+          <Control onChange={handleChange} />
+          <WheelControl onChange={handleWheel} />
+          <Box mb={6}>
+            <Text className="test">
+              frame: <span className="frame">{frame}</span>
+            </Text>
+          </Box>
+        </Box>
+        <Box>
+          <Button
+            colorScheme="blue"
+            onClick={resetViewport}
+            className="reset"
+            mb="0px"
+          >
+            Reset
+          </Button>
+        </Box>
+      </Stack>
+
+      <Stack direction="row">
+        <ViewerWrapper>
+          <InsightViewer
+            image={images[frame]}
+            interaction={interaction}
+            onViewportChange={setViewport}
+            viewport={viewport}
+            Progress={CustomProgress}
+          >
+            <OverlayLayer viewport={viewport} />
+            <Canvas viewport={viewport} />
+          </InsightViewer>
+        </ViewerWrapper>
+      </Stack>
+
+      <Box>
+        <CodeBlock
+          code={BASE_CODE}
+          codeSandbox={CODE_SANDBOX.builtInInteraction}
+        />
+      </Box>
+    </Box>
+  )
+}

--- a/apps/insight-viewer-docs/src/containers/Interaction/Image2.tsx
+++ b/apps/insight-viewer-docs/src/containers/Interaction/Image2.tsx
@@ -1,0 +1,125 @@
+import { Box, Text, Button, Stack } from '@chakra-ui/react'
+import InsightViewer, {
+  useInteraction,
+  useViewport,
+  useMultipleImages,
+  useFrame,
+  Interaction,
+  Wheel,
+} from '@lunit/insight-viewer'
+import CodeBlock from '../../components/CodeBlock'
+import Control from './Control'
+import WheelControl from './Control/Wheel'
+import OverlayLayer from '../../components/OverlayLayer'
+import CustomProgress from '../../components/CustomProgress'
+import { ViewerWrapper } from '../../components/Wrapper'
+import { BASE_CODE } from './Code'
+import Canvas from './Canvas'
+import { IMAGES, CODE_SANDBOX } from '../../const'
+
+const MIN_FRAME = 0
+const MAX_FRAME = IMAGES.length - 1
+const MIN_SCALE = 0.178
+const MAX_SCALE = 3
+
+export default function App(): JSX.Element {
+  const { loadingStates, images } = useMultipleImages({
+    wadouri: IMAGES,
+  })
+  const { frame, setFrame } = useFrame({
+    initial: 0,
+    max: images.length - 1,
+  })
+  const { interaction, setInteraction } = useInteraction()
+  const { viewport, setViewport, resetViewport } = useViewport({
+    scale: 1,
+  })
+
+  function handleChange(type: string) {
+    return (value: string) => {
+      setInteraction((prev: Interaction) => ({
+        ...prev,
+        [type]: value === 'none' ? undefined : value,
+      }))
+    }
+  }
+
+  const handleFrame: Wheel = (_, deltaY) => {
+    if (deltaY !== 0)
+      setFrame(prev =>
+        Math.min(Math.max(prev + (deltaY > 0 ? 1 : -1), MIN_FRAME), MAX_FRAME)
+      )
+  }
+
+  const handleScale: Wheel = (_, deltaY) => {
+    if (deltaY !== 0)
+      setViewport(prev => ({
+        ...prev,
+        scale: Math.min(
+          Math.max(prev.scale + (deltaY > 0 ? 0.25 : -0.25), MIN_SCALE),
+          MAX_SCALE
+        ),
+      }))
+  }
+
+  const handler = {
+    frame: handleFrame,
+    scale: handleScale,
+  }
+
+  function handleWheel(value: string) {
+    setInteraction((prev: Interaction) => ({
+      ...prev,
+      mouseWheel:
+        value === 'none' ? undefined : handler[value as keyof typeof handler],
+    }))
+  }
+
+  return (
+    <Box data-cy-loaded={loadingStates[frame]}>
+      <Stack direction="row" spacing="80px" align="flex-start">
+        <Box>
+          <Control onChange={handleChange} />
+          <WheelControl onChange={handleWheel} />
+          <Box mb={6}>
+            <Text className="test">
+              frame: <span className="frame">{frame}</span>
+            </Text>
+          </Box>
+        </Box>
+        <Box>
+          <Button
+            colorScheme="blue"
+            onClick={resetViewport}
+            className="reset"
+            mb="0px"
+          >
+            Reset
+          </Button>
+        </Box>
+      </Stack>
+
+      <Stack direction="row">
+        <ViewerWrapper>
+          <InsightViewer
+            image={images[frame]}
+            interaction={interaction}
+            onViewportChange={setViewport}
+            viewport={viewport}
+            Progress={CustomProgress}
+          >
+            <OverlayLayer viewport={viewport} />
+            <Canvas viewport={viewport} />
+          </InsightViewer>
+        </ViewerWrapper>
+      </Stack>
+
+      <Box>
+        <CodeBlock
+          code={BASE_CODE}
+          codeSandbox={CODE_SANDBOX.builtInInteraction}
+        />
+      </Box>
+    </Box>
+  )
+}

--- a/packages/insight-viewer/src/components/LoadingProgress/index.tsx
+++ b/packages/insight-viewer/src/components/LoadingProgress/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import { Subscription, merge } from 'rxjs'
 import {
   loadingProgressMessage,
@@ -6,8 +6,6 @@ import {
 } from '../../utils/messageService'
 import { getProgress } from '../../utils/common/getProgress'
 import { ProgressComponent } from '../../types'
-
-let subscription: Subscription
 
 const style = {
   position: 'absolute',
@@ -22,6 +20,7 @@ export default function LoadingProgress({
 }: {
   Progress: ProgressComponent
 }): JSX.Element {
+  const subscriptionRef = useRef<Subscription>()
   const [{ progress, hidden }, setState] = useState<{
     progress?: number
     hidden: boolean
@@ -39,7 +38,7 @@ export default function LoadingProgress({
     let totalCount = 1
     let _progress = 0
 
-    subscription = merge(progress$, loadedCount$).subscribe(prop => {
+    subscriptionRef.current = merge(progress$, loadedCount$).subscribe(prop => {
       if (typeof prop === 'number') {
         _progress = prop
       } else {
@@ -60,7 +59,7 @@ export default function LoadingProgress({
 
     return () => {
       isCancelled = true
-      subscription.unsubscribe()
+      subscriptionRef?.current?.unsubscribe()
     }
   }, [])
 

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleClick/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleClick/index.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { fromEvent, Subscription } from 'rxjs'
 import { map, filter, tap } from 'rxjs/operators'
 import { ViewportInteraction } from '../types'
@@ -7,7 +7,6 @@ import { MOUSE_BUTTON, PRIMARY_CLICK, SECONDARY_CLICK } from '../const'
 import { preventContextMenu } from '../utils'
 import { getViewport } from '../../../utils/cornerstoneHelper'
 
-let subscription: Subscription
 type ClickType = typeof PRIMARY_CLICK | typeof SECONDARY_CLICK
 
 function getCoord(element: Element, viewport?: Viewport) {
@@ -26,6 +25,8 @@ export default function useHandleClick({
   interaction,
   viewport,
 }: ViewportInteraction): void {
+  const subscriptionRef = useRef<Subscription>()
+
   useEffect(() => {
     if (!interaction || !element) return undefined
     // Restore context menu display.
@@ -41,7 +42,7 @@ export default function useHandleClick({
     let clickType: ClickType | undefined
     if (!interaction) return undefined
 
-    subscription = mousedown$
+    subscriptionRef.current = mousedown$
       .pipe(
         tap(({ button }) => {
           // tap operator for side effect
@@ -71,7 +72,7 @@ export default function useHandleClick({
           )
       })
     return () => {
-      subscription.unsubscribe()
+      subscriptionRef?.current?.unsubscribe()
     }
   }, [element, interaction, viewport])
 

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { fromEvent, Subscription } from 'rxjs'
 import { tap, switchMap, map, takeUntil, filter } from 'rxjs/operators'
 import { Element, OnViewportChange } from '../../../types'
@@ -13,7 +13,6 @@ import { MOUSE_BUTTON, PRIMARY_DRAG, SECONDARY_DRAG } from '../const'
 import { preventContextMenu } from '../utils'
 import control from './control'
 
-let subscription: Subscription
 type DragType = typeof PRIMARY_DRAG | typeof SECONDARY_DRAG
 
 /**
@@ -91,6 +90,8 @@ export default function useHandleDrag({
   interaction,
   onViewportChange,
 }: ViewportInteraction): void {
+  const subscriptionRef = useRef<Subscription>()
+
   useEffect(() => {
     if (!interaction || !element) return undefined
     // Restore context menu display.
@@ -107,7 +108,7 @@ export default function useHandleDrag({
     const mouseup$ = fromEvent<MouseEvent>(document, 'mouseup')
     let dragType: DragType | undefined
 
-    subscription = mousedown$
+    subscriptionRef.current = mousedown$
       .pipe(
         tap(({ button }) => {
           // tap operator for side effect
@@ -155,7 +156,7 @@ export default function useHandleDrag({
       })
 
     return () => {
-      subscription.unsubscribe()
+      subscriptionRef?.current?.unsubscribe()
     }
   }, [element, interaction, onViewportChange])
 }

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleWheel/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleWheel/index.ts
@@ -1,20 +1,20 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { fromEvent, Subscription } from 'rxjs'
 import { filter, tap } from 'rxjs/operators'
 import { ViewportInteraction } from '../types'
-
-let subscription: Subscription
 
 export default function useHandleWheel({
   element,
   interaction,
   onViewportChange,
 }: ViewportInteraction): void {
+  const subscriptionRef = useRef<Subscription>()
+
   useEffect(() => {
     if (!element) return undefined
     const wheel$ = fromEvent<WheelEvent>(<HTMLDivElement>element, 'wheel')
 
-    subscription = wheel$
+    subscriptionRef.current = wheel$
       .pipe(
         filter(({ deltaY }) => deltaY !== 0),
         tap(e => {
@@ -25,7 +25,7 @@ export default function useHandleWheel({
         if (interaction?.mouseWheel) interaction?.mouseWheel(deltaX, deltaY)
       })
     return () => {
-      subscription.unsubscribe()
+      subscriptionRef?.current?.unsubscribe()
     }
   }, [interaction, element, onViewportChange])
 }


### PR DESCRIPTION
## 📝 Description

뷰어가 여러개일 때 useInteraction 동작이 정상적이지 않다.


## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

예를 들어, 뷰어1을 primaryDrag를 'pan'으로 한 후, 뷰어2의 인터랙션을 조작하고,
다시 뷰어2의 primaryDrag을 'adjust'로 변경하면, 이전의 pan과 adjust가 같이 적용된다.

Issue Number: N/A

## 🚀 New behavior

다른 뷰어의 동작과 상관없이 자유롭게 인터랙션 변경을 할 수 있다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
