### PR TITLE
Refactor/measurement points

### DIFF
--- a/packages/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.types.ts
+++ b/packages/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.types.ts
@@ -1,7 +1,7 @@
 import { Point, EditMode } from '../../types'
 
 export interface CircleDrawerProps {
-  points: Point[]
+  points: [Point, Point]
   textPoint: Point
   setMeasurementEditMode: (targetPoint: EditMode) => void
 }

--- a/packages/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
@@ -37,7 +37,7 @@ export function MeasurementDrawer({
 
   return (
     <>
-      {points.length > 1 && textPoint != null ? (
+      {points && textPoint ? (
         <svg ref={svgRef} width={width} height={height} style={{ ...svgStyle.default, ...style }} className={className}>
           {drawingMode === 'ruler' && (
             <RulerDrawer setMeasurementEditMode={setMeasurementEditMode} rulerPoints={points} textPoint={textPoint} />

--- a/packages/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.types.ts
+++ b/packages/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.types.ts
@@ -2,6 +2,6 @@ import { Point, EditMode } from '../../types'
 
 export interface RulerDrawerProps {
   textPoint: Point
-  rulerPoints: Point[]
+  rulerPoints: [Point, Point]
   setMeasurementEditMode: (targetPoint: EditMode) => void
 }

--- a/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -22,7 +22,7 @@ export default function useMeasurementPointsHandler({
   addMeasurement,
   onSelectMeasurement,
 }: UseMeasurementPointsHandlerProps): UseMeasurementPointsHandlerReturnType {
-  const [points, setPoints] = useState<Point[]>([])
+  const [points, setPoints] = useState<[Point, Point] | null>(null)
   const [textPoint, setTextPoint] = useState<Point | null>(null)
   const [editPoint, setEditPoint] = useState<Point | null>(null)
   const [editMode, setEditMode] = useState<EditMode | null>(null)
@@ -33,6 +33,8 @@ export default function useMeasurementPointsHandler({
   const isMeasurementEditing = isEditing && selectedMeasurement && editMode
 
   useEffect(() => {
+    if (points == null) return
+
     const pixelPoints = points.map(pixelToCanvas)
     const editPoints = getEditPointPosition(pixelPoints, selectedMeasurement)
 
@@ -61,14 +63,14 @@ export default function useMeasurementPointsHandler({
       return
     }
 
-    setPoints([point])
+    setPoints([point, point])
   }
 
   const addDrawingPoint = (point: Point) => {
     setPoints(prevPoints => {
       const isPrepareEditing = isEditing && selectedMeasurement && !editMode
 
-      if (prevPoints.length === 0 || isPrepareEditing) return prevPoints
+      if (prevPoints == null || isPrepareEditing) return prevPoints
 
       if (isEditing && selectedMeasurement && editMode && editPoint) {
         const editedPoints = getMeasurementEditingPoints(
@@ -89,7 +91,9 @@ export default function useMeasurementPointsHandler({
     })
 
     setTextPoint(() => {
-      if (points.length < 2) return null
+      if (points == null) {
+        return points
+      }
 
       if (mode === 'ruler') {
         return getRulerTextPosition(point)
@@ -107,21 +111,19 @@ export default function useMeasurementPointsHandler({
       return
     }
 
-    setPoints([])
+    setPoints(null)
     setEditPoint(null)
     setEditMode(null)
     onSelectMeasurement(null)
   }
 
   const addDrewMeasurement = () => {
-    if (isMeasurementEditing) return
+    if (isMeasurementEditing || points == null || textPoint == null) return
 
-    if (points.length > 1 && textPoint) {
-      const drawingMode = isEditing && selectedMeasurement ? selectedMeasurement.type : mode
-      const drewMeasurement = getDrewMeasurement(points, textPoint, drawingMode, measurements, image)
+    const drawingMode = isEditing && selectedMeasurement ? selectedMeasurement.type : mode
+    const drewMeasurement = getDrewMeasurement(points, textPoint, drawingMode, measurements, image)
 
-      addMeasurement(drewMeasurement)
-    }
+    addMeasurement(drewMeasurement)
   }
 
   const setMeasurementEditMode = (targetPoint: EditMode) => {

--- a/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -96,7 +96,7 @@ export default function useMeasurementPointsHandler({
       }
 
       if (mode === 'ruler') {
-        return getRulerTextPosition(point)
+        return getRulerTextPosition(points[1])
       }
       // mode === 'circle'
       const drawingRadius = getLineLengthWithoutImage(points[0], points[1])

--- a/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/types.ts
+++ b/packages/insight-viewer/src/hooks/useMeasurementPointsHandler/types.ts
@@ -15,7 +15,7 @@ export interface UseMeasurementPointsHandlerProps {
 }
 
 export interface UseMeasurementPointsHandlerReturnType {
-  points: Point[]
+  points: [Point, Point] | null
   textPoint: Point | null
   editPoints: EditPoints | null
   setMeasurementEditMode: (targetPoint: EditMode) => void

--- a/packages/insight-viewer/src/utils/common/getMeasurementDrawingPoints.ts
+++ b/packages/insight-viewer/src/utils/common/getMeasurementDrawingPoints.ts
@@ -1,6 +1,10 @@
 import { Point, MeasurementMode } from '../../types'
 
-export function getMeasurementDrawingPoints(prevPoints: Point[], currentPoint: Point, mode: MeasurementMode): Point[] {
+export function getMeasurementDrawingPoints(
+  prevPoints: [Point, Point],
+  currentPoint: Point,
+  mode: MeasurementMode
+): [Point, Point] {
   if (mode === 'ruler' || mode === 'circle') {
     return [prevPoints[0], currentPoint]
   }

--- a/packages/insight-viewer/src/utils/common/getMeasurementEditingPoints.ts
+++ b/packages/insight-viewer/src/utils/common/getMeasurementEditingPoints.ts
@@ -3,13 +3,13 @@ import { Point, EditMode, MeasurementMode } from '../../types'
 import { getMovedPoints } from './getMovedPoints'
 
 export function getMeasurementEditingPoints(
-  prevPoints: Point[],
+  prevPoints: [Point, Point],
   currentPoint: Point,
   editPoint: Point,
   editMode: EditMode,
   mode: MeasurementMode,
   setEditPoint: Dispatch<SetStateAction<Point | null>>
-): Point[] {
+): [Point, Point] {
   if (mode === 'ruler' && editMode === 'startPoint') {
     return [currentPoint, prevPoints[1]]
   }

--- a/packages/insight-viewer/src/utils/common/getMovedPoints.ts
+++ b/packages/insight-viewer/src/utils/common/getMovedPoints.ts
@@ -1,19 +1,19 @@
 import { Point } from '../../types'
 
 interface GetMoveRulerPointsProp {
-  prevPoints: Point[]
+  prevPoints: [Point, Point]
   editStartPoint: Point
   currentPoint: Point
 }
 
-export function getMovedPoints({ prevPoints, editStartPoint, currentPoint }: GetMoveRulerPointsProp): Point[] {
+export function getMovedPoints({ prevPoints, editStartPoint, currentPoint }: GetMoveRulerPointsProp): [Point, Point] {
   const [currentX, currentY] = currentPoint
   const [startEditX, startEditY] = editStartPoint
 
   const deltaX = currentX - startEditX
   const deltaY = currentY - startEditY
 
-  const movedPoints = prevPoints.map(point => [point[0] + deltaX, point[1] + deltaY] as Point)
+  const movedPoints = prevPoints.map(point => [point[0] + deltaX, point[1] + deltaY]) as [Point, Point]
 
   return movedPoints
 }

--- a/packages/insight-viewer/src/utils/common/getMovedPoints.ts
+++ b/packages/insight-viewer/src/utils/common/getMovedPoints.ts
@@ -1,7 +1,7 @@
 import { Point } from '../../types'
 
 interface GetMoveRulerPointsProp {
-  prevPoints: [Point, Point]
+  prevPoints: Point[]
   editStartPoint: Point
   currentPoint: Point
 }


### PR DESCRIPTION
## 📝 Description

Measurement 좌표값 타입을 `Point[]` 에서 `[Point, Point]` 로 변경했습니다.
Measurement text position 이동 기능 구현, `*Drawer component` 내 계산 로직 삭제 리팩토링 작업 전
선행되어야할 작업으로 판단하여 진행했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Measurement 에서 사용하는 좌표계 타입이 `Point[]` 로 지정했습니다.
이에 따라 해당 좌표값 사용 시 불필요한 length 체크 로직이 필요합니다.

## 🚀 New behavior

Measurement 에서 사용하는 좌표계 타입을 `[Point, Point]` 로 지정했습니다.
`([x: number, y: number], [x: number, y: number])` 형태로 `start point`, `end point` 값을 가지고 있습니다.
이를 통해 불필요한 length 체크 로직을 제거할 수 있으며, 보다 명확한 타입을 지정할 수 있습니다.

useMeasurementPointsHandler hook 의 points state 타입을 `[Point, Point]` 로 수정했습니다. [0fe4bb4](https://github.com/lunit-io/frontend-components/pull/256/commits/0fe4bb43b97ec9f6c754fc6738f6029ffe7361da)

getMeasurementEditingPoints, getMeasurementDrawingPoints util function 의 
prevPoints 타입을 `[Point, Point]` 로 수정했습니다.
이와 더불어 return 값도 `[Point, Point]` 로 수정했습니다. [f8c5750](https://github.com/lunit-io/frontend-components/pull/256/commits/f8c5750d4044637783318ae6f126ba13b41f0307), [460833e](https://github.com/lunit-io/frontend-components/pull/256/commits/460833eb02208e7dac0a21461c45e68040562b63)

Ruler, Circle Drawer Points prop type 을 `[Point, Point]` 으로 수정했습니다. [f1ef01e](https://github.com/lunit-io/frontend-components/pull/256/commits/f1ef01e47b82ae111504eb518327ffa8aa811e92), [b9f71d3](https://github.com/lunit-io/frontend-components/pull/256/commits/b9f71d3ae1a55097f8feb0490d0385e674772583)

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
