### PR TITLE
Feature/measurement text position

### DIFF
--- a/apps/insight-viewer-docs/mocks/circles.ts
+++ b/apps/insight-viewer-docs/mocks/circles.ts
@@ -7,6 +7,7 @@ export const CIRCLE_MEASUREMENTS: CircleMeasurement[] = [
     type: 'circle',
     center: [305.99999999999994, 301.26562499999994],
     radius: 125.39936203984452,
+    textPoint: [454.67073925484095, 419.9363642548409],
   },
   {
     id: 2,
@@ -14,6 +15,7 @@ export const CIRCLE_MEASUREMENTS: CircleMeasurement[] = [
     type: 'circle',
     center: [519.9999999999999, 322.26562499999994],
     radius: 48.05205510693585,
+    textPoint: [613.977934016064, 386.24355901606395],
   },
   {
     id: 3,
@@ -21,6 +23,7 @@ export const CIRCLE_MEASUREMENTS: CircleMeasurement[] = [
     type: 'circle',
     center: [457.9999999999999, 477.26562499999994],
     radius: 84.43340571124682,
+    textPoint: [577.7034337370975, 566.9690587370975],
   },
   {
     id: 4,
@@ -28,5 +31,6 @@ export const CIRCLE_MEASUREMENTS: CircleMeasurement[] = [
     type: 'circle',
     center: [226.99999999999997, 519.2656249999999],
     radius: 53.03772242470448,
+    textPoint: [324.50333318519836, 586.7689581851982],
   },
 ]

--- a/apps/insight-viewer-docs/mocks/ruler.ts
+++ b/apps/insight-viewer-docs/mocks/ruler.ts
@@ -9,6 +9,7 @@ export const RULER_MEASUREMENTS: Measurement[] = [
       [213.57714285714283, 205.39428571428567],
     ],
     length: 26.13,
+    textPoint: [223.57714285714283, 225.39428571428567],
   },
   {
     id: 2,
@@ -18,6 +19,7 @@ export const RULER_MEASUREMENTS: Measurement[] = [
       [225.27999999999997, 291.7028571428571],
     ],
     length: 22.5,
+    textPoint: [235.27999999999997, 311.7028571428571],
   },
   {
     id: 3,
@@ -27,6 +29,7 @@ export const RULER_MEASUREMENTS: Measurement[] = [
       [266.23999999999995, 239.77142857142854],
     ],
     length: 41.33,
+    textPoint: [276.23999999999995, 259.77142857142854],
   },
   {
     id: 4,
@@ -36,5 +39,6 @@ export const RULER_MEASUREMENTS: Measurement[] = [
       [224.5485714285714, 366.3085714285714],
     ],
     length: 38.2,
+    textPoint: [234.5485714285714, 386.3085714285714],
   },
 ]

--- a/packages/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.types.ts
+++ b/packages/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.types.ts
@@ -2,5 +2,6 @@ import { Point, EditMode } from '../../types'
 
 export interface CircleDrawerProps {
   points: Point[]
+  textPoint: Point
   setMeasurementEditMode: (targetPoint: EditMode) => void
 }

--- a/packages/insight-viewer/src/Viewer/CircleDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/CircleDrawer/index.tsx
@@ -4,18 +4,17 @@ import React, { ReactElement } from 'react'
 import { circleStyle, textStyle } from './CircleDrawer.styles'
 import { CircleDrawerProps } from './CircleDrawer.types'
 import { getCircleRadius } from '../../utils/common/getCircleRadius'
-import { getCircleTextPosition } from '../../utils/common/getCircleTextPosition'
 import { getLineLengthWithoutImage } from '../../utils/common/getLineLengthWithoutImage'
-import { CIRCLE_TEXT_POSITION_SPACING } from '../../const'
 import { useOverlayContext } from '../../contexts'
 
-export function CircleDrawer({ points, setMeasurementEditMode }: CircleDrawerProps): ReactElement | null {
+export function CircleDrawer({ points, textPoint, setMeasurementEditMode }: CircleDrawerProps): ReactElement | null {
   const { image, pixelToCanvas } = useOverlayContext()
 
   const [startPoint, endPoint] = points.map(pixelToCanvas)
+  const [textPointX, textPointY] = pixelToCanvas(textPoint)
   const radius = getCircleRadius(points, image)
+
   const drawingRadius = getLineLengthWithoutImage(startPoint, endPoint)
-  const textPosition = getCircleTextPosition(startPoint, drawingRadius)
   const [cx, cy] = startPoint
 
   return (
@@ -27,11 +26,7 @@ export function CircleDrawer({ points, setMeasurementEditMode }: CircleDrawerPro
         cy={cy}
         r={drawingRadius}
       />
-      <text
-        style={{ ...textStyle.default }}
-        x={textPosition[0] + CIRCLE_TEXT_POSITION_SPACING.x}
-        y={textPosition[1] + CIRCLE_TEXT_POSITION_SPACING.y}
-      >
+      <text style={{ ...textStyle.default }} x={textPointX} y={textPointY}>
         {`radius: ${radius.toFixed(2)}mm`}
       </text>
     </>

--- a/packages/insight-viewer/src/Viewer/CircleViewer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/CircleViewer/index.tsx
@@ -3,23 +3,22 @@ import React, { ReactElement } from 'react'
 
 import { CircleViewerProps } from './CircleViewer.types'
 import { circleStyle, textStyle } from './CircleViewer.styles'
-import { CIRCLE_TEXT_POSITION_SPACING } from '../../const'
+
 import { calculateDistance } from '../../utils/common/calculateDistance'
-import { getCircleTextPosition } from '../../utils/common/getCircleTextPosition'
 import { useOverlayContext } from '../../contexts'
 import { Point } from '../../types'
 
 export function CircleViewer({ measurement, hoveredMeasurement }: CircleViewerProps): ReactElement {
   const { pixelToCanvas, image } = useOverlayContext()
 
-  const { id, center, radius } = measurement
+  const { id, center, radius, textPoint } = measurement
   const calculatedDistance = calculateDistance(radius, image)
   const endPoint: Point = [center[0] + (calculatedDistance ?? 0), center[1]]
   const points: [Point, Point] = [center, endPoint]
 
   const [pixelStartPoint, pixelEndPoint] = points.map(pixelToCanvas)
+  const [textPointX, textPointY] = pixelToCanvas(textPoint)
   const drawingRadius = Math.abs(pixelStartPoint[0] - pixelEndPoint[0])
-  const textPosition = getCircleTextPosition(pixelToCanvas(center), drawingRadius)
 
   const isHoveredMeasurement = measurement === hoveredMeasurement
   const [cx, cy] = pixelStartPoint
@@ -36,11 +35,7 @@ export function CircleViewer({ measurement, hoveredMeasurement }: CircleViewerPr
         cy={cy}
         r={drawingRadius}
       />
-      <text
-        style={{ ...textStyle[isHoveredMeasurement ? 'hover' : 'default'] }}
-        x={textPosition[0] + CIRCLE_TEXT_POSITION_SPACING.x}
-        y={textPosition[1] + CIRCLE_TEXT_POSITION_SPACING.y}
-      >
+      <text style={{ ...textStyle[isHoveredMeasurement ? 'hover' : 'default'] }} x={textPointX} y={textPointY}>
         {`radius: ${radius.toFixed(2)}mm`}
       </text>
     </>

--- a/packages/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
@@ -24,7 +24,7 @@ export function MeasurementDrawer({
   const svgRef = useRef<SVGSVGElement>(null)
   const drawingMode = isEditing && selectedMeasurement ? selectedMeasurement.type : mode
 
-  const { points, editPoints, setMeasurementEditMode } = useMeasurementPointsHandler({
+  const { points, editPoints, textPoint, setMeasurementEditMode } = useMeasurementPointsHandler({
     mode,
     device,
     isEditing,
@@ -37,10 +37,14 @@ export function MeasurementDrawer({
 
   return (
     <>
-      {points.length > 1 ? (
+      {points.length > 1 && textPoint != null ? (
         <svg ref={svgRef} width={width} height={height} style={{ ...svgStyle.default, ...style }} className={className}>
-          {drawingMode === 'ruler' && <RulerDrawer setMeasurementEditMode={setMeasurementEditMode} points={points} />}
-          {drawingMode === 'circle' && <CircleDrawer setMeasurementEditMode={setMeasurementEditMode} points={points} />}
+          {drawingMode === 'ruler' && (
+            <RulerDrawer setMeasurementEditMode={setMeasurementEditMode} rulerPoints={points} textPoint={textPoint} />
+          )}
+          {drawingMode === 'circle' && (
+            <CircleDrawer setMeasurementEditMode={setMeasurementEditMode} points={points} textPoint={textPoint} />
+          )}
           {editPoints && (
             <>
               <EditPointer

--- a/packages/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.types.ts
+++ b/packages/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.types.ts
@@ -1,6 +1,7 @@
 import { Point, EditMode } from '../../types'
 
 export interface RulerDrawerProps {
-  points: Point[]
+  textPoint: Point
+  rulerPoints: Point[]
   setMeasurementEditMode: (targetPoint: EditMode) => void
 }

--- a/packages/insight-viewer/src/Viewer/RulerDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/RulerDrawer/index.tsx
@@ -2,33 +2,29 @@ import React, { ReactElement } from 'react'
 
 import { RulerDrawerProps } from './RulerDrawer.types'
 import { polyline, textStyle } from './RulerDrawer.styles'
-import { RULER_TEXT_POSITION_SPACING } from '../../const'
 import { useOverlayContext } from '../../contexts'
 import { getLineLength } from '../../utils/common/getLineLength'
 
-export function RulerDrawer({ points, setMeasurementEditMode }: RulerDrawerProps): ReactElement | null {
+export function RulerDrawer({ rulerPoints, textPoint, setMeasurementEditMode }: RulerDrawerProps): ReactElement | null {
   const { image, pixelToCanvas } = useOverlayContext()
 
-  const canvasPoints = points.map(pixelToCanvas)
-  const [endPointX, endPointY] = canvasPoints[1]
+  const canvasPoints = rulerPoints.map(pixelToCanvas)
+  const [textPointX, textPointY] = pixelToCanvas(textPoint)
+
   const linePoints = canvasPoints
     .map(point => {
       const [x, y] = point
       return `${x},${y}`
     })
     .join(' ')
-  const lineLength = image ? `${getLineLength(points[0], points[1], image)?.toFixed(2)}mm` : null
+  const lineLength = image ? `${getLineLength(rulerPoints[0], rulerPoints[1], image)?.toFixed(2)}mm` : null
 
   return (
     <>
       {canvasPoints && canvasPoints.length > 0 && image ? (
         <>
           <polyline onMouseDown={() => setMeasurementEditMode('move')} style={polyline.default} points={linePoints} />
-          <text
-            style={{ ...textStyle.default }}
-            x={endPointX + RULER_TEXT_POSITION_SPACING.x}
-            y={endPointY + RULER_TEXT_POSITION_SPACING.y}
-          >
+          <text style={{ ...textStyle.default }} x={textPointX} y={textPointY}>
             {lineLength}
           </text>
         </>

--- a/packages/insight-viewer/src/Viewer/RulerViewer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/RulerViewer/index.tsx
@@ -2,13 +2,14 @@ import React, { ReactElement } from 'react'
 
 import { RulerViewerProps } from './RulerViewer.types'
 import { textStyle, polylineStyle } from '../MeasurementViewer/MeasurementViewer.styles'
-import { RULER_TEXT_POSITION_SPACING } from '../../const'
+
 import { useOverlayContext } from '../../contexts'
 
 export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProps): ReactElement {
   const { pixelToCanvas } = useOverlayContext()
 
-  const { id, points, length } = measurement
+  const { id, points, length, textPoint } = measurement
+
   const canvasPoints = points.map(pixelToCanvas)
 
   const poygonPoints: string = canvasPoints
@@ -17,7 +18,8 @@ export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProp
       return `${x},${y}`
     })
     .join(' ')
-  const [endPointX, endPointY] = canvasPoints[1]
+
+  const [textPointX, textPointY] = pixelToCanvas(textPoint)
   const isHoveredMeasurement = measurement === hoveredMeasurement
 
   return (
@@ -31,11 +33,7 @@ export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProp
         points={poygonPoints}
       />
       {length && (
-        <text
-          style={{ ...textStyle[isHoveredMeasurement ? 'hover' : 'default'] }}
-          x={endPointX + RULER_TEXT_POSITION_SPACING.x}
-          y={endPointY + RULER_TEXT_POSITION_SPACING.y}
-        >
+        <text style={{ ...textStyle[isHoveredMeasurement ? 'hover' : 'default'] }} x={textPointX} y={textPointY}>
           {length}mm
         </text>
       )}

--- a/packages/insight-viewer/src/const/index.ts
+++ b/packages/insight-viewer/src/const/index.ts
@@ -50,7 +50,7 @@ export const RULER_TEXT_POSITION_SPACING = {
 
 export const CIRCLE_TEXT_POSITION_SPACING = {
   x: 60,
-  y: 30,
+  y: 10,
 }
 
 // The ruler min length is 0.1mm

--- a/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/types.ts
+++ b/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/types.ts
@@ -16,6 +16,7 @@ export interface UseMeasurementPointsHandlerProps {
 
 export interface UseMeasurementPointsHandlerReturnType {
   points: Point[]
+  textPoint: Point | null
   editPoints: EditPoints | null
   setMeasurementEditMode: (targetPoint: EditMode) => void
 }

--- a/packages/insight-viewer/src/types/index.ts
+++ b/packages/insight-viewer/src/types/index.ts
@@ -130,6 +130,7 @@ export interface MeasurementBase {
   type: MeasurementMode
   lineWidth?: number
   dataAttrs?: { [attr: string]: string }
+  textPoint: Point
 }
 
 export interface RulerMeasurement extends MeasurementBase {

--- a/packages/insight-viewer/src/utils/common/getCircleTextPosition.ts
+++ b/packages/insight-viewer/src/utils/common/getCircleTextPosition.ts
@@ -1,9 +1,11 @@
-import { CIRCLE_TEXT_POINT_ANGLE } from '../../const'
+import { CIRCLE_TEXT_POINT_ANGLE, CIRCLE_TEXT_POSITION_SPACING } from '../../const'
 import { Point } from '../../types'
 
-export function getCircleTextPosition(point: Point, radius: number): [number, number] {
-  const positionX = Math.sin((CIRCLE_TEXT_POINT_ANGLE * Math.PI) / 180) * radius + point[0]
-  const positionY = -Math.cos((CIRCLE_TEXT_POINT_ANGLE * Math.PI) / 180) * radius + point[1]
+export function getCircleTextPosition(point: Point, radius: number): Point {
+  const positionX =
+    Math.sin((CIRCLE_TEXT_POINT_ANGLE * Math.PI) / 180) * radius + point[0] + CIRCLE_TEXT_POSITION_SPACING.x
+  const positionY =
+    -Math.cos((CIRCLE_TEXT_POINT_ANGLE * Math.PI) / 180) * radius + point[1] + CIRCLE_TEXT_POSITION_SPACING.y
 
   return [positionX, positionY]
 }

--- a/packages/insight-viewer/src/utils/common/getDrewMeasurement.ts
+++ b/packages/insight-viewer/src/utils/common/getDrewMeasurement.ts
@@ -5,6 +5,7 @@ import { Point, Measurement, MeasurementMode } from '../../types'
 
 export function getDrewMeasurement(
   points: Point[],
+  textPoint: Point,
   mode: MeasurementMode,
   measurements: Measurement[],
   image: Image | null
@@ -25,8 +26,10 @@ export function getDrewMeasurement(
       type: 'circle',
       center: startPoint,
       radius: getCircleRadius([startPoint, endPoint], image),
+      textPoint,
     }
   } else {
+    // Ruler mode
     const lineLength = image ? Number(getLineLength(startPoint, endPoint, image)?.toFixed(2)) : null
 
     drewMeasurement = {
@@ -34,6 +37,7 @@ export function getDrewMeasurement(
       type: 'ruler',
       points: [startPoint, endPoint],
       length: lineLength,
+      textPoint,
     }
   }
 

--- a/packages/insight-viewer/src/utils/common/getRulerTextPosition.ts
+++ b/packages/insight-viewer/src/utils/common/getRulerTextPosition.ts
@@ -1,0 +1,9 @@
+import { Point } from '../../types'
+import { RULER_TEXT_POSITION_SPACING } from '../../const'
+
+export function getRulerTextPosition(point: Point): Point {
+  const positionX = point[0] + RULER_TEXT_POSITION_SPACING.x
+  const positionY = point[1] + RULER_TEXT_POSITION_SPACING.y
+
+  return [positionX, positionY]
+}


### PR DESCRIPTION
## 📝 Description

Measurement text move 기능 구현 전 MeasurementBase interface 에 textPoint 필드 추가 및
해당 값으로 Measurement text 를 표기하는 기능 구현했습니다.

textPoint 를 추가한 이유는 추후 text 에 대한 별도의 move 기능 구현 시, 
각 Measurement 는 text position 에 대한 고유한 좌표값을 가지고 있어야하며,
move 기능 활용 시 위 좌표값이 변경되어 move 기능을 구현할 수 있을 것으로 판단하여 textPoint 필드를 추가했습니다.

(Measurement text move 기능 구현 시 변경점이 굉장히 많아 PR 을 분리했습니다.)

## ✔️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Circle, Ruler viewer, drawer component 에서 별도의 계산식을 통해 text 좌표계를 구한 후 화면에 렌더링하는 방식

## 🚀 New behavior

useMeasurementPointsHandler hook 에서 textPoint 에 대한 값을 관리, drawing 시 좌표계를 해당 hook 에서 구한 후
Render component 레벨에서는 prop 으로 받아서 렌더링하는 방식으로 변경했습니다.

**getRulerTextPosition util function 을 추가했습니다.** a04e3af  
- _간단하게 더하는 연산을 진행하지만, circle 도 text position 을 구하는 별도의 util function 이 존재하므로,
   text position 을 구할 때 function depth 를 일정하게 유지하기 위해 추가했습니다._

**MeasurementBase interface 에 textPoint 를 추가했습니다.** ccc8c2c
- _text move 기능 구현 시 각 Measurement 에는 text position 값이 필요하다고 판단하여 추가했습니다._

**getDrewMeasurement util function 에 textPoint 값을 반영했습니다.** f3ad21c

**useMeasurementPointsHandler hook 에서 textPoint state 를 추가, addDrawingPoint function 실행 시
textPoint 에 대한 값도 업데이트 하도록 로직을 추가했습니다**. 4ef95e7
- _addDrawingPoint 의 경우, mouse move 이벤트 발생 시 실행하므로 drawing 시 업데이트가 가능합니다._

**CircleDrawer 에 textPoint prop 을 추가, 별도로 render component 에서 값을 구하는 방식을 대체하였습니다.** 603ed06

**RulerDrawer 에 textPoint prop 을 추가, 별도로 render component 에서 값을 구하는 방식을 대체하였습니다.** bb91f88

**Circle, Ruler Viewer 내에서도 prop 으로 전달 받은 measurement 내 textPoint field 로 text position 를 대체했습니다.** 4efc3ac, 2ed1f85


## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

- useMeasurement hook 에서 `initialMeasurement` 에 대한 값을 사용하고 있었던 경우, textPoint 에 대한 필드를 추가해야합니다. 
  이를 추가하지 않고 사용할 경우, 예상 밖의 오류가 발생할 수 있습니다.
