### PR TITLE
Fix/annotation mode drawing

### DIFF
--- a/packages/insight-viewer/src/Viewer/AnnotationOverlay/AnnotationOverlay.types.ts
+++ b/packages/insight-viewer/src/Viewer/AnnotationOverlay/AnnotationOverlay.types.ts
@@ -1,8 +1,9 @@
-import { Annotation, LineHeadMode } from '../../types'
+import { Annotation, AnnotationMode, LineHeadMode } from '../../types'
 import { AnnotationViewerProps } from '../AnnotationViewer/AnnotationViewer.types'
 
 export interface AnnotationOverlayProps extends AnnotationViewerProps {
   isDrawing?: boolean
+  mode?: AnnotationMode
 
   /**
    *  normal has no head

--- a/packages/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
+++ b/packages/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
@@ -37,7 +37,6 @@ export function AnnotationOverlay({
         style={style}
         showOutline={showOutline}
         showAnnotationLabel={showAnnotationLabel}
-        mode={mode}
         annotationAttrs={annotationAttrs}
         onFocus={onFocus}
         onRemove={onRemove}

--- a/packages/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.types.ts
+++ b/packages/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.types.ts
@@ -1,5 +1,5 @@
 import { CSSProperties, SVGProps } from 'react'
-import { Point, AnnotationMode, Annotation } from '../../types'
+import { Point, Annotation } from '../../types'
 
 export interface AnnotationViewerProps {
   width?: number
@@ -37,12 +37,9 @@ export interface AnnotationViewerProps {
    * Default value is false
    */
   showAnnotationLabel?: boolean
-
-  mode?: AnnotationMode
 }
 
 export interface AnnotationsDrawProps extends Omit<AnnotationViewerProps, 'width' | 'height'> {
-  mode: AnnotationMode
   showOutline: boolean
   pixelToCanvas: (point: Point) => Point
 }

--- a/packages/insight-viewer/src/Viewer/AnnotationViewer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/AnnotationViewer/index.tsx
@@ -6,7 +6,6 @@ import { LineViewer } from '../LineViewer'
 import { PolygonViewer } from '../PolygonViewer'
 
 function AnnotationsDraw({
-  mode,
   annotations,
   showOutline,
   showAnnotationLabel,
@@ -40,8 +39,6 @@ function AnnotationsDraw({
       onFocus(null)
     }
 
-    if (annotation.type !== mode) return null
-
     return (
       <g
         data-cy-id={annotation.id}
@@ -66,7 +63,6 @@ export function AnnotationViewer({
   annotations,
   className,
   selectedAnnotation,
-  mode = 'polygon',
   showOutline = false,
   showAnnotationLabel = false,
   annotationAttrs,
@@ -81,7 +77,6 @@ export function AnnotationViewer({
       {annotations.length === 0 || !enabledElement
         ? null
         : AnnotationsDraw({
-            mode,
             annotations,
             selectedAnnotation,
             showOutline,


### PR DESCRIPTION
## 📝 Description

특정 mode 에서 annotation drawing 한 후 mode 이동 시
그려진 annotation 이 사라지는 버그를 수정했습니다.

위 내용은 현재 PR 에서 테스트가 어렵습니다.
annotation docs 개선 코드에서 확인 후 진행했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

특정 mode 에서 annotation drawing 한 후 mode 이동 시 그려진 annotation 이 사라집니다.

Issue Number: https://github.com/lunit-io/frontend-components/issues/221

## 🚀 New behavior

특정 mode 에서 annotation drawing 한 후 mode 이동 시 그려진 annotation 이 남아있습니다.
모드 변경 관계없이 정상적으로 drawing 이 가능합니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

## Comment

해당 PR 에서는 테스트가 불가하여, 아래 변경 사항에 대한 별도 코멘트를 작성하겠습니다.

AnnotationViewer 내 annotation.type 과 mode 가 다를 경우
early return (null) 하는 로직을 삭제했습니다.

위 로직으로 인해 기존에 그렸던 annotations 배열 중 annotation 의 타입이 polygon 인 상태에서
Line mode 로 변경하게 될 경우, 위 조건문에 의해 null 이 return 되어, 현재 설정된 mode 와 다른
type 의 annotation 이 보이지 않습니다.

위 조건문 삭제, 불필요한 mode prop 을 삭제하여 버그 해결했습니다.

브랜치의 경우, 정책이 정해지면 Merge 대상 브랜치 수정하겠습니다.