### PR TITLE
feat(viewer): add line spacing and apply line annotation label position

### DIFF
--- a/packages/insight-viewer/src/const/index.ts
+++ b/packages/insight-viewer/src/const/index.ts
@@ -44,6 +44,11 @@ export const ERROR_MESSAGE = {
   ENABLED_ELEMENT_NOT_READY: 'enabledElement value is null, Please check the enabledElement value.',
 } as const
 
+export const LINE_TEXT_POSITION_SPACING = {
+  x: 2,
+  y: 5,
+}
+
 export const RULER_TEXT_POSITION_SPACING = {
   x: 10,
   y: 15,

--- a/packages/insight-viewer/src/utils/common/getDrewAnnotation.ts
+++ b/packages/insight-viewer/src/utils/common/getDrewAnnotation.ts
@@ -2,6 +2,7 @@ import polylabel from 'polylabel'
 import { getCircleRadius } from './getCircleRadius'
 import { Annotation, AnnotationMode, LineHeadMode, Point } from '../../types'
 import { Image } from '../../Viewer/types'
+import { LINE_TEXT_POSITION_SPACING } from '../../const'
 
 export function getDrewAnnotation(
   image: Image | null,
@@ -33,6 +34,7 @@ export function getDrewAnnotation(
   } else if (mode === 'line') {
     drewAnnotation = {
       ...defaultAnnotationInfo,
+      labelPosition: [xPosition - LINE_TEXT_POSITION_SPACING.x, yPosition - LINE_TEXT_POSITION_SPACING.y],
       type: mode,
       points: [points[0], points[1]],
       hasArrowHead: lineHead === 'arrow',


### PR DESCRIPTION
## 📝 Description

Line Annotation Label position 이 start point 와 근접하게 위치하고 있습니다.
이로 인해 arrow mode 일 때 arrow head 가 잘 보이지 않는 문제가 발생하기에,
적절한 간격을 추가하여 이를 해결하고자 합니다.

Ruler 에 사용한 간격을 사용하려 했는데, Ruler 는 Line 과 달리 polylabel 라이브러리를 사용하지 
않아 간격의 차이가 존재하네요. 이는 Ruler text position 에 polylabel 을 적용하여
같은 값을 공유할 수 있도록 개선할 예정입니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

기존 Line Annotation 의 label position 은 start point 에 근접해있습니다.
이로 인해 arrow head 가 가려지는 문제가 발생합니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-28
<img width="328" alt="스크린샷 2022-08-01 오후 6 54 44" src="https://user-images.githubusercontent.com/88369343/182123278-587a7746-9b7e-452b-9c59-41c708154ad5.png">

## 🚀 New behavior

Line Annotation 에 적절한 간격을 적용하여 위 문제를 해결했습니다.

<img width="322" alt="스크린샷 2022-08-01 오후 6 55 39" src="https://user-images.githubusercontent.com/88369343/182123436-d474891a-e44b-4f97-8f41-e3f3dd3d0928.png">


## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
