### PR TITLE
VIEWER-24 / Annotation, Measurement Extend Select Area

### DIFF
--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.styles.ts
@@ -31,7 +31,7 @@ export const polyline: ViewerStyle = {
   },
   extendsArea: {
     fill: 'transparent',
-    strokeWidth: '20px',
+    strokeWidth: '12px',
     stroke: 'transparent',
     cursor: 'grab',
   },

--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.styles.ts
@@ -29,4 +29,10 @@ export const polyline: ViewerStyle = {
     fill: 'transparent',
     cursor: 'grab',
   },
+  extendsArea: {
+    fill: 'transparent',
+    strokeWidth: '20px',
+    stroke: 'transparent',
+    cursor: 'grab',
+  },
 }

--- a/libs/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.styles.ts
@@ -75,6 +75,12 @@ export const polygonStyle: ViewerStyle = {
     stroke: '#99999B',
     cursor: 'pointer',
   },
+  extendsArea: {
+    fill: 'transparent',
+    strokeWidth: '20px',
+    stroke: 'transparent',
+    cursor: 'pointer',
+  },
 }
 
 export const polylineStyle: ViewerStyle = {
@@ -94,6 +100,12 @@ export const polylineStyle: ViewerStyle = {
     fill: 'transparent',
     strokeWidth: '3px',
     stroke: '#99999B',
+    cursor: 'pointer',
+  },
+  extendsArea: {
+    fill: 'transparent',
+    strokeWidth: '20px',
+    stroke: 'transparent',
     cursor: 'pointer',
   },
 }

--- a/libs/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.styles.ts
@@ -77,7 +77,7 @@ export const polygonStyle: ViewerStyle = {
   },
   extendsArea: {
     fill: 'transparent',
-    strokeWidth: '20px',
+    strokeWidth: '12px',
     stroke: 'transparent',
     cursor: 'pointer',
   },
@@ -104,7 +104,7 @@ export const polylineStyle: ViewerStyle = {
   },
   extendsArea: {
     fill: 'transparent',
-    strokeWidth: '20px',
+    strokeWidth: '12px',
     stroke: 'transparent',
     cursor: 'pointer',
   },

--- a/libs/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.styles.ts
@@ -24,7 +24,7 @@ export const circleStyle: ViewerStyle = {
   },
   extendsArea: {
     fill: 'transparent',
-    strokeWidth: '20px',
+    strokeWidth: '12px',
     stroke: 'transparent',
     cursor: 'grab',
   },

--- a/libs/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.styles.ts
@@ -22,6 +22,12 @@ export const circleStyle: ViewerStyle = {
     fill: 'transparent',
     cursor: 'grab',
   },
+  extendsArea: {
+    fill: 'transparent',
+    strokeWidth: '20px',
+    stroke: 'transparent',
+    cursor: 'grab',
+  },
 }
 
 export const textStyle: ViewerStyle = {

--- a/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
@@ -53,6 +53,13 @@ export function CircleDrawer({
         cy={centerPointOnCanvas[1]}
         r={drawingRadius}
       />
+      <circle
+        onMouseDown={() => setMeasurementEditMode('move')}
+        style={circleStyle.extendsArea}
+        cx={centerPointOnCanvas[0]}
+        cy={centerPointOnCanvas[1]}
+        r={drawingRadius}
+      />
       <text
         onMouseDown={() => setMeasurementEditMode('textMove')}
         style={{ ...textStyle[isSelectedMode ? 'select' : 'default'] }}

--- a/libs/insight-viewer/src/Viewer/CircleViewer/CircleViewer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/CircleViewer/CircleViewer.styles.ts
@@ -19,4 +19,10 @@ export const circleStyle: ViewerStyle = {
     stroke: '#99999B',
     cursor: 'pointer',
   },
+  extendsArea: {
+    fill: 'transparent',
+    strokeWidth: '20px',
+    stroke: 'transparent',
+    cursor: 'pointer',
+  },
 }

--- a/libs/insight-viewer/src/Viewer/CircleViewer/CircleViewer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/CircleViewer/CircleViewer.styles.ts
@@ -21,7 +21,7 @@ export const circleStyle: ViewerStyle = {
   },
   extendsArea: {
     fill: 'transparent',
-    strokeWidth: '20px',
+    strokeWidth: '12px',
     stroke: 'transparent',
     cursor: 'pointer',
   },

--- a/libs/insight-viewer/src/Viewer/CircleViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/CircleViewer/index.tsx
@@ -49,6 +49,15 @@ export function CircleViewer({ measurement, hoveredMeasurement }: CircleViewerPr
       />
       <circle
         style={{
+          ...circleStyle.extendsArea,
+        }}
+        data-focus={isHoveredMeasurement || undefined}
+        cx={centerPointOnCanvas[0]}
+        cy={centerPointOnCanvas[1]}
+        r={drawingRadius}
+      />
+      <circle
+        style={{
           ...circleStyle.default,
         }}
         data-focus={isHoveredMeasurement || undefined}

--- a/libs/insight-viewer/src/Viewer/LineViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/LineViewer/index.tsx
@@ -57,6 +57,14 @@ export function LineViewer({
         data-select={isHoveredAnnotation || undefined}
         points={polygonPoints}
       />
+      <polyline
+        style={{
+          ...polylineStyle.extendsArea,
+          ...polygonAttributes?.style,
+        }}
+        data-select={isHoveredAnnotation || undefined}
+        points={polygonPoints}
+      />
       {showAnnotationLabel && labelPosition && (
         <text style={{ ...textStyle.default }} x={labelPosition[0]} y={labelPosition[1]}>
           {polygonLabel}

--- a/libs/insight-viewer/src/Viewer/MeasurementDrawer/MeasurementDrawer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/MeasurementDrawer/MeasurementDrawer.styles.ts
@@ -45,4 +45,10 @@ export const circleStyle: ViewerStyle = {
     fill: '#FFD600',
     cursor: 'move',
   },
+  extendsArea: {
+    fill: 'transparent',
+    strokeWidth: '12px',
+    stroke: 'transparent',
+    cursor: 'move',
+  },
 }

--- a/libs/insight-viewer/src/Viewer/MeasurementViewer/MeasurementViewer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/MeasurementViewer/MeasurementViewer.styles.ts
@@ -41,7 +41,7 @@ export const polylineStyle: ViewerStyle = {
   },
   extendsArea: {
     fill: 'transparent',
-    strokeWidth: '20px',
+    strokeWidth: '12px',
     stroke: 'transparent',
     cursor: 'pointer',
   },

--- a/libs/insight-viewer/src/Viewer/MeasurementViewer/MeasurementViewer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/MeasurementViewer/MeasurementViewer.styles.ts
@@ -39,6 +39,12 @@ export const polylineStyle: ViewerStyle = {
     fill: 'transparent',
     strokeDasharray: '5, 5',
   },
+  extendsArea: {
+    fill: 'transparent',
+    strokeWidth: '20px',
+    stroke: 'transparent',
+    cursor: 'pointer',
+  },
 }
 
 export const textStyle: ViewerStyle = {

--- a/libs/insight-viewer/src/Viewer/PolygonViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/PolygonViewer/index.tsx
@@ -42,6 +42,14 @@ export function PolygonViewer({
         data-select={isHoveredAnnotation || undefined}
         points={polygonPoints}
       />
+      <polygon
+        style={{
+          ...polygonStyle.extendsArea,
+          ...polygonAttributes?.style,
+        }}
+        data-select={isHoveredAnnotation || undefined}
+        points={polygonPoints}
+      />
       {showAnnotationLabel && labelPosition && (
         <text style={{ ...textStyle.default }} x={labelPosition[0]} y={labelPosition[1]}>
           {polygonLabel}

--- a/libs/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
@@ -68,6 +68,7 @@ export function PolylineDrawer({
             style={polyline[isSelectedMode ? 'select' : 'default']}
             points={polylinePoints}
           />
+          <PolylineElement isPolygon={!!isPolygonSelected} style={polyline.extendsArea} points={polylinePoints} />
         </>
       )}
       {selectedAnnotationLabel && labelPosition && (

--- a/libs/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.styles.ts
@@ -59,7 +59,7 @@ export const polyline: ViewerStyle = {
   },
   extendsArea: {
     fill: 'transparent',
-    strokeWidth: '20px',
+    strokeWidth: '12px',
     stroke: 'transparent',
     cursor: 'grab',
   },

--- a/libs/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.styles.ts
@@ -57,4 +57,10 @@ export const polyline: ViewerStyle = {
     fill: 'transparent',
     strokeDasharray: '5, 5',
   },
+  extendsArea: {
+    fill: 'transparent',
+    strokeWidth: '20px',
+    stroke: 'transparent',
+    cursor: 'grab',
+  },
 }

--- a/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
@@ -36,6 +36,12 @@ export function RulerDrawer({
         style={polyline[isSelectedMode ? 'select' : 'default']}
         points={rulerLine}
       />
+      <polyline
+        data-cy-move
+        onMouseDown={() => setMeasurementEditMode('move')}
+        style={polyline.extendsArea}
+        points={rulerLine}
+      />
       <text
         onMouseDown={() => setMeasurementEditMode('textMove')}
         style={{ ...textStyle[isSelectedMode ? 'select' : 'default'] }}

--- a/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
@@ -35,6 +35,13 @@ export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProp
       />
       <polyline
         style={{
+          ...polylineStyle.extendsArea,
+        }}
+        data-select={isHoveredMeasurement || undefined}
+        points={rulerLine}
+      />
+      <polyline
+        style={{
           ...polylineStyle.default,
         }}
         data-select={isHoveredMeasurement || undefined}

--- a/libs/insight-viewer/src/components/EditPointer/index.tsx
+++ b/libs/insight-viewer/src/components/EditPointer/index.tsx
@@ -35,6 +35,13 @@ export function EditPointer({
         cx={cx}
         cy={cy}
         r={EDIT_CIRCLE_RADIUS}
+        style={circleStyle.extendsArea}
+      />
+      <circle
+        onMouseDown={() => setEditMode(editMode)}
+        cx={cx}
+        cy={cy}
+        r={EDIT_CIRCLE_RADIUS}
         style={circleStyle[isSelectedMode ? 'select' : isHighlightMode ? 'highlight' : 'default']}
       />
     </>

--- a/libs/insight-viewer/src/types/index.ts
+++ b/libs/insight-viewer/src/types/index.ts
@@ -65,6 +65,7 @@ export type ViewerStyleType =
   | 'selectedOutline'
   | 'highlight'
   | 'dashLine'
+  | 'extendsArea'
 export type ViewerStyle = {
   [styleType in ViewerStyleType]?: CSSProperties
 }


### PR DESCRIPTION
## 📝 Description

Annotation, Measurement 선택 영역 확장했습니다.
각각 Viewer, Drawer 에서 svg Element 를 추가한 후 storke width 를 `20px` 로 지정했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

기존 Annotation, Measurement 는 정확히 Drawing 된 영역을 클릭해야 선택이 가능합니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-24

## 🚀 New behavior

확장시킨 Annotation Viewer, Drawer 을 적용했습니다. e8a5133

확장시킨 Measurement Viewer, Drawer 을 적용했습니다. 35f54a3

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
