### PR TITLE
VIEWER-27 / Add timeout option to useImage

### DIFF
--- a/apps/insight-viewer-docs/src/containers/Basic/Code.ts
+++ b/apps/insight-viewer-docs/src/containers/Basic/Code.ts
@@ -11,6 +11,7 @@ export default function App() {
     wadouri: IMAGE_ID,
     onError,            // optional
     requestInterceptor, // optional
+    timeout,            // optional, default is 60 * 1000
     /**
      * required if you want to support more transfer syntaxes
      * see: https://github.com/cornerstonejs/cornerstoneWADOImageLoader/issues/403
@@ -50,6 +51,7 @@ export default function App() {
     web: IMAGE_ID,
     onError,            // optional
     requestInterceptor, // optional
+    timeout,            // optional, default is 60 * 1000
   })
 
   return (

--- a/packages/insight-viewer/src/const/index.ts
+++ b/packages/insight-viewer/src/const/index.ts
@@ -17,6 +17,7 @@ export const CONFIG = {
   Progress: undefined,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   requestInterceptor: (_request: Request): void => {},
+  timeout: 60 * 1000,
 }
 
 export const LOADING_STATE = {

--- a/packages/insight-viewer/src/hooks/useImage/index.ts
+++ b/packages/insight-viewer/src/hooks/useImage/index.ts
@@ -21,6 +21,7 @@ interface UseImage {
       ImageId & {
         onImageLoaded?: OnImageLoaded
         loaderOptions?: WadoImageLoaderOptions
+        timeout?: number
       }
   ): {
     loadingState: LoadingState
@@ -39,6 +40,7 @@ interface UseImage {
 export const useImage: UseImage = ({
   requestInterceptor = CONFIG.requestInterceptor,
   onError = CONFIG.onError,
+  timeout = CONFIG.timeout,
   onImageLoaded = noop,
   loaderOptions,
   ...rest
@@ -63,6 +65,7 @@ export const useImage: UseImage = ({
       imageScheme,
       requestInterceptor,
       onError,
+      timeout,
     })
       .then(res => {
         dispatch({
@@ -75,7 +78,7 @@ export const useImage: UseImage = ({
         }, 0)
       })
       .catch(() => dispatch({ type: LOADING_STATE.FAIL }))
-  }, [hasLoader, imageId, imageScheme, requestInterceptor, onError])
+  }, [hasLoader, imageId, imageScheme, requestInterceptor, onError, timeout])
 
   return imageLoad
 }

--- a/packages/insight-viewer/src/hooks/useImage/loadCornerstoneImage.ts
+++ b/packages/insight-viewer/src/hooks/useImage/loadCornerstoneImage.ts
@@ -7,10 +7,16 @@ import { GetImage } from './types'
 /**
  * It calls cornerstone.js loadImage. It is pluggable for unit test.
  */
-export const loadCornerstoneImage: GetImage = async ({ imageId, imageScheme, requestInterceptor }) => {
+export const loadCornerstoneImage: GetImage = async ({ imageId, imageScheme, requestInterceptor, timeout }) => {
   try {
     const loadedImage = await loadImage(imageId, {
-      loader: imageScheme === IMAGE_LOADER_SCHEME.DICOMFILE ? undefined : getHttpClient(requestInterceptor),
+      loader:
+        imageScheme === IMAGE_LOADER_SCHEME.DICOMFILE
+          ? undefined
+          : getHttpClient({
+              requestInterceptor,
+              timeout,
+            }),
     })
 
     return loadedImage

--- a/packages/insight-viewer/src/hooks/useImage/loadImage.ts
+++ b/packages/insight-viewer/src/hooks/useImage/loadImage.ts
@@ -13,8 +13,10 @@ interface LoadImage {
     imageScheme,
     requestInterceptor,
     onError,
+    timeout,
   }: Required<Props> & {
     imageScheme: ImageLoaderScheme
+    timeout: number
   }): Promise<ImageWithoutKey>
 }
 
@@ -24,12 +26,13 @@ interface LoadImage {
  * @returns Promise<CornerstoneImage>.
  * @throws If image fetching fails.
  */
-export const loadImage: LoadImage = async ({ imageId, imageScheme, requestInterceptor, onError }) => {
+export const loadImage: LoadImage = async ({ imageId, imageScheme, requestInterceptor, onError, timeout }) => {
   try {
     const cornerStoneImage = await loadCornerstoneImage({
       imageId,
       imageScheme,
       requestInterceptor,
+      timeout,
     })
 
     return cornerStoneImage

--- a/packages/insight-viewer/src/hooks/useImage/types.ts
+++ b/packages/insight-viewer/src/hooks/useImage/types.ts
@@ -9,4 +9,5 @@ export type GetImage = (arg: {
   imageId: string
   imageScheme: ImageLoaderScheme
   requestInterceptor: RequestInterceptor
+  timeout: number
 }) => Promise<ImageWithoutKey>

--- a/packages/insight-viewer/src/hooks/useMultipleImages/index.ts
+++ b/packages/insight-viewer/src/hooks/useMultipleImages/index.ts
@@ -9,7 +9,7 @@ import { useLoadImages } from './useLoadImages'
 import { ImagesLoadState, OnImagesLoaded } from './types'
 
 interface UseMultipleImages {
-  (props: Partial<HTTP> & ImageId & { onImagesLoaded?: OnImagesLoaded }): ImagesLoadState
+  (props: Partial<HTTP> & ImageId & { onImagesLoaded?: OnImagesLoaded; timeout?: number }): ImagesLoadState
 }
 
 /**
@@ -23,6 +23,7 @@ interface UseMultipleImages {
 export const useMultipleImages: UseMultipleImages = ({
   requestInterceptor = CONFIG.requestInterceptor,
   onError = CONFIG.onError,
+  timeout = CONFIG.timeout,
   onImagesLoaded = noop,
   ...rest
 }) => {
@@ -32,6 +33,7 @@ export const useMultipleImages: UseMultipleImages = ({
     ...rest,
     onError,
     requestInterceptor,
+    timeout,
     onImagesLoaded: onImagesLoadedRef.current,
   })
 

--- a/packages/insight-viewer/src/hooks/useMultipleImages/loadCornerstoneImages.ts
+++ b/packages/insight-viewer/src/hooks/useMultipleImages/loadCornerstoneImages.ts
@@ -4,14 +4,25 @@ import { IMAGE_LOADER_SCHEME } from '../../const'
 import { getHttpClient } from '../../utils/httpClient'
 import { ImageWithoutKey } from '../../Viewer/types'
 
-interface GetLoadImage {
-  (image: string, imageScheme: ImageLoaderScheme, requestInterceptor: RequestInterceptor): Promise<ImageWithoutKey>
+interface GetImage {
+  (arg: {
+    imageId: string
+    imageScheme: ImageLoaderScheme
+    requestInterceptor: RequestInterceptor
+    timeout: number
+  }): Promise<ImageWithoutKey>
 }
 
 /**
  * It calls cornerstone.js loadImage. It is pluggable for unit test.
  */
-export const loadCornerstoneImages: GetLoadImage = (image, imageScheme, requestInterceptor) =>
-  loadImage(image, {
-    loader: imageScheme === IMAGE_LOADER_SCHEME.DICOMFILE ? undefined : getHttpClient(requestInterceptor),
+export const loadCornerstoneImages: GetImage = ({ imageId, imageScheme, requestInterceptor, timeout }) =>
+  loadImage(imageId, {
+    loader:
+      imageScheme === IMAGE_LOADER_SCHEME.DICOMFILE
+        ? undefined
+        : getHttpClient({
+            requestInterceptor,
+            timeout,
+          }),
   })

--- a/packages/insight-viewer/src/hooks/useMultipleImages/loadImages.ts
+++ b/packages/insight-viewer/src/hooks/useMultipleImages/loadImages.ts
@@ -17,6 +17,7 @@ interface LoadImages {
     images: string[]
     imageScheme: ImageLoaderScheme
     requestInterceptor: RequestInterceptor
+    timeout: number
   }): Observable<Loaded>
 }
 
@@ -26,7 +27,7 @@ interface LoadImages {
  * @returns Observable<{ image, loaded }>. image is cornerstone image. loaded is the numbe of loaded images.
  * @throws If image fetching fails.
  */
-export const loadImages: LoadImages = ({ images, imageScheme, requestInterceptor }) => {
+export const loadImages: LoadImages = ({ images, imageScheme, requestInterceptor, timeout }) => {
   let loaded = 0
   // Should send message before loading starts, because subscriber needs total value.
   loadedCountMessageMessage.sendMessage({
@@ -36,7 +37,7 @@ export const loadImages: LoadImages = ({ images, imageScheme, requestInterceptor
 
   return from(images).pipe(
     // Sequential Requests.
-    concatMap(image => loadCornerstoneImages(image, imageScheme, requestInterceptor)),
+    concatMap(imageId => loadCornerstoneImages({ imageId, imageScheme, requestInterceptor, timeout })),
     map(image => {
       loaded += 1
       loadedCountMessageMessage.sendMessage({

--- a/packages/insight-viewer/src/hooks/useMultipleImages/useLoadImages.ts
+++ b/packages/insight-viewer/src/hooks/useMultipleImages/useLoadImages.ts
@@ -11,7 +11,11 @@ import { getImageIdsAndScheme } from './getImageIdsAndScheme'
 import { Image } from '../../Viewer/types'
 
 interface UseLoadImages {
-  ({ onError, requestInterceptor, ...rest }: HTTP & ImageId & { onImagesLoaded?: OnImagesLoaded }): ImagesLoadState
+  ({
+    onError,
+    requestInterceptor,
+    ...rest
+  }: HTTP & ImageId & { onImagesLoaded?: OnImagesLoaded; timeout: number }): ImagesLoadState
 }
 
 interface State {
@@ -31,7 +35,13 @@ let _imageSeriesKey: string // Detect whether the image series are changed.
  * @returns <{ images, loadingStates }> images are CornerstoneImages.
  *  loadingStates are <'initial'|'loading'|'success'|'fail'>[]
  */
-export const useLoadImages: UseLoadImages = ({ onError, requestInterceptor, onImagesLoaded = noop, ...rest }) => {
+export const useLoadImages: UseLoadImages = ({
+  onError,
+  requestInterceptor,
+  onImagesLoaded = noop,
+  timeout,
+  ...rest
+}) => {
   const { ids: imageIds, scheme: imageScheme } = getImageIdsAndScheme(rest)
   const [{ loadingStates }, setState] = useState<State>({
     loadingStates: getLoadingStateMap(Array.isArray(imageIds) ? imageIds.length : 0),
@@ -59,7 +69,7 @@ export const useLoadImages: UseLoadImages = ({ onError, requestInterceptor, onIm
     // Update _imageSeriesKey When the image series are changed.
     _imageSeriesKey = uid()
 
-    loadImages({ images: imageIds, imageScheme, requestInterceptor }).subscribe({
+    loadImages({ images: imageIds, imageScheme, requestInterceptor, timeout }).subscribe({
       next: ({ image, loaded }: Loaded) => {
         const newImage = { ...image, _imageSeriesKey }
 
@@ -84,7 +94,7 @@ export const useLoadImages: UseLoadImages = ({ onError, requestInterceptor, onIm
         onImagesLoaded()
       },
     })
-  }, [imageIds, imageScheme, onError, onImagesLoaded, requestInterceptor, hasLoader])
+  }, [imageIds, imageScheme, onError, onImagesLoaded, requestInterceptor, hasLoader, timeout])
 
   return {
     images: imagesRef.current,

--- a/packages/insight-viewer/src/utils/httpClient/index.ts
+++ b/packages/insight-viewer/src/utils/httpClient/index.ts
@@ -3,27 +3,27 @@ import { loadingProgressMessage } from '../messageService'
 import { RequestInterceptor } from '../../types'
 
 type HttpClient = (url: string) => Promise<ArrayBuffer>
-type GetHttpClient = (requestInterceptor: RequestInterceptor) => HttpClient
+type HttpClientOptions = {
+  requestInterceptor: RequestInterceptor
+  timeout: number
+}
+type GetHttpClient = (options: HttpClientOptions) => HttpClient
 
-export const getHttpClient: GetHttpClient = requestInterceptor => {
+export const getHttpClient: GetHttpClient = options => {
   const httpClient: HttpClient = async url => {
     const http = ky.create({
+      timeout: options.timeout,
       hooks: {
         beforeRequest: [
           request => {
-            requestInterceptor(request)
+            options.requestInterceptor(request)
           },
         ],
       },
       onDownloadProgress: async progress => {
-        const noContentLength =
-          progress.percent === 0 &&
-          progress.totalBytes === 0 &&
-          progress.transferredBytes > 0
+        const noContentLength = progress.percent === 0 && progress.totalBytes === 0 && progress.transferredBytes > 0
 
-        loadingProgressMessage.sendMessage(
-          noContentLength ? 100 : Math.round(progress.percent * 100)
-        )
+        loadingProgressMessage.sendMessage(noContentLength ? 100 : Math.round(progress.percent * 100))
       },
     })
 


### PR DESCRIPTION
## 📝 Description

`useImage()` 및 `useMultipleImages()` 사용 시 기본 타임아웃인 10초를 60초로 늘리고, `timeout` 옵션으로 변경 가능하게 합니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

이미지 로딩이 10초 이상 걸리면 실패합니다.

Issue Number: [VIEWER-27]

## 🚀 New behavior

이미지 로딩이 60초 이상 걸리면 실패하며, timeout 옵션으로 변경 가능합니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.


[VIEWER-27]: https://lunit.atlassian.net/browse/VIEWER-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ