### PR TITLE
Refactor/measurement pixel to canvas hook

### DIFF
--- a/packages/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.types.ts
+++ b/packages/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.types.ts
@@ -2,6 +2,7 @@ import { Point, EditMode } from '../../types'
 
 export interface CircleDrawerProps {
   points: Point[]
+  canvasPoints: Point[]
   textPoint: Point
   setMeasurementEditMode: (targetPoint: EditMode) => void
 }

--- a/packages/insight-viewer/src/Viewer/CircleDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/CircleDrawer/index.tsx
@@ -7,15 +7,18 @@ import { getCircleRadius } from '../../utils/common/getCircleRadius'
 import { getLineLengthWithoutImage } from '../../utils/common/getLineLengthWithoutImage'
 import { useOverlayContext } from '../../contexts'
 
-export function CircleDrawer({ points, textPoint, setMeasurementEditMode }: CircleDrawerProps): ReactElement | null {
-  const { image, pixelToCanvas } = useOverlayContext()
+export function CircleDrawer({
+  points,
+  canvasPoints,
+  textPoint,
+  setMeasurementEditMode,
+}: CircleDrawerProps): ReactElement | null {
+  const { image } = useOverlayContext()
 
-  const [startPoint, endPoint] = points.map(pixelToCanvas)
-  const [textPointX, textPointY] = pixelToCanvas(textPoint)
+  const [cx, cy] = canvasPoints[0]
+
   const radius = getCircleRadius(points, image)
-
-  const drawingRadius = getLineLengthWithoutImage(startPoint, endPoint)
-  const [cx, cy] = startPoint
+  const drawingRadius = getLineLengthWithoutImage(canvasPoints[0], canvasPoints[1])
 
   return (
     <>
@@ -26,7 +29,7 @@ export function CircleDrawer({ points, textPoint, setMeasurementEditMode }: Circ
         cy={cy}
         r={drawingRadius}
       />
-      <text style={{ ...textStyle.default }} x={textPointX} y={textPointY}>
+      <text style={{ ...textStyle.default }} x={textPoint[0]} y={textPoint[1]}>
         {`radius: ${radius.toFixed(2)}mm`}
       </text>
     </>

--- a/packages/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
@@ -24,7 +24,7 @@ export function MeasurementDrawer({
   const svgRef = useRef<SVGSVGElement>(null)
   const drawingMode = isEditing && selectedMeasurement ? selectedMeasurement.type : mode
 
-  const { points, editPoints, textPoint, setMeasurementEditMode } = useMeasurementPointsHandler({
+  const { points, canvasPoints, editPoints, textPoint, setMeasurementEditMode } = useMeasurementPointsHandler({
     mode,
     device,
     isEditing,
@@ -40,10 +40,20 @@ export function MeasurementDrawer({
       {points.length > 1 && textPoint != null ? (
         <svg ref={svgRef} width={width} height={height} style={{ ...svgStyle.default, ...style }} className={className}>
           {drawingMode === 'ruler' && (
-            <RulerDrawer setMeasurementEditMode={setMeasurementEditMode} rulerPoints={points} textPoint={textPoint} />
+            <RulerDrawer
+              setMeasurementEditMode={setMeasurementEditMode}
+              points={points}
+              canvasPoints={canvasPoints}
+              textPoint={textPoint}
+            />
           )}
           {drawingMode === 'circle' && (
-            <CircleDrawer setMeasurementEditMode={setMeasurementEditMode} points={points} textPoint={textPoint} />
+            <CircleDrawer
+              setMeasurementEditMode={setMeasurementEditMode}
+              points={points}
+              canvasPoints={canvasPoints}
+              textPoint={textPoint}
+            />
           )}
           {editPoints && (
             <>

--- a/packages/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.types.ts
+++ b/packages/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.types.ts
@@ -1,7 +1,8 @@
 import { Point, EditMode } from '../../types'
 
 export interface RulerDrawerProps {
+  points: Point[]
   textPoint: Point
-  rulerPoints: Point[]
+  canvasPoints: Point[]
   setMeasurementEditMode: (targetPoint: EditMode) => void
 }

--- a/packages/insight-viewer/src/Viewer/RulerDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/RulerDrawer/index.tsx
@@ -5,11 +5,13 @@ import { polyline, textStyle } from './RulerDrawer.styles'
 import { useOverlayContext } from '../../contexts'
 import { getLineLength } from '../../utils/common/getLineLength'
 
-export function RulerDrawer({ rulerPoints, textPoint, setMeasurementEditMode }: RulerDrawerProps): ReactElement | null {
-  const { image, pixelToCanvas } = useOverlayContext()
-
-  const canvasPoints = rulerPoints.map(pixelToCanvas)
-  const [textPointX, textPointY] = pixelToCanvas(textPoint)
+export function RulerDrawer({
+  points,
+  textPoint,
+  canvasPoints,
+  setMeasurementEditMode,
+}: RulerDrawerProps): ReactElement | null {
+  const { image } = useOverlayContext()
 
   const linePoints = canvasPoints
     .map(point => {
@@ -17,14 +19,14 @@ export function RulerDrawer({ rulerPoints, textPoint, setMeasurementEditMode }: 
       return `${x},${y}`
     })
     .join(' ')
-  const lineLength = image ? `${getLineLength(rulerPoints[0], rulerPoints[1], image)?.toFixed(2)}mm` : null
+  const lineLength = image ? `${getLineLength(points[0], points[1], image)?.toFixed(2)}mm` : null
 
   return (
     <>
       {canvasPoints && canvasPoints.length > 0 && image ? (
         <>
           <polyline onMouseDown={() => setMeasurementEditMode('move')} style={polyline.default} points={linePoints} />
-          <text style={{ ...textStyle.default }} x={textPointX} y={textPointY}>
+          <text style={{ ...textStyle.default }} x={textPoint[0]} y={textPoint[1]}>
             {lineLength}
           </text>
         </>

--- a/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -23,6 +23,7 @@ export default function useMeasurementPointsHandler({
   onSelectMeasurement,
 }: UseMeasurementPointsHandlerProps): UseMeasurementPointsHandlerReturnType {
   const [points, setPoints] = useState<Point[]>([])
+  const [canvasPoints, setCanvasPoints] = useState<Point[]>([])
   const [textPoint, setTextPoint] = useState<Point | null>(null)
   const [editPoint, setEditPoint] = useState<Point | null>(null)
   const [editMode, setEditMode] = useState<EditMode | null>(null)
@@ -33,9 +34,10 @@ export default function useMeasurementPointsHandler({
   const isMeasurementEditing = isEditing && selectedMeasurement && editMode
 
   useEffect(() => {
-    const pixelPoints = points.map(pixelToCanvas)
-    const editPoints = getEditPointPosition(pixelPoints, selectedMeasurement)
+    const convertedPoints = points.map(pixelToCanvas)
+    const editPoints = getEditPointPosition(convertedPoints, selectedMeasurement)
 
+    setCanvasPoints(convertedPoints)
     setEditTargetPoints(editPoints)
   }, [image, points, mode, selectedMeasurement, pixelToCanvas])
 
@@ -139,5 +141,11 @@ export default function useMeasurementPointsHandler({
     addDrewElement: addDrewMeasurement,
   })
 
-  return { points, textPoint, editPoints: editTargetPoints, setMeasurementEditMode }
+  return {
+    points,
+    canvasPoints,
+    editPoints: editTargetPoints,
+    textPoint: textPoint ? pixelToCanvas(textPoint) : null,
+    setMeasurementEditMode,
+  }
 }

--- a/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/types.ts
+++ b/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/types.ts
@@ -16,6 +16,7 @@ export interface UseMeasurementPointsHandlerProps {
 
 export interface UseMeasurementPointsHandlerReturnType {
   points: Point[]
+  canvasPoints: Point[]
   textPoint: Point | null
   editPoints: EditPoints | null
   setMeasurementEditMode: (targetPoint: EditMode) => void


### PR DESCRIPTION
## 📝 Description

Ruler, Circle Drawer component 내에서 pixelToCanvas 좌표계 계산 로직이 각각 반복되어 적용하는 부분 리팩토링 했습니다.
`useMeasurementPointsHandler` hook 에서 pixelToCanvas 를 적용한 canvasPoints 를 return 하여
이를 각 Drawer component 에서 prop 으로 전달 받아 사용하는 방식으로 리팩토링 진행했습니다.

관련 코드 리뷰 링크
1. https://github.com/lunit-io/frontend-components/pull/252#issuecomment-1145622868
2. https://github.com/lunit-io/frontend-components/pull/252#issuecomment-1145872302

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

각 Drawer component 에서 pixelToCanvas 를 호출하여 좌표계를 각각 계산하는 방식입니다. 

## 🚀 New behavior

`useMeasurementPointsHandler` hook 에서 pixelToCanvas 를 적용한 값을 return 하여
이를 각 Drawer 에서 prop 으로 전달 받아서 해당 값을 사용하도록 리팩토링 했습니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
