### PR TITLE
VIEWER-32 apply timeout arguments to loadImages test code

### DIFF
--- a/packages/insight-viewer/src/hooks/useImage/loadImage.spec.ts
+++ b/packages/insight-viewer/src/hooks/useImage/loadImage.spec.ts
@@ -10,6 +10,7 @@ const defaultParam = {
   onError: CONFIG.onError,
   requestInterceptor: CONFIG.requestInterceptor,
   imageId: IMAGE_ID,
+  timeout: CONFIG.timeout,
   imageScheme: IMAGE_LOADER_SCHEME.WADO,
 }
 const cornerstoneImage = CORNERSTONE_IMAGE_MOCK as unknown as CornerstoneImage

--- a/packages/insight-viewer/src/hooks/useMultipleImages/loadImages.spec.ts
+++ b/packages/insight-viewer/src/hooks/useMultipleImages/loadImages.spec.ts
@@ -31,9 +31,7 @@ function handleMock({ errorIndex = -1 }) {
   return mockLoadCornerstoneImages.mockImplementation(() => {
     count += 1
     if (errorIndex === count) {
-      return Promise.reject(
-        new Error(`${ErrorTexts[errorIndex]} image fetch fails`)
-      )
+      return Promise.reject(new Error(`${ErrorTexts[errorIndex]} image fetch fails`))
     }
     return Promise.resolve(cornerstoneImage)
   })
@@ -54,6 +52,7 @@ describe('loadImages()', () => {
       loadImages({
         images: IMAGES,
         imageScheme: IMAGE_LOADER_SCHEME.WADO,
+        timeout: CONFIG.timeout,
         requestInterceptor,
       }).subscribe({
         next: async (res: Loaded) => {
@@ -72,6 +71,7 @@ describe('loadImages()', () => {
       loadImages({
         images: IMAGES,
         imageScheme: IMAGE_LOADER_SCHEME.WADO,
+        timeout: CONFIG.timeout,
         requestInterceptor,
       }).subscribe({
         error: async (err: ViewerError) => {
@@ -87,6 +87,7 @@ describe('loadImages()', () => {
       loadImages({
         images: IMAGES,
         imageScheme: IMAGE_LOADER_SCHEME.WADO,
+        timeout: CONFIG.timeout,
         requestInterceptor,
       }).subscribe({
         next: async (res: Loaded) => {
@@ -109,6 +110,7 @@ describe('loadImages()', () => {
       loadImages({
         images: IMAGES,
         imageScheme: IMAGE_LOADER_SCHEME.WADO,
+        timeout: CONFIG.timeout,
         requestInterceptor,
       }).subscribe({
         next: async (res: Loaded) => {
@@ -131,6 +133,7 @@ describe('loadImages()', () => {
       loadImages({
         images: IMAGES,
         imageScheme: IMAGE_LOADER_SCHEME.WADO,
+        timeout: CONFIG.timeout,
         requestInterceptor,
       }).subscribe({
         error: async (err: ViewerError) => {


### PR DESCRIPTION
## 📝 Description

https://github.com/lunit-io/frontend-components/pull/273 의 timeout 설정 추가로 인하여
loadImage, loadImages test code 가 실패하고 있습니다. timeout 을 추가하여 해결했습니다.

테스트 코드 관련 티켓이 머지될 시점에 테스트 코드에 대한 github action 이 필요할 것 같네요 🤔

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

loadImage, loadImages 에 대한 테스트 코드가 실패하고 있습니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-32

## 🚀 New behavior

loadImage, loadImages 에 대한 테스크 코드가 성공합니다.

loadImages test code 에 timeout 반영 [a626fde](https://github.com/lunit-io/frontend-components/pull/278/commits/a626fde74eebcaabb23b303140186a679e392826)

loadImage test code timeout 반영 [e338023](https://github.com/lunit-io/frontend-components/pull/278/commits/e338023561079e3314f8e0e5416d756268803dc7)

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
