### PR TITLE
VIEWER-21 / add arrow head mode radio to Annotation docs

### DIFF
--- a/apps/insight-viewer-docs/src/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/src/containers/Annotation/Drawer/index.tsx
@@ -8,6 +8,7 @@ import InsightViewer, {
   useViewport,
   AnnotationOverlay,
   AnnotationMode,
+  LineHeadMode,
 } from '@lunit/insight-viewer'
 import { IMAGES } from '../../../const'
 
@@ -22,6 +23,7 @@ const DEFAULT_SIZE = { width: 700, height: 700 }
 
 function AnnotationDrawerContainer(): JSX.Element {
   const [annotationMode, setAnnotationMode] = useState<AnnotationMode>('polygon')
+  const [lineHeadMode, setLineHeadMode] = useState<LineHeadMode>('normal')
   const [isEditing, setIsEditing] = useState(false)
 
   const { loadingState, image } = useImage({
@@ -43,6 +45,10 @@ function AnnotationDrawerContainer(): JSX.Element {
     setAnnotationMode(mode)
   }
 
+  const handleLineHeadModeButtonChange = (lineHead: LineHeadMode) => {
+    setLineHeadMode(lineHead)
+  }
+
   const handleEditModeChange = (event: ChangeEvent<HTMLInputElement>) => {
     setIsEditing(event.target.checked)
   }
@@ -57,12 +63,19 @@ function AnnotationDrawerContainer(): JSX.Element {
       </Box>
       <RadioGroup onChange={handleAnnotationModeClick} value={annotationMode}>
         <Stack direction="row">
-          <p style={{ marginRight: '10px' }}>Select Head mode</p>
+          <p style={{ marginRight: '10px' }}>Select Annotation mode</p>
           <Radio value="polygon">Polygon</Radio>
           <Radio value="line">line</Radio>
           <Radio value="freeLine">Free Line</Radio>
           <Radio value="text">Text</Radio>
           <Radio value="circle">Circle - Not implemented yet</Radio>
+        </Stack>
+      </RadioGroup>
+      <RadioGroup onChange={handleLineHeadModeButtonChange} value={lineHeadMode}>
+        <Stack direction="row">
+          <p style={{ marginRight: '10px' }}>Select Line Head mode</p>
+          <Radio value="normal">normal</Radio>
+          <Radio value="arrow">arrow</Radio>
         </Stack>
       </RadioGroup>
       <Resizable style={style} defaultSize={DEFAULT_SIZE}>
@@ -73,6 +86,7 @@ function AnnotationDrawerContainer(): JSX.Element {
               isEditing={isEditing}
               width={700}
               height={700}
+              lineHead={lineHeadMode}
               mode={annotationMode}
               annotations={annotations}
               hoveredAnnotation={hoveredAnnotation}


### PR DESCRIPTION
## 📝 Description

Annotation docs 에서 arrow head mode 를 선택할 수 있는 radio 를 추가했습니다.
기본 normal 상태이며 arrow 를 선택할 시, arrow line 을 그릴 수 있습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

arrow head mode 를 선택할 수 없어 normal line 만 그릴 수 있습니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-21

## 🚀 New behavior

arrow head mode 를 선택할 수 있어, normal, arrow line 을 그릴 수 있습니다. ebbb851

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
