### PR TITLE
Feature/annotation cursor style

### DIFF
--- a/packages/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.styles.ts
+++ b/packages/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.styles.ts
@@ -15,15 +15,18 @@ export const polyline: ViewerStyle = {
     fill: 'transparent',
     strokeWidth: '3px',
     stroke: '#FAFAFB',
+    cursor: 'grab',
   },
   outline: {
     stroke: '#000000',
     strokeWidth: '4px',
     fill: 'transparent',
+    cursor: 'grab',
   },
   select: {
     stroke: '#00FFF0',
     strokeWidth: '3px',
     fill: 'transparent',
+    cursor: 'grab',
   },
 }

--- a/packages/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.styles.ts
+++ b/packages/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.styles.ts
@@ -25,6 +25,20 @@ export const textStyle: ViewerStyle = {
     lineHeight: LINE_HEIGHT,
     fontWeight: 600,
     textAnchor: 'middle',
+    cursor: 'pointer',
+  },
+  hover: {
+    fill: '#00FFF0',
+    paintOrder: 'stroke',
+    stroke: '#000000',
+    strokeWidth: '1px',
+    strokeLinecap: 'butt',
+    strokeLinejoin: 'miter',
+    fontSize: TEXT_SIZE,
+    lineHeight: LINE_HEIGHT,
+    fontWeight: 600,
+    textAnchor: 'middle',
+    cursor: 'pointer',
   },
   select: {
     fill: '#00FFF0',
@@ -87,6 +101,12 @@ export const textBoxStyle: ViewerStyle = {
   default: {
     fill: 'transparent',
     stroke: 'transparent',
+    cursor: 'pointer',
+  },
+  hover: {
+    fill: 'transparent',
+    stroke: 'rgb(0, 201, 234)',
+    strokeWidth: '1px',
     cursor: 'pointer',
   },
   select: {

--- a/packages/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.styles.ts
+++ b/packages/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.styles.ts
@@ -37,6 +37,7 @@ export const textStyle: ViewerStyle = {
     lineHeight: LINE_HEIGHT,
     fontWeight: 600,
     textAnchor: 'middle',
+    cursor: 'grab',
   },
 }
 
@@ -45,16 +46,19 @@ export const polygonStyle: ViewerStyle = {
     fill: 'transparent',
     strokeWidth: '3px',
     stroke: '#FAFAFB',
+    cursor: 'pointer',
   },
   outline: {
     fill: 'transparent',
     strokeWidth: '4px',
     stroke: '#000000',
+    cursor: 'pointer',
   },
   hoveredOutline: {
     fill: 'transparent',
     strokeWidth: '3px',
     stroke: '#99999B',
+    cursor: 'pointer',
   },
 }
 
@@ -63,16 +67,19 @@ export const polylineStyle: ViewerStyle = {
     strokeWidth: '3px',
     stroke: '#ffffff',
     fill: 'transparent',
+    cursor: 'pointer',
   },
   outline: {
     fill: 'transparent',
     strokeWidth: '4px',
     stroke: '#000000',
+    cursor: 'pointer',
   },
   hoveredOutline: {
     fill: 'transparent',
     strokeWidth: '3px',
     stroke: '#99999B',
+    cursor: 'pointer',
   },
 }
 
@@ -80,10 +87,12 @@ export const textBoxStyle: ViewerStyle = {
   default: {
     fill: 'transparent',
     stroke: 'transparent',
+    cursor: 'pointer',
   },
   select: {
     fill: 'transparent',
     stroke: 'rgb(0, 201, 234)',
     strokeWidth: '1px',
+    cursor: 'grab',
   },
 }

--- a/packages/insight-viewer/src/Viewer/TextViewer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/TextViewer/index.tsx
@@ -16,7 +16,7 @@ export function TextViewer({ annotation, hoveredAnnotation }: TextViewerProps): 
     <>
       <text
         style={{
-          ...textStyle[isHoveredAnnotation ? 'select' : 'default'],
+          ...textStyle[isHoveredAnnotation ? 'hover' : 'default'],
           textAnchor: 'start',
           dominantBaseline: 'hanging',
         }}
@@ -30,7 +30,7 @@ export function TextViewer({ annotation, hoveredAnnotation }: TextViewerProps): 
         ))}
       </text>
       <rect
-        style={{ ...textBoxStyle[isHoveredAnnotation ? 'select' : 'default'] }}
+        style={{ ...textBoxStyle[isHoveredAnnotation ? 'hover' : 'default'] }}
         x={start[0]}
         y={start[1]}
         width={dimensions[0]}


### PR DESCRIPTION
## 📝 Description

Annotation hover, select 에 대한 cursor style 을 적용했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Edit Point 를 제외하고는 기본 cursor 스타일을 유지하고 있습니다.

## 🚀 New behavior

hover, select 에 대한 cursor 스타일을 적용했습니다.

hover 는 `pointer`, select 는 `grab` 을 적용했습니다 

AnnotationDrawer component 에 cursor grab 스타일을 추가했습니다. 054dbd1

AnnotationViewer component 에 cursor pointer, grab 스타일을 적용했습니다. 0b5b6ec

text, textbox style hover 을 추가했습니다.
이는 select, hover 시 cursor 아이콘을 분리하기 위함입니다. 2d68e7e

TextViewer component 에 isHoveredAnnotation 일 경우, select 가 아닌 hover 스타일을 적용하도록 수정했습니다. 0abb676

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
