### PR TITLE
VIEWER-33 / apply selectedAnnotation Id to addDrewAnnotation logic

### DIFF
--- a/packages/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
+++ b/packages/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
@@ -101,7 +101,15 @@ export default function useAnnotationPointsHandler({
 
     if (points.length > 1) {
       const drawingMode = isEditing && selectedAnnotation ? selectedAnnotation.type : mode
-      const drewAnnotation = getDrewAnnotation(image, points, drawingMode, lineHead, annotations)
+      const currentId = (() => {
+        if (selectedAnnotation) {
+          return selectedAnnotation.id
+        }
+
+        return annotations.length === 0 ? 1 : Math.max(...annotations.map(({ id }) => id), 0) + 1
+      })()
+
+      const drewAnnotation = getDrewAnnotation(image, points, currentId, drawingMode, lineHead)
       if (selectedAnnotation?.type === 'text') {
         drewAnnotation.label = selectedAnnotation.label
       }

--- a/packages/insight-viewer/src/utils/common/getDrewAnnotation.ts
+++ b/packages/insight-viewer/src/utils/common/getDrewAnnotation.ts
@@ -7,12 +7,11 @@ import { LINE_TEXT_POSITION_SPACING } from '../../const'
 export function getDrewAnnotation(
   image: Image | null,
   points: Point[],
+  currentId: number,
   mode: AnnotationMode,
-  lineHead: LineHeadMode,
-  annotations: Annotation[]
+  lineHead: LineHeadMode
 ): Annotation {
   const [xPosition, yPosition] = polylabel([points], 1)
-  const currentId = annotations.length === 0 ? 1 : Math.max(...annotations.map(({ id }) => id), 0) + 1
 
   const defaultAnnotationInfo: Pick<Annotation, 'id' | 'labelPosition' | 'lineWidth'> = {
     id: currentId,


### PR DESCRIPTION
## 📝 Description

Annotation Edit 기능을 통해 수정할 경우, 기존 label 에서 `마지막 label number + 1` 로 변경되는 버그를 수정했습니다.
Edit 기능을 사용하더라도 동일한 label 을 표기해야한다고 생각하기에 위와 같이 수정했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Annotation 에 Edit 기능 사용 시, 기존 label 을 표기하는 것이 아닌 `마지막 label number + 1` 을 표기하고 있습니다.

https://user-images.githubusercontent.com/88369343/182541536-d41605b0-3db7-44e9-a844-56faf12618e5.mov

Issue Number: https://lunit.atlassian.net/browse/VIEWER-33

## 🚀 New behavior

Edit 기능 사용 시 기존 label 로 표기합니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
