### PR TITLE
VIEWER-29 / Delete headPoints field, add hasArrowHead field to Line Annotation

### DIFF
--- a/apps/insight-viewer-docs/mocks/lines.ts
+++ b/apps/insight-viewer-docs/mocks/lines.ts
@@ -11,6 +11,7 @@ export const LINE_ANNOTATIONS: LineAnnotation[] = [
       [185.05142857142854, 183.05142857142854],
       [305.7371428571428, 188.17142857142855],
     ],
+    hasArrowHead: true,
   },
   {
     id: 2,
@@ -21,6 +22,7 @@ export const LINE_ANNOTATIONS: LineAnnotation[] = [
       [263.3142857142857, 248.87999999999997],
       [370.1028571428571, 197.67999999999998],
     ],
+    hasArrowHead: false,
   },
   {
     id: 3,
@@ -31,6 +33,7 @@ export const LINE_ANNOTATIONS: LineAnnotation[] = [
       [155.79428571428568, 267.1657142857143],
       [264.7771428571428, 297.88571428571424],
     ],
+    hasArrowHead: true,
   },
   {
     id: 4,
@@ -41,5 +44,6 @@ export const LINE_ANNOTATIONS: LineAnnotation[] = [
       [350.35428571428565, 256.92571428571426],
       [283.79428571428565, 352.7428571428571],
     ],
+    hasArrowHead: false,
   },
 ]

--- a/packages/insight-viewer/src/types/index.ts
+++ b/packages/insight-viewer/src/types/index.ts
@@ -97,7 +97,7 @@ export interface LineAnnotation extends AnnotationBase {
   type: 'line'
   points: [Point, Point]
 
-  headPoints?: Point[]
+  hasArrowHead: boolean
 }
 
 export interface FreeLineAnnotation extends AnnotationBase {

--- a/packages/insight-viewer/src/types/index.ts
+++ b/packages/insight-viewer/src/types/index.ts
@@ -97,7 +97,7 @@ export interface LineAnnotation extends AnnotationBase {
   type: 'line'
   points: [Point, Point]
 
-  hasArrowHead: boolean
+  hasArrowHead?: boolean
 }
 
 export interface FreeLineAnnotation extends AnnotationBase {

--- a/packages/insight-viewer/src/utils/common/getDrewAnnotation.ts
+++ b/packages/insight-viewer/src/utils/common/getDrewAnnotation.ts
@@ -1,5 +1,4 @@
 import polylabel from 'polylabel'
-import { getArrowPosition } from './getArrowPosition'
 import { getCircleRadius } from './getCircleRadius'
 import { Annotation, AnnotationMode, LineHeadMode, Point } from '../../types'
 import { Image } from '../../Viewer/types'
@@ -36,7 +35,7 @@ export function getDrewAnnotation(
       ...defaultAnnotationInfo,
       type: mode,
       points: [points[0], points[1]],
-      headPoints: lineHead === 'arrow' ? getArrowPosition(points) : undefined,
+      hasArrowHead: lineHead === 'arrow',
     }
   } else if (mode === 'text') {
     drewAnnotation = {

--- a/packages/insight-viewer/src/utils/common/getPolyProps.ts
+++ b/packages/insight-viewer/src/utils/common/getPolyProps.ts
@@ -44,7 +44,7 @@ export function getPolyViewerInfo({
     .join(' ')
 
   const headPoints: string | null =
-    annotation.type === 'line' && annotation?.headPoints
+    annotation.type === 'line' && annotation.hasArrowHead
       ? getArrowPosition(canvasPoints)
           .map(point => {
             const [x, y] = point


### PR DESCRIPTION
## 📝 Description

Line Annotation 의 headPoints field 값을 삭제한 후, hasArrowHead field 를 추가했습니다.
위 방식을 통해 사용자 입장에서는 mock data 구성 시 arrow head 에 대한 별도의 계산을 할 필요가 없습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

기존에는 headPoints field 내에 arrow head points 좌표계를 들고 있었습니다.
이를 기반으로 pixelToCanvas 를 적용하여 arrow head 를 drawing 했습니다.
위 방식으로 인해 Dicom Image 에 따라 arrow head 의 비율이 다르게 표기됩니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-22, https://lunit.atlassian.net/browse/VIEWER-29

## 🚀 New behavior

사용하지 않는 headPoints field 를 삭제한 후 arrow mode 일 때 drawing 했는지 여부를 알 수 있는
hasArrowHead field 를 추가하여 arrow head 계산 여부를 결정합니다.

## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

기존 line head 의 mock data 가 있을 경우 수정이 필요합니다. 
headPoints field 삭제해야합니다.

