### PR TITLE
fix(viewer): show polygon closing line while editing

### DIFF
--- a/packages/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
@@ -63,6 +63,7 @@ export function AnnotationDrawer({
             <PolylineDrawer
               points={points}
               isSelectedMode={isSelectedAnnotation}
+              isPolygonSelected={selectedAnnotation?.type === 'polygon'}
               lineHead={lineHead}
               setAnnotationEditMode={setAnnotationEditMode}
             />

--- a/packages/insight-viewer/src/Viewer/PolylineDrawer/PolylineDrawer.types.ts
+++ b/packages/insight-viewer/src/Viewer/PolylineDrawer/PolylineDrawer.types.ts
@@ -5,4 +5,5 @@ export interface PolylineDrawerProps {
   isSelectedMode: boolean
   lineHead: LineHeadMode
   setAnnotationEditMode: (mode: EditMode) => void
+  isPolygonSelected?: boolean
 }

--- a/packages/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
@@ -32,6 +32,15 @@ export function PolylineDrawer({
     return arrowPoints
   }
 
+  const closingPoints = points
+    .filter((point, index) => {
+      if (index === 0 || index === points.length - 1) {
+        return true
+      }
+      return false
+    })
+    .map(point => pixelToCanvas(point))
+
   return (
     <>
       {points && points.length > 0 && (
@@ -53,6 +62,26 @@ export function PolylineDrawer({
             onMouseDown={() => setAnnotationEditMode('move')}
             points={polylinePoints}
           />
+          {isSelectedMode && (
+            <>
+              <line
+                style={polyline.outline}
+                x1={closingPoints[0][0]}
+                y1={closingPoints[0][1]}
+                x2={closingPoints[1][0]}
+                y2={closingPoints[1][1]}
+                onMouseDown={() => setAnnotationEditMode('move')}
+              />
+              <line
+                style={polyline.select}
+                x1={closingPoints[0][0]}
+                y1={closingPoints[0][1]}
+                x2={closingPoints[1][0]}
+                y2={closingPoints[1][1]}
+                onMouseDown={() => setAnnotationEditMode('move')}
+              />
+            </>
+          )}
         </>
       )}
     </>

--- a/packages/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
@@ -33,7 +33,7 @@ export function PolylineDrawer({
   }
 
   const closingPoints = points
-    .filter((point, index) => {
+    .filter((_, index) => {
       if (index === 0 || index === points.length - 1) {
         return true
       }

--- a/packages/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
@@ -9,6 +9,7 @@ export function PolylineDrawer({
   lineHead,
   points,
   isSelectedMode,
+  isPolygonSelected,
   setAnnotationEditMode,
 }: PolylineDrawerProps): ReactElement {
   const { pixelToCanvas } = useOverlayContext()
@@ -32,56 +33,30 @@ export function PolylineDrawer({
     return arrowPoints
   }
 
-  const closingPoints = points
-    .filter((_, index) => {
-      if (index === 0 || index === points.length - 1) {
-        return true
-      }
-      return false
-    })
-    .map(point => pixelToCanvas(point))
+  const PolylineElement = (props: React.SVGProps<SVGPolygonElement | SVGPolylineElement>) =>
+    isPolygonSelected ? <polygon {...props} /> : <polyline {...props} />
 
   return (
     <>
       {points && points.length > 0 && (
         <>
-          <polyline
+          <PolylineElement
             style={polyline.outline}
             onMouseDown={() => setAnnotationEditMode('move')}
             points={polylinePoints}
           />
           {lineHead === 'arrow' && (
-            <polyline
+            <PolylineElement
               style={polyline[isSelectedMode ? 'select' : 'default']}
               onMouseDown={() => setAnnotationEditMode('move')}
               points={getArrowPoints()}
             />
           )}
-          <polyline
+          <PolylineElement
             style={polyline[isSelectedMode ? 'select' : 'default']}
             onMouseDown={() => setAnnotationEditMode('move')}
             points={polylinePoints}
           />
-          {isSelectedMode && (
-            <>
-              <line
-                style={polyline.outline}
-                x1={closingPoints[0][0]}
-                y1={closingPoints[0][1]}
-                x2={closingPoints[1][0]}
-                y2={closingPoints[1][1]}
-                onMouseDown={() => setAnnotationEditMode('move')}
-              />
-              <line
-                style={polyline.select}
-                x1={closingPoints[0][0]}
-                y1={closingPoints[0][1]}
-                x2={closingPoints[1][0]}
-                y2={closingPoints[1][1]}
-                onMouseDown={() => setAnnotationEditMode('move')}
-              />
-            </>
-          )}
         </>
       )}
     </>

--- a/packages/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
+++ b/packages/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
@@ -5,6 +5,12 @@ import { polyline } from '../AnnotationDrawer/AnnotationDrawer.styles'
 import { getArrowPosition } from '../../utils/common/getArrowPosition'
 import { useOverlayContext } from '../../contexts'
 
+const PolylineElement = ({
+  isPolygon,
+  ...rest
+}: React.SVGProps<SVGPolygonElement | SVGPolylineElement> & { isPolygon: boolean }) =>
+  isPolygon ? <polygon {...rest} /> : <polyline {...rest} />
+
 export function PolylineDrawer({
   lineHead,
   points,
@@ -33,26 +39,26 @@ export function PolylineDrawer({
     return arrowPoints
   }
 
-  const PolylineElement = (props: React.SVGProps<SVGPolygonElement | SVGPolylineElement>) =>
-    isPolygonSelected ? <polygon {...props} /> : <polyline {...props} />
-
   return (
     <>
       {points && points.length > 0 && (
         <>
           <PolylineElement
+            isPolygon={!!isPolygonSelected}
             style={polyline.outline}
             onMouseDown={() => setAnnotationEditMode('move')}
             points={polylinePoints}
           />
           {lineHead === 'arrow' && (
             <PolylineElement
+              isPolygon={!!isPolygonSelected}
               style={polyline[isSelectedMode ? 'select' : 'default']}
               onMouseDown={() => setAnnotationEditMode('move')}
               points={getArrowPoints()}
             />
           )}
           <PolylineElement
+            isPolygon={!!isPolygonSelected}
             style={polyline[isSelectedMode ? 'select' : 'default']}
             onMouseDown={() => setAnnotationEditMode('move')}
             points={polylinePoints}


### PR DESCRIPTION
## 📝 Description

Polygon Annotation을 edit 모드에서 선택 시 끝점 연결이 사라지는 문제를 해결했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

<img width="229" alt="스크린샷 2022-06-20 오전 11 57 50" src="https://user-images.githubusercontent.com/495412/174517452-5defe1f7-14c6-4e8d-9b01-3f32f5505c5b.png">


## 🚀 New behavior

<img width="201" alt="스크린샷 2022-06-20 오전 11 57 37" src="https://user-images.githubusercontent.com/495412/174517467-e7499141-e779-4532-8abc-e7501443e80b.png">


## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
