### PR TITLE
Modify useAnnotationPointsHandler hook function naming

### DIFF
--- a/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
@@ -39,7 +39,7 @@ export default function useAnnotationPointsHandler({
     setEditTargetPoints(currentEditPoint)
   }, [image, isEditing, selectedAnnotation, pixelToCanvas])
 
-  const addStartPoint = (point: Point) => {
+  const setInitialAnnotation = (point: Point) => {
     if (isEditing && selectedAnnotation) {
       setEditStartPoint(point)
       return
@@ -56,7 +56,7 @@ export default function useAnnotationPointsHandler({
     setAnnotation(initialAnnotation)
   }
 
-  const addDrawingPoint = (point: Point) => {
+  const addDrawingAnnotation = (point: Point) => {
     if (isEditing && selectedAnnotation != null && !editMode) return
 
     if (annotation == null) {
@@ -120,8 +120,8 @@ export default function useAnnotationPointsHandler({
   useDrawingHandler({
     mode,
     svgElement,
-    setInitialPoint: addStartPoint,
-    addDrawingPoint,
+    setInitialPoint: setInitialAnnotation,
+    addDrawingPoint: addDrawingAnnotation,
     cancelDrawing,
     addDrewElement: addDrewAnnotation,
   })


### PR DESCRIPTION
## 📝 Description

`useAnnotationPointsHandler` hook 내 리랙토링 전 기준 네이밍을 현재 방식에 변경했습니다.
Points -> Annotation 으로 변경했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

리팩토링 전 points 기준 네이밍을 가지고 있습니다.
(ex: `addDrawingPoints` 등)

Issue Number: N/A

## 🚀 New behavior

리팩토링 후 Annotation 기준 네이밍을 가집니다.

useAnnotationPointsHandler hook 내 function 네이밍 변경 c0b3562

`addDrawingPoints` -> `addDrawingAnnotation`

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
