### PR TITLE
VIEWER-26 / Fix Drawer Error

### DIFF
--- a/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
@@ -32,8 +32,8 @@ export default function useAnnotationPointsHandler({
     if (!isEditing || selectedAnnotation == null) return
 
     const selectedAnnotationPoints = getExistingAnnotationPoints(selectedAnnotation, image)
-    const currnetPoints = selectedAnnotationPoints.map(pixelToCanvas)
-    const currentEditPoint = getEditPointPosition(currnetPoints, selectedAnnotation)
+    const currentPoints = selectedAnnotationPoints.map(pixelToCanvas)
+    const currentEditPoint = getEditPointPosition(currentPoints, selectedAnnotation)
 
     setAnnotation(selectedAnnotation)
     setEditTargetPoints(currentEditPoint)

--- a/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
@@ -76,6 +76,7 @@ function useDrawingHandler({
       enabledElement.element.addEventListener('mouseup', handleMouseUp)
       enabledElement.element.addEventListener('mouseleave', handleMouseLeave)
       enabledElement.element.addEventListener('mousedown', handleMouseDown)
+      enabledElement.element.addEventListener('mouseover', activeMouseDrawEvents)
       window.addEventListener('keydown', handleKeyDown)
     }
 
@@ -86,11 +87,8 @@ function useDrawingHandler({
       enabledElement.element.removeEventListener('mouseup', handleMouseUp)
       enabledElement.element.removeEventListener('mouseleave', handleMouseLeave)
       enabledElement.element.removeEventListener('mousedown', handleMouseDown)
-      window.removeEventListener('keydown', handleKeyDown)
-    }
 
-    const checkMouseEvent = () => {
-      enabledElement.element.addEventListener('mouseover', activeMouseDrawEvents)
+      window.removeEventListener('keydown', handleKeyDown)
     }
 
     const disableCheckMouseEvent = () => {
@@ -98,8 +96,7 @@ function useDrawingHandler({
     }
 
     activeMouseDrawEvents()
-    checkMouseEvent()
-    // eslint-disable-next-line consistent-return
+
     return () => {
       deactivateMouseDrawEvents()
       disableCheckMouseEvent()

--- a/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
@@ -89,11 +89,20 @@ function useDrawingHandler({
       window.removeEventListener('keydown', handleKeyDown)
     }
 
-    activeMouseDrawEvents()
+    const checkMouseEvent = () => {
+      enabledElement.element.addEventListener('mouseover', activeMouseDrawEvents)
+    }
 
+    const disableCheckMouseEvent = () => {
+      enabledElement.element.removeEventListener('mouseover', activeMouseDrawEvents)
+    }
+
+    activeMouseDrawEvents()
+    checkMouseEvent()
     // eslint-disable-next-line consistent-return
     return () => {
       deactivateMouseDrawEvents()
+      disableCheckMouseEvent()
     }
   }, [svgElement, enabledElement, pageToPixel, addDrawingPoint, addDrewElement, cancelDrawing, setInitialPoint])
 }


### PR DESCRIPTION
## 📝 Description

1. 마우스가 캔버스 밖으로 나갈 시 기존에 붙어있던 마우스 이벤트들이 전부 제거되고 다시 추가가 되지않던 문제를 확인
2. 마우스 오버 시 이벤트를 추가해주는 이벤트를 추가함

버그를 고치긴하였지만 임시 방편같은 느낌이 납니다. 선을 그리는 동안 이벤트들이 반복적으로 추가되고 제거가 되는 것을 확인 하였는데 근본적으로 해결을 위해서는 이 부분은 리팩토링이 되는 게 좋지않을까 생각합니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

마우스가 캔버스 밖으로 나갔다가 다시 돌아오는 경우 drawing 기능이 작동하지 않음

Issue Number: https://lunit.atlassian.net/browse/VIEWER-26

## 🚀 New behavior

마우스가 캔버스 밖으로 나갔다 오더라도 drawing 기능이 작동

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
