### PR TITLE
Add zoom by drag feature to interaction hook

### DIFF
--- a/apps/insight-viewer-docs/src/components/OverlayLayer/index.tsx
+++ b/apps/insight-viewer-docs/src/components/OverlayLayer/index.tsx
@@ -7,27 +7,16 @@ export default function OverlayLayer({
   viewport: Viewport
 }): JSX.Element {
   return (
-    <Box
-      position="absolute"
-      top="0"
-      left="0"
-      w="100%"
-      h="100%"
-      p="4"
-      color="blue.200"
-      textShadow="1px 1px 1px black"
-    >
+    <Box position="absolute" top="0" left="0" w="100%" h="100%" p="4" color="blue.200" textShadow="1px 1px 1px black">
       <UnorderedList>
         <ListItem>
-          scale: <span data-cy-scale>{scale}</span>
+          scale: <span data-cy-scale>{scale.toFixed(2)}</span>
         </ListItem>
         <ListItem>
-          hflip/vflip: <span data-cy-hflip>{`${hflip}`}</span> /{' '}
-          <span data-cy-vflip>{`${vflip}`}</span>
+          hflip/vflip: <span data-cy-hflip>{`${hflip}`}</span> / <span data-cy-vflip>{`${vflip}`}</span>
         </ListItem>
         <ListItem>
-          translation: <span data-cy-x>{x?.toFixed(2)}</span> /{' '}
-          <span data-cy-y>{y?.toFixed(2)}</span>
+          translation: <span data-cy-x>{x?.toFixed(2)}</span> / <span data-cy-y>{y?.toFixed(2)}</span>
         </ListItem>
         <ListItem>
           invert: <span data-cy-invert>{`${invert}`}</span>

--- a/apps/insight-viewer-docs/src/containers/Interaction/Canvas.tsx
+++ b/apps/insight-viewer-docs/src/containers/Interaction/Canvas.tsx
@@ -7,7 +7,6 @@ const style: React.CSSProperties = {
   left: 0,
   width: '100%',
   height: '100%',
-  zIndex: 10,
 }
 
 const BOX_WIDTH = 100
@@ -34,11 +33,7 @@ function drawRect({ context, canvas, x, y, scale }: Prop) {
   context.restore()
 }
 
-export default function Canvas({
-  viewport,
-}: {
-  viewport: Viewport
-}): JSX.Element {
+export default function Canvas({ viewport }: { viewport: Viewport }): JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [context, setContext] = useState<CanvasRenderingContext2D | null>(null)
 

--- a/apps/insight-viewer-docs/src/containers/Interaction/Control/index.tsx
+++ b/apps/insight-viewer-docs/src/containers/Interaction/Control/index.tsx
@@ -1,10 +1,10 @@
 import { Box, RadioGroup, Radio, Stack } from '@chakra-ui/react'
-import { DragEvent } from '@lunit/insight-viewer'
+import { DragAction } from '@lunit/insight-viewer'
 
 export default function Control({
   onChange,
 }: {
-  onChange: (type: string) => (value: DragEvent | 'none') => void
+  onChange: (type: string) => (value: DragAction | 'none') => void
 }): JSX.Element {
   return (
     <Box mb={6}>
@@ -22,6 +22,9 @@ export default function Control({
               <Radio value="adjust" className="primary-drag-adjust">
                 adjust
               </Radio>
+              <Radio value="zoom" className="primary-drag-zoom">
+                zoom
+              </Radio>
             </Stack>
           </RadioGroup>
         </Box>
@@ -37,6 +40,9 @@ export default function Control({
               </Radio>
               <Radio value="adjust" className="secondary-drag-adjust">
                 adjust
+              </Radio>
+              <Radio value="zoom" className="secondary-drag-zoom">
+                zoom
               </Radio>
             </Stack>
           </RadioGroup>

--- a/apps/insight-viewer-docs/src/containers/Interaction/Custom.tsx
+++ b/apps/insight-viewer-docs/src/containers/Interaction/Custom.tsx
@@ -37,13 +37,7 @@ export default function App(): JSX.Element {
   })
 
   const customPan: Drag = ({ viewport, delta }) => {
-    consola.info(
-      'pan',
-      viewport.translation?.x,
-      viewport.translation?.y,
-      delta.x,
-      delta.y
-    )
+    consola.info('pan', viewport.translation?.x, viewport.translation?.y, delta.x, delta.y)
 
     setViewport(prev => ({
       ...prev,
@@ -53,17 +47,19 @@ export default function App(): JSX.Element {
   }
 
   const customAdjust: Drag = ({ viewport, delta }) => {
-    consola.info(
-      'adjust',
-      viewport.voi.windowWidth,
-      viewport.voi.windowCenter,
-      delta.x,
-      delta.y
-    )
+    consola.info('adjust', viewport.voi.windowWidth, viewport.voi.windowCenter, delta.x, delta.y)
     setViewport(prev => ({
       ...prev,
       windowWidth: prev.windowWidth + delta.x / prev.scale,
       windowCenter: prev.windowCenter + delta.y / prev.scale,
+    }))
+  }
+
+  const customZoom: Drag = ({ viewport, delta }) => {
+    consola.info('zoom', viewport.scale, delta.x, delta.y)
+    setViewport(prev => ({
+      ...prev,
+      scale: prev.scale + delta.x / 100,
     }))
   }
 
@@ -84,6 +80,7 @@ export default function App(): JSX.Element {
   const customDrag = {
     pan: customPan,
     adjust: customAdjust,
+    zoom: customZoom,
   }
 
   const customClick = {
@@ -104,10 +101,7 @@ export default function App(): JSX.Element {
     return (value: string) => {
       setInteraction((prev: Interaction) => ({
         ...prev,
-        [type]:
-          value === 'none'
-            ? undefined
-            : customClick[type as keyof typeof customClick],
+        [type]: value === 'none' ? undefined : customClick[type as keyof typeof customClick],
       }))
     }
   }
@@ -147,10 +141,7 @@ export default function App(): JSX.Element {
       </Stack>
 
       <Box>
-        <CodeBlock
-          code={CUSTOM_CODE}
-          codeSandbox={CODE_SANDBOX.customInteraction}
-        />
+        <CodeBlock code={CUSTOM_CODE} codeSandbox={CODE_SANDBOX.customInteraction} />
       </Box>
     </Box>
   )

--- a/apps/insight-viewer-docs/src/containers/Interaction/Image1.tsx
+++ b/apps/insight-viewer-docs/src/containers/Interaction/Image1.tsx
@@ -45,20 +45,14 @@ export default function App(): JSX.Element {
   }
 
   const handleFrame: Wheel = (_, deltaY) => {
-    if (deltaY !== 0)
-      setFrame(prev =>
-        Math.min(Math.max(prev + (deltaY > 0 ? 1 : -1), MIN_FRAME), MAX_FRAME)
-      )
+    if (deltaY !== 0) setFrame(prev => Math.min(Math.max(prev + (deltaY > 0 ? 1 : -1), MIN_FRAME), MAX_FRAME))
   }
 
   const handleScale: Wheel = (_, deltaY) => {
     if (deltaY !== 0)
       setViewport(prev => ({
         ...prev,
-        scale: Math.min(
-          Math.max(prev.scale + (deltaY > 0 ? 0.25 : -0.25), MIN_SCALE),
-          MAX_SCALE
-        ),
+        scale: Math.min(Math.max(prev.scale + (deltaY > 0 ? 0.25 : -0.25), MIN_SCALE), MAX_SCALE),
       }))
   }
 
@@ -70,8 +64,7 @@ export default function App(): JSX.Element {
   function handleWheel(value: string) {
     setInteraction((prev: Interaction) => ({
       ...prev,
-      mouseWheel:
-        value === 'none' ? undefined : handler[value as keyof typeof handler],
+      mouseWheel: value === 'none' ? undefined : handler[value as keyof typeof handler],
     }))
   }
 
@@ -88,12 +81,7 @@ export default function App(): JSX.Element {
           </Box>
         </Box>
         <Box>
-          <Button
-            colorScheme="blue"
-            onClick={resetViewport}
-            className="reset"
-            mb="0px"
-          >
+          <Button colorScheme="blue" onClick={resetViewport} className="reset" mb="0px">
             Reset
           </Button>
         </Box>
@@ -108,17 +96,14 @@ export default function App(): JSX.Element {
             viewport={viewport}
             Progress={CustomProgress}
           >
-            <OverlayLayer viewport={viewport} />
             <Canvas viewport={viewport} />
+            <OverlayLayer viewport={viewport} />
           </InsightViewer>
         </ViewerWrapper>
       </Stack>
 
       <Box>
-        <CodeBlock
-          code={BASE_CODE}
-          codeSandbox={CODE_SANDBOX.builtInInteraction}
-        />
+        <CodeBlock code={BASE_CODE} codeSandbox={CODE_SANDBOX.builtInInteraction} />
       </Box>
     </Box>
   )

--- a/packages/insight-viewer/src/hooks/useInteraction/const.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/const.ts
@@ -1,6 +1,7 @@
 export const DRAG = {
   pan: 'pan',
   adjust: 'adjust',
+  zoom: 'zoom',
 } as const
 
 export const MOUSE_WHEEL = {

--- a/packages/insight-viewer/src/hooks/useInteraction/types.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/types.ts
@@ -1,39 +1,25 @@
-import {
-  DRAG,
-  PRIMARY_DRAG,
-  SECONDARY_DRAG,
-  PRIMARY_CLICK,
-  SECONDARY_CLICK,
-  MOUSEWHEEL,
-} from './const'
+import { DRAG, PRIMARY_DRAG, SECONDARY_DRAG, PRIMARY_CLICK, SECONDARY_CLICK, MOUSEWHEEL } from './const'
 import { CornerstoneViewport } from '../../utils/cornerstoneHelper'
 import { Element, Viewport, OnViewportChange } from '../../types'
 
-export type DragEvent = keyof typeof DRAG
+export type DragAction = keyof typeof DRAG
+/** @deprecated in flavor of DragAction */
+export type DragEvent = DragAction
 export type Click = (offsetX: number, offsetY: number) => void
-export interface Coord {
-  x: number
-  y: number
+export interface DragCoords {
+  startX: number
+  startY: number
+  deltaX: number
+  deltaY: number
 }
-export type Drag = ({
-  viewport,
-  delta,
-}: {
-  viewport: CornerstoneViewport
-  delta: Coord
-}) => void
-export type Pan = (viewport: CornerstoneViewport, delta: Coord) => Coord
-export type Adjust = (
-  viewport: CornerstoneViewport,
-  delta: Coord
-) => {
-  windowWidth: number
-  windowCenter: number
-}
+export type Drag = ({ viewport, delta }: { viewport: CornerstoneViewport; delta: { x: number; y: number } }) => void
+export type DragEventHandler = (viewport: CornerstoneViewport, dragEvent: DragCoords) => Partial<Viewport>
+
 export type Wheel = (deltaX: number, deltaY: number) => void
+
 export interface DragInteraction {
-  [PRIMARY_DRAG]: DragEvent | Drag | undefined
-  [SECONDARY_DRAG]: DragEvent | Drag | undefined
+  [PRIMARY_DRAG]: DragAction | Drag | undefined
+  [SECONDARY_DRAG]: DragAction | Drag | undefined
 }
 
 export interface ClickInteraction {

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/control.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/control.ts
@@ -10,11 +10,16 @@ const adjust: DragEventHandler = (viewport, event) => ({
   windowCenter: viewport.voi.windowCenter + event.deltaY / viewport.scale,
 })
 
+const zoom: DragEventHandler = (viewport, event) => ({
+  scale: viewport.scale + event.deltaX / 100,
+})
+
 type Control = Record<DragAction, DragEventHandler>
 
 const control: Control = {
   pan,
   adjust,
+  zoom,
 }
 
 export default control

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/control.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/control.ts
@@ -10,9 +10,16 @@ const adjust: DragEventHandler = (viewport, event) => ({
   windowCenter: viewport.voi.windowCenter + event.deltaY / viewport.scale,
 })
 
-const zoom: DragEventHandler = (viewport, event) => ({
-  scale: viewport.scale + event.deltaX / 100,
-})
+const zoom: DragEventHandler = (viewport, event) => {
+  const newScale = Math.max(0.01, viewport.scale + event.deltaX / 100)
+  const newX = viewport.translation.x + event.startX * (1 / newScale - 1 / viewport.scale)
+  const newY = viewport.translation.y + event.startY * (1 / newScale - 1 / viewport.scale)
+  return {
+    scale: newScale,
+    x: newX,
+    y: newY,
+  }
+}
 
 type Control = Record<DragAction, DragEventHandler>
 

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/control.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/control.ts
@@ -1,16 +1,16 @@
-import { DragEvent, Pan, Adjust } from '../types'
+import { DragAction, DragEventHandler } from '../types'
 
-const pan: Pan = (viewport, delta) => ({
-  x: viewport.translation.x + delta.x / viewport.scale,
-  y: viewport.translation.y + delta.y / viewport.scale,
+const pan: DragEventHandler = (viewport, event) => ({
+  x: viewport.translation.x + event.deltaX / viewport.scale,
+  y: viewport.translation.y + event.deltaY / viewport.scale,
 })
 
-const adjust: Adjust = (viewport, delta) => ({
-  windowWidth: viewport.voi.windowWidth + delta.x / viewport.scale,
-  windowCenter: viewport.voi.windowCenter + delta.y / viewport.scale,
+const adjust: DragEventHandler = (viewport, event) => ({
+  windowWidth: viewport.voi.windowWidth + event.deltaX / viewport.scale,
+  windowCenter: viewport.voi.windowCenter + event.deltaY / viewport.scale,
 })
 
-type Control = Record<DragEvent, typeof pan | typeof adjust>
+type Control = Record<DragAction, DragEventHandler>
 
 const control: Control = {
   pan,

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
@@ -111,6 +111,11 @@ export default function useHandleDrag({ element, interaction, onViewportChange }
         switchMap(start => {
           let lastX = start.pageX
           let lastY = start.pageY
+          const { top, left, width, height } = element?.getBoundingClientRect()
+          /** relative x position from center of the viewer */
+          const startX = start.pageX - (left + width / 2)
+          /** relative y position from center of the viewer */
+          const startY = start.pageY - (top + height / 2)
           return mousemove$.pipe(
             map((move: MouseEvent) => {
               move.preventDefault()
@@ -120,8 +125,8 @@ export default function useHandleDrag({ element, interaction, onViewportChange }
               lastY = move.pageY
 
               return {
-                startX: start.pageX,
-                startY: start.pageY,
+                startX,
+                startY,
                 deltaX,
                 deltaY,
               }

--- a/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
+++ b/packages/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
@@ -3,12 +3,8 @@ import { fromEvent, Subscription } from 'rxjs'
 import { tap, switchMap, map, takeUntil, filter } from 'rxjs/operators'
 import { Element, OnViewportChange } from '../../../types'
 import { formatCornerstoneViewport } from '../../../utils/common/formatViewport'
-import {
-  getViewport,
-  setViewport,
-  CornerstoneViewport,
-} from '../../../utils/cornerstoneHelper'
-import { Interaction, DragEvent, ViewportInteraction } from '../types'
+import { getViewport, setViewport, CornerstoneViewport } from '../../../utils/cornerstoneHelper'
+import { DragCoords, Interaction, DragAction, ViewportInteraction } from '../types'
 import { MOUSE_BUTTON, PRIMARY_DRAG, SECONDARY_DRAG } from '../const'
 import { preventContextMenu } from '../utils'
 import control from './control'
@@ -39,10 +35,7 @@ function handleViewportByDrag({
   dragType: DragType
   element: Element
   viewport: CornerstoneViewport
-  dragged: {
-    x: number
-    y: number
-  }
+  dragged: DragCoords
   onViewportChange?: OnViewportChange
 }): void {
   const dragHandler = interaction[dragType]
@@ -50,9 +43,8 @@ function handleViewportByDrag({
   /**
    * If a drag handler is pre-defined, call the drag control function provided by default.
    * It results in the Viewer's viewport update.
-   * @param dragEventType 'pan' | 'adjust'
    */
-  function updateViewportByDrag(dragEventType?: DragEvent): void {
+  function updateViewportByDrag(dragEventType?: DragAction): void {
     if (!dragEventType) return
 
     // If there is a viewport setter, set a new viewport which is triggered by interaction.
@@ -65,10 +57,7 @@ function handleViewportByDrag({
       // If no viewport setter, just update cornerstone viewport.
       setViewport(
         <HTMLDivElement>element,
-        formatCornerstoneViewport(
-          viewport,
-          control[dragEventType]?.(viewport, dragged)
-        )
+        formatCornerstoneViewport(viewport, control[dragEventType]?.(viewport, dragged))
       )
     }
   }
@@ -78,18 +67,20 @@ function handleViewportByDrag({
       updateViewportByDrag(dragHandler)
       break
     case 'function':
-      dragHandler({ viewport, delta: dragged })
+      dragHandler({
+        viewport,
+        delta: {
+          x: dragged.deltaX,
+          y: dragged.deltaY,
+        },
+      })
       break
     default:
       break
   }
 }
 
-export default function useHandleDrag({
-  element,
-  interaction,
-  onViewportChange,
-}: ViewportInteraction): void {
+export default function useHandleDrag({ element, interaction, onViewportChange }: ViewportInteraction): void {
   const subscriptionRef = useRef<Subscription>()
 
   useEffect(() => {
@@ -97,13 +88,9 @@ export default function useHandleDrag({
     // Restore context menu display.
     element?.removeEventListener('contextmenu', preventContextMenu)
     // No drag interaction.
-    if (!(interaction[PRIMARY_DRAG] || interaction[SECONDARY_DRAG]))
-      return undefined
+    if (!(interaction[PRIMARY_DRAG] || interaction[SECONDARY_DRAG])) return undefined
 
-    const mousedown$ = fromEvent<MouseEvent>(
-      <HTMLDivElement>element,
-      'mousedown'
-    )
+    const mousedown$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mousedown')
     const mousemove$ = fromEvent<MouseEvent>(document, 'mousemove')
     const mouseup$ = fromEvent<MouseEvent>(document, 'mouseup')
     let dragType: DragType | undefined
@@ -133,8 +120,10 @@ export default function useHandleDrag({
               lastY = move.pageY
 
               return {
-                x: deltaX,
-                y: deltaY,
+                startX: start.pageX,
+                startY: start.pageY,
+                deltaX,
+                deltaY,
               }
             }),
             takeUntil(mouseup$)

--- a/packages/insight-viewer/src/index.ts
+++ b/packages/insight-viewer/src/index.ts
@@ -25,7 +25,7 @@ export type {
   AnnotationMode,
   AnnotationViewerProps,
 } from './types'
-export type { DragEvent, Click, Drag, Wheel } from './hooks/useInteraction/types'
+export type { DragAction, DragEvent, Click, Drag, Wheel } from './hooks/useInteraction/types'
 export { useDicomFile } from './hooks/useDicomFile'
 export { useOverlayContext } from './contexts'
 export type { OverlayContext } from './contexts'


### PR DESCRIPTION
## 📝 Description

마우스 드래그 동작으로 기존에 지원하던 이동, 윈도우 조절 외에 줌 인 / 아웃을 추가합니다.
드래그를 통한 줌 방식은 애플리케이션마다 다르나, 여기서는 INSIGHT View에서 사용할 `우측으로 드래그하면 줌 인, 좌측으로 드래그하면 줌 아웃`을 구현했습니다.
줌 기준점은 영상 중앙이 아닌 마우스 드래그 시작점이며, 이 기능은 휠을 통한 줌에도 차후 적용할 예정입니다.

<img width="276" alt="스크린샷 2022-03-21 오후 3 48 03" src="https://user-images.githubusercontent.com/495412/159216080-01d3ffd4-055d-4265-8e6d-3d194b9f5f2a.png">


## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

`{ setInteraction } = useInteraction()`의 `primaryDrag`, `secondaryDrag`에 `'pan'`, `'adjust'` 만 사용 가능

## 🚀 New behavior

`'zoom'` 추가 

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

기존에 뷰어에서 익스포트하던 `DragEvent` 타입의 명명이 혼동을 가져올 수 있어 `DragAction`으로 변경하였습니다. 기존 타입은 deprecated 표시하였으며 여전히 사용 가능합니다.