### PR TITLE
fix(viewer-docs): wrong hostname in loader worker setting

### DIFF
--- a/apps/insight-viewer-docs/src/containers/Basic/Code.ts
+++ b/apps/insight-viewer-docs/src/containers/Basic/Code.ts
@@ -19,8 +19,8 @@ export default function App() {
     loaderOptions: {
       webWorkerManagerOptions: {
         webWorkerTaskPaths: [
-          'http://localhost:3000/workers/610.bundle.min.worker.js',
-          'http://localhost:3000/workers/888.bundle.min.worker.js',
+          \`\${window.location.origin}/workers/610.bundle.min.worker.js\`,
+          \`\${window.location.origin}/workers/888.bundle.min.worker.js\`,
         ],
         taskConfiguration: {
           decodeTask: {

--- a/apps/insight-viewer-docs/src/containers/Basic/ImageSelectableViewer.tsx
+++ b/apps/insight-viewer-docs/src/containers/Basic/ImageSelectableViewer.tsx
@@ -11,8 +11,8 @@ export default function ImageSelectableViewer(): JSX.Element {
     loaderOptions: {
       webWorkerManagerOptions: {
         webWorkerTaskPaths: [
-          'http://localhost:3000/workers/610.bundle.min.worker.js',
-          'http://localhost:3000/workers/888.bundle.min.worker.js',
+          `${window.location.origin}/workers/610.bundle.min.worker.js`,
+          `${window.location.origin}/workers/888.bundle.min.worker.js`,
         ],
         taskConfiguration: {
           decodeTask: {


### PR DESCRIPTION
## 📝 Description

View에서 코덱 세팅을 위해 로더 설정을 참고하다가 발견한 버그입니다. 예시를 위해 localhost:3000을 기입했는데 실제 동작에서도 사용되고 있었네요.

[VIEWER-6] 의 원인일 가능성도 있어보입니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [x] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

docs 배포에서 콘솔에 에러 표시되고 이미지 로딩되지 않음

Issue Number: N/A

## 🚀 New behavior

이미지가 정상적으로 로드됨

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.


[VIEWER-6]: https://lunit.atlassian.net/browse/VIEWER-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ