### PR TITLE
VIEWER-2/ Change Circle Measurement Drawing

### DIFF
--- a/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from 'react'
 import { useOverlayContext } from '../../contexts'
 
 import { getCircleEndPoint } from '../../utils/common/getCircleEndPoint'
-import { getCircleRadius } from '../../utils/common/getCircleRadius'
+import { getCircleRadiusByCenter } from '../../utils/common/getCircleRadius'
 import { getCircleTextPosition } from '../../utils/common/getCircleTextPosition'
 import { getCircleConnectingLine } from '../../utils/common/getCircleConnectingLine'
 import { calculateCircleArea } from '../../utils/common/calculateCircleArea'
@@ -20,12 +20,11 @@ export function CircleDrawer({
   const { pixelToCanvas } = useOverlayContext()
 
   const { centerPoint, radius, measuredValue, unit } = measurement
-
   const endPoint = getCircleEndPoint(centerPoint, radius)
 
   const [centerPointOnCanvas, endPointOnCanvas] = [centerPoint, endPoint].map(pixelToCanvas)
 
-  const drawingRadius = getCircleRadius(centerPointOnCanvas, endPointOnCanvas)
+  const drawingRadius = getCircleRadiusByCenter(centerPointOnCanvas, endPointOnCanvas)
 
   const textPointOnCanvas = measurement.textPoint
     ? pixelToCanvas(measurement.textPoint)

--- a/libs/insight-viewer/src/Viewer/CircleViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/CircleViewer/index.tsx
@@ -5,7 +5,7 @@ import { textStyle, svgWrapperStyle } from '../Viewer.styles'
 import { useOverlayContext } from '../../contexts'
 
 import { calculateCircleArea } from '../../utils/common/calculateCircleArea'
-import { getCircleRadius } from '../../utils/common/getCircleRadius'
+import { getCircleRadiusByCenter } from '../../utils/common/getCircleRadius'
 import { getCircleEndPoint } from '../../utils/common/getCircleEndPoint'
 import { getCircleConnectingLine } from '../../utils/common/getCircleConnectingLine'
 import { getCircleTextPosition } from '../../utils/common/getCircleTextPosition'
@@ -18,10 +18,9 @@ export function CircleViewer({ measurement, hoveredMeasurement }: CircleViewerPr
   const { centerPoint, radius, measuredValue, unit } = measurement
 
   const endPoint = getCircleEndPoint(centerPoint, radius)
-
   const [centerPointOnCanvas, endPointOnCanvas] = [centerPoint, endPoint].map(pixelToCanvas)
 
-  const drawingRadius = getCircleRadius(centerPointOnCanvas, endPointOnCanvas)
+  const drawingRadius = getCircleRadiusByCenter(centerPointOnCanvas, endPointOnCanvas)
 
   const textPointOnCanvas = measurement.textPoint
     ? pixelToCanvas(measurement.textPoint)

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -109,8 +109,6 @@ export default function useMeasurementPointsHandler({
         currentMeasurement = getMeasurement(currentPoints, currentTextPosition, drawingMode, measurements, image)
       }
 
-      setMeasurement(currentMeasurement)
-
       return currentMeasurement
     })
   }

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -84,14 +84,16 @@ export default function useMeasurementPointsHandler({
       setEditTargetPoints(editPoints)
 
       let currentMeasurement = null
-      if (drawingMode === 'circle' && mouseDownPoint !== null) {
-        currentMeasurement = getMeasurement(
-          [mouseDownPoint, point],
-          currentTextPosition,
-          drawingMode,
-          measurements,
-          image
-        )
+      if (drawingMode === 'circle') {
+        if (mouseDownPoint !== null) {
+          currentMeasurement = getMeasurement(
+            [mouseDownPoint, point],
+            currentTextPosition,
+            drawingMode,
+            measurements,
+            image
+          )
+        }
         if (isEditing && editMode) {
           const [currentCenterPoint, currentEndPoint] = currentPoints
           const radius = getCircleRadiusByCenter(currentCenterPoint, currentEndPoint)

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react'
 import { useOverlayContext } from '../../contexts'
 
 import { getMeasurement } from '../../utils/common/getMeasurement'
-import { getCurrentMeasurement } from '../../utils/common/getCurrentMeasurement'
+import { getMeasurementPointsByMode } from '../../utils/common/getMeasurementPointsByMode'
 import { getTextPosition } from '../../utils/common/getTextPosition'
 import { getMeasurementPoints } from '../../utils/common/getMeasurementPoints'
 import { getEditPointPosition, EditPoints } from '../../utils/common/getEditPointPosition'
@@ -83,17 +83,23 @@ export default function useMeasurementPointsHandler({
       const editPoints = getEditPointPosition(editPointsOnCanvas, selectedMeasurement, drawingMode)
       setEditTargetPoints(editPoints)
 
-      const currentMeasurement = getCurrentMeasurement(
+      const measurementPointsByMode = getMeasurementPointsByMode(
         isEditing,
         editMode,
         drawingMode,
-        currentTextPosition,
         mouseDownPoint,
         point,
-        currentPoints,
+        currentPoints
+      )
+
+      const currentMeasurement = getMeasurement(
+        measurementPointsByMode,
+        currentTextPosition,
+        drawingMode,
         measurements,
         image
       )
+
       return currentMeasurement
     })
   }

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -3,11 +3,11 @@ import { useState, useEffect } from 'react'
 import { useOverlayContext } from '../../contexts'
 
 import { getMeasurement } from '../../utils/common/getMeasurement'
+import { getCurrentMeasurement } from '../../utils/common/getCurrentMeasurement'
 import { getTextPosition } from '../../utils/common/getTextPosition'
 import { getMeasurementPoints } from '../../utils/common/getMeasurementPoints'
 import { getEditPointPosition, EditPoints } from '../../utils/common/getEditPointPosition'
 import { getExistingMeasurementPoints } from '../../utils/common/getExistingMeasurementPoints'
-import { getCircleRadiusByCenter } from '../../utils/common/getCircleRadius'
 
 import useDrawingHandler from '../useDrawingHandler'
 
@@ -83,34 +83,17 @@ export default function useMeasurementPointsHandler({
       const editPoints = getEditPointPosition(editPointsOnCanvas, selectedMeasurement, drawingMode)
       setEditTargetPoints(editPoints)
 
-      let currentMeasurement = null
-      if (drawingMode === 'circle') {
-        if (mouseDownPoint !== null) {
-          currentMeasurement = getMeasurement(
-            [mouseDownPoint, point],
-            currentTextPosition,
-            drawingMode,
-            measurements,
-            image
-          )
-        }
-        if (isEditing && editMode) {
-          const [currentCenterPoint, currentEndPoint] = currentPoints
-          const radius = getCircleRadiusByCenter(currentCenterPoint, currentEndPoint)
-          const currentStartPoint: Point = [currentCenterPoint[0] - radius, currentCenterPoint[1]]
-
-          currentMeasurement = getMeasurement(
-            [currentStartPoint, currentEndPoint],
-            currentTextPosition,
-            drawingMode,
-            measurements,
-            image
-          )
-        }
-      } else {
-        currentMeasurement = getMeasurement(currentPoints, currentTextPosition, drawingMode, measurements, image)
-      }
-
+      const currentMeasurement = getCurrentMeasurement(
+        isEditing,
+        editMode,
+        drawingMode,
+        currentTextPosition,
+        mouseDownPoint,
+        point,
+        currentPoints,
+        measurements,
+        image
+      )
       return currentMeasurement
     })
   }

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -80,7 +80,7 @@ export default function useMeasurementPointsHandler({
       const currentTextPosition = getTextPosition(measurement, editMode, point)
 
       const editPointsOnCanvas = currentPoints.map(pixelToCanvas) as [Point, Point]
-      const editPoints = getEditPointPosition(editPointsOnCanvas, selectedMeasurement)
+      const editPoints = getEditPointPosition(editPointsOnCanvas, selectedMeasurement, drawingMode)
       setEditTargetPoints(editPoints)
 
       let currentMeasurement = null

--- a/libs/insight-viewer/src/utils/common/getCircleCenterPoint.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getCircleCenterPoint.spec.ts
@@ -1,0 +1,18 @@
+import { getCircleCenterPoint } from './getCircleCenterPoint'
+
+import type { Point } from '../../types'
+
+describe('getCircleCenterPoint: ', () => {
+  it('should return the center point', () => {
+    const MOCK_START_POINT_1: Point = [0, 0]
+    const MOCK_END_POINT_1: Point = [10, 20]
+    const MOCK_START_POINT_2: Point = [15, 20]
+    const MOCK_END_POINT_2: Point = [40, 17]
+    const MOCK_START_POINT_3: Point = [1, 29]
+    const MOCK_END_POINT_3: Point = [4, 5]
+
+    expect(getCircleCenterPoint(MOCK_START_POINT_1, MOCK_END_POINT_1)).toEqual([5, 10])
+    expect(getCircleCenterPoint(MOCK_START_POINT_2, MOCK_END_POINT_2)).toEqual([27.5, 18.5])
+    expect(getCircleCenterPoint(MOCK_START_POINT_3, MOCK_END_POINT_3)).toEqual([2.5, 17])
+  })
+})

--- a/libs/insight-viewer/src/utils/common/getCircleCenterPoint.ts
+++ b/libs/insight-viewer/src/utils/common/getCircleCenterPoint.ts
@@ -1,0 +1,10 @@
+import type { Point } from '../../types'
+
+export function getCircleCenterPoint(startPoint: Point, endPoint: Point): Point {
+  const centerX = (startPoint[0] + endPoint[0]) / 2
+  const centerY = (startPoint[1] + endPoint[1]) / 2
+
+  const centerPoint: Point = [centerX, centerY]
+
+  return centerPoint
+}

--- a/libs/insight-viewer/src/utils/common/getCircleConnectingLine.ts
+++ b/libs/insight-viewer/src/utils/common/getCircleConnectingLine.ts
@@ -1,12 +1,12 @@
-import type { Point } from '../../types'
+import { getCircleRadiusByCenter } from "./getCircleRadius"
 
-import { getCircleRadius } from '../../utils/common/getCircleRadius'
+import type { Point } from '../../types'
 
 export function getCircleConnectingLine(points: [Point, Point], textPoint: Point): [Point, Point] {
   const startPoint = points[0]
   const endPoint = points[1]
 
-  const radius = getCircleRadius(startPoint, endPoint)
+  const radius = getCircleRadiusByCenter(startPoint, endPoint)
 
   if (startPoint[0] < textPoint[0]) {
     if (startPoint[1] < textPoint[1]) {

--- a/libs/insight-viewer/src/utils/common/getCircleRadius.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getCircleRadius.spec.ts
@@ -1,4 +1,4 @@
-import { getCircleRadiusByMeasuringUnit, getCircleRadius } from './getCircleRadius'
+import { getCircleRadiusByMeasuringUnit, getCircleRadius, getCircleRadiusByCenter } from './getCircleRadius'
 
 import type { Point } from '../../types'
 import type { Image } from '../../Viewer/types'
@@ -13,9 +13,25 @@ describe('getCircleRadius:', () => {
     const MOCK_MOUSE_UP_POINT_2: Point = [10, 10]
     const MOCK_MOUSE_UP_POINT_3: Point = [20, 20]
 
-    expect(getCircleRadius(MOCK_MOUSE_DOWN_POINT_1, MOCK_MOUSE_UP_POINT_1)).toEqual(7.0710678118654755)
-    expect(getCircleRadius(MOCK_MOUSE_DOWN_POINT_2, MOCK_MOUSE_UP_POINT_2)).toEqual(12.727922061357855)
-    expect(getCircleRadius(MOCK_MOUSE_DOWN_POINT_3, MOCK_MOUSE_UP_POINT_3)).toEqual(25.45584412271571)
+    expect(getCircleRadius(MOCK_MOUSE_DOWN_POINT_1, MOCK_MOUSE_UP_POINT_1)).toEqual(3.5355339059327378)
+    expect(getCircleRadius(MOCK_MOUSE_DOWN_POINT_2, MOCK_MOUSE_UP_POINT_2)).toEqual(6.363961030678928)
+    expect(getCircleRadius(MOCK_MOUSE_DOWN_POINT_3, MOCK_MOUSE_UP_POINT_3)).toEqual(12.727922061357855)
+  })
+})
+
+describe('getCircleRadiusByCenter:', () => {
+  it('should calculate circle radius', () => {
+    const MOCK_MOUSE_DOWN_POINT_1: Point = [0, 0]
+    const MOCK_MOUSE_DOWN_POINT_2: Point = [1, 1]
+    const MOCK_MOUSE_DOWN_POINT_3: Point = [2, 2]
+
+    const MOCK_MOUSE_UP_POINT_1: Point = [5, 5]
+    const MOCK_MOUSE_UP_POINT_2: Point = [10, 10]
+    const MOCK_MOUSE_UP_POINT_3: Point = [20, 20]
+
+    expect(getCircleRadiusByCenter(MOCK_MOUSE_DOWN_POINT_1, MOCK_MOUSE_UP_POINT_1)).toEqual(7.0710678118654755)
+    expect(getCircleRadiusByCenter(MOCK_MOUSE_DOWN_POINT_2, MOCK_MOUSE_UP_POINT_2)).toEqual(12.727922061357855)
+    expect(getCircleRadiusByCenter(MOCK_MOUSE_DOWN_POINT_3, MOCK_MOUSE_UP_POINT_3)).toEqual(25.45584412271571)
   })
 })
 
@@ -30,15 +46,15 @@ describe('getCircleRadiusByMeasuringUnit:', () => {
     const MOCK_MOUSE_UP_POINT_3: Point = [20, 20]
 
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_1, MOCK_MOUSE_UP_POINT_1, null)).toEqual({
-      radius: 7.0710678118654755,
+      radius: 3.5355339059327378,
       unit: 'px',
     })
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_2, MOCK_MOUSE_UP_POINT_2, null)).toEqual({
-      radius: 12.727922061357855,
+      radius: 6.363961030678928,
       unit: 'px',
     })
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_3, MOCK_MOUSE_UP_POINT_3, null)).toEqual({
-      radius: 25.45584412271571,
+      radius: 12.727922061357855,
       unit: 'px',
     })
   })
@@ -54,15 +70,15 @@ describe('getCircleRadiusByMeasuringUnit:', () => {
     const MOCK_MOUSE_UP_POINT_3: Point = [20, 20]
 
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_1, MOCK_MOUSE_UP_POINT_1, MOCK_IMAGE_1)).toEqual({
-      radius: 4.949747468305833,
+      radius: 2.4748737341529163,
       unit: 'mm',
     })
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_2, MOCK_MOUSE_UP_POINT_2, MOCK_IMAGE_2)).toEqual({
-      radius: 10.182337649086284,
+      radius: 5.091168824543142,
       unit: 'mm',
     })
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_3, MOCK_MOUSE_UP_POINT_3, MOCK_IMAGE_3)).toEqual({
-      radius: 22.91025971044414,
+      radius: 11.45512985522207,
       unit: 'mm',
     })
   })
@@ -78,15 +94,15 @@ describe('getCircleRadiusByMeasuringUnit:', () => {
     const MOCK_MOUSE_UP_POINT_3: Point = [20, 20]
 
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_1, MOCK_MOUSE_UP_POINT_1, MOCK_IMAGE_1)).toEqual({
-      radius: 4.949747468305833,
+      radius: 2.4748737341529163,
       unit: 'mm',
     })
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_2, MOCK_MOUSE_UP_POINT_2, MOCK_IMAGE_2)).toEqual({
-      radius: 10.182337649086284,
+      radius: 5.091168824543142,
       unit: 'mm',
     })
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_3, MOCK_MOUSE_UP_POINT_3, MOCK_IMAGE_3)).toEqual({
-      radius: 22.91025971044414,
+      radius: 11.45512985522207,
       unit: 'mm',
     })
   })
@@ -104,15 +120,15 @@ describe('getCircleRadiusByMeasuringUnit:', () => {
     const MOCK_MOUSE_UP_POINT_3: Point = [20, 20]
 
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_1, MOCK_MOUSE_UP_POINT_1, MOCK_IMAGE)).toEqual({
-      radius: 7.0710678118654755,
+      radius: 3.5355339059327378,
       unit: 'px',
     })
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_2, MOCK_MOUSE_UP_POINT_2, MOCK_IMAGE)).toEqual({
-      radius: 12.727922061357855,
+      radius: 6.363961030678928,
       unit: 'px',
     })
     expect(getCircleRadiusByMeasuringUnit(MOCK_MOUSE_DOWN_POINT_3, MOCK_MOUSE_UP_POINT_3, MOCK_IMAGE)).toEqual({
-      radius: 25.45584412271571,
+      radius: 12.727922061357855,
       unit: 'px',
     })
   })

--- a/libs/insight-viewer/src/utils/common/getCircleRadius.ts
+++ b/libs/insight-viewer/src/utils/common/getCircleRadius.ts
@@ -4,11 +4,10 @@ import type { Point } from '../../types'
 import type { Image } from '../../Viewer/types'
 
 /**
- * The ImageSpacing uses cornerstone image's columnPixelSpacing, rowPixelSpacing
+ * The ImageSpacing uses cornerstone image's columnPixelSpacing and rowPixelSpacing
  * If there is no image or cornerstone's pixel spacing does not exist,
  * radius is calculated without spacing value
  */
-
 interface ImageSpacing {
   columnPixelSpacing: number
   rowPixelSpacing: number

--- a/libs/insight-viewer/src/utils/common/getCircleRadius.ts
+++ b/libs/insight-viewer/src/utils/common/getCircleRadius.ts
@@ -3,30 +3,27 @@ import { IMAGER_PIXEL_SPACING } from './const'
 import type { Point } from '../../types'
 import type { Image } from '../../Viewer/types'
 
-function getMidPoint(startPoint: Point, endPoint: Point): Point {
+function calculateRadius(startPoint: Point, endPoint: Point, col?: number, row?: number): number {
   const [x1, y1] = startPoint
   const [x2, y2] = endPoint
 
-  const midX = Math.abs(x2 - x1)
-  const midY = Math.abs(y2 - y1)
+  const [distanceX, distanceY] = col && row ? [(x2 - x1) * col, (y2 - y1) * row] : [x2 - x1, y2 - y1]
 
-  return [midX, midY]
+  const radius = Math.sqrt(Math.pow(distanceX, 2) + Math.pow(distanceY, 2))
+
+  return radius
 }
 
 export function getCircleRadius(startPoint: Point, endPoint: Point): number {
-  const [midX, midY] = getMidPoint(startPoint, endPoint)
+  const circleRadius = calculateRadius(startPoint, endPoint) / 2
 
-  const radius = Math.sqrt(Math.pow(midX, 2) + Math.pow(midY, 2)) / 2
-
-  return radius
+  return circleRadius
 }
 
 export function getCircleRadiusByCenter(centerPoint: Point, endPoint: Point): number {
-  const [midX, midY] = getMidPoint(centerPoint, endPoint)
+  const circleRadiusByCenter = calculateRadius(centerPoint, endPoint)
 
-  const radius = Math.sqrt(Math.pow(midX, 2) + Math.pow(midY, 2))
-
-  return radius
+  return circleRadiusByCenter
 }
 
 /** radius is measured value of circle */
@@ -35,35 +32,27 @@ export function getCircleRadiusByMeasuringUnit(
   endPoint: Point,
   currentImage: Image | null
 ): { radius: number; unit: 'px' | 'mm' } {
-  const [midX, midY] = getMidPoint(startPoint, endPoint)
-
-  const calcRadius = (x: number, y: number, col: number, row: number) => {
-    const radius = Math.sqrt(Math.pow(x * col, 2) + Math.pow(y * row, 2)) / 2
-
-    return radius
-  }
-
   if (!currentImage) {
-    return { radius: calcRadius(midX, midY, 1, 1), unit: 'px' }
+    return { radius: calculateRadius(startPoint, endPoint, 1, 1), unit: 'px' }
   }
 
   if (currentImage.columnPixelSpacing && currentImage.rowPixelSpacing) {
     const { columnPixelSpacing, rowPixelSpacing } = currentImage
 
-    return { radius: calcRadius(midX, midY, columnPixelSpacing, rowPixelSpacing), unit: 'mm' }
+    return { radius: calculateRadius(startPoint, endPoint, columnPixelSpacing, rowPixelSpacing), unit: 'mm' }
   }
 
   const imagerPixelSpacing = currentImage.data.string(IMAGER_PIXEL_SPACING) as string | undefined
 
   if (!imagerPixelSpacing) {
-    return { radius: calcRadius(midX, midY, 1, 1), unit: 'px' }
+    return { radius: calculateRadius(startPoint, endPoint, 1, 1), unit: 'px' }
   }
 
   if (imagerPixelSpacing.length !== 0) {
     const [columnPixelSpacing, rowPixelSpacing] = imagerPixelSpacing.split('\\').map(Number)
 
-    return { radius: calcRadius(midX, midY, columnPixelSpacing, rowPixelSpacing), unit: 'mm' }
+    return { radius: calculateRadius(startPoint, endPoint, columnPixelSpacing, rowPixelSpacing), unit: 'mm' }
   }
 
-  return { radius: calcRadius(midX, midY, 1, 1), unit: 'px' }
+  return { radius: calculateRadius(startPoint, endPoint, 1, 1), unit: 'px' }
 }

--- a/libs/insight-viewer/src/utils/common/getCircleRadius.ts
+++ b/libs/insight-viewer/src/utils/common/getCircleRadius.ts
@@ -3,11 +3,28 @@ import { IMAGER_PIXEL_SPACING } from './const'
 import type { Point } from '../../types'
 import type { Image } from '../../Viewer/types'
 
-function calculateRadius(startPoint: Point, endPoint: Point, col?: number, row?: number): number {
+/**
+ * The ImageSpacing uses cornerstone image's columnPixelSpacing, rowPixelSpacing
+ * If there is no image or cornerstone's pixel spacing does not exist,
+ * radius is calculated without spacing value
+ */
+
+interface ImageSpacing {
+  columnPixelSpacing: number
+  rowPixelSpacing: number
+}
+
+function calculateRadius(startPoint: Point, endPoint: Point, imageSpacing?: ImageSpacing): number {
   const [x1, y1] = startPoint
   const [x2, y2] = endPoint
 
-  const [distanceX, distanceY] = col && row ? [(x2 - x1) * col, (y2 - y1) * row] : [x2 - x1, y2 - y1]
+  let distanceX = x2 - x1
+  let distanceY = y2 - y1
+
+  if (imageSpacing) {
+    distanceX = (x2 - x1) * imageSpacing.columnPixelSpacing
+    distanceY = (y2 - y1) * imageSpacing.rowPixelSpacing
+  }
 
   const radius = Math.sqrt(Math.pow(distanceX, 2) + Math.pow(distanceY, 2))
 
@@ -33,26 +50,26 @@ export function getCircleRadiusByMeasuringUnit(
   currentImage: Image | null
 ): { radius: number; unit: 'px' | 'mm' } {
   if (!currentImage) {
-    return { radius: calculateRadius(startPoint, endPoint, 1, 1), unit: 'px' }
+    return { radius: calculateRadius(startPoint, endPoint), unit: 'px' }
   }
 
   if (currentImage.columnPixelSpacing && currentImage.rowPixelSpacing) {
     const { columnPixelSpacing, rowPixelSpacing } = currentImage
 
-    return { radius: calculateRadius(startPoint, endPoint, columnPixelSpacing, rowPixelSpacing), unit: 'mm' }
+    return { radius: calculateRadius(startPoint, endPoint, { columnPixelSpacing, rowPixelSpacing }), unit: 'mm' }
   }
 
   const imagerPixelSpacing = currentImage.data.string(IMAGER_PIXEL_SPACING) as string | undefined
 
   if (!imagerPixelSpacing) {
-    return { radius: calculateRadius(startPoint, endPoint, 1, 1), unit: 'px' }
+    return { radius: calculateRadius(startPoint, endPoint), unit: 'px' }
   }
 
   if (imagerPixelSpacing.length !== 0) {
     const [columnPixelSpacing, rowPixelSpacing] = imagerPixelSpacing.split('\\').map(Number)
 
-    return { radius: calculateRadius(startPoint, endPoint, columnPixelSpacing, rowPixelSpacing), unit: 'mm' }
+    return { radius: calculateRadius(startPoint, endPoint, { columnPixelSpacing, rowPixelSpacing }), unit: 'mm' }
   }
 
-  return { radius: calculateRadius(startPoint, endPoint, 1, 1), unit: 'px' }
+  return { radius: calculateRadius(startPoint, endPoint), unit: 'px' }
 }

--- a/libs/insight-viewer/src/utils/common/getCircleRadius.ts
+++ b/libs/insight-viewer/src/utils/common/getCircleRadius.ts
@@ -3,26 +3,21 @@ import { IMAGER_PIXEL_SPACING } from './const'
 import type { Point } from '../../types'
 import type { Image } from '../../Viewer/types'
 
-/**
- * The ImageSpacing uses cornerstone image's columnPixelSpacing and rowPixelSpacing
- * If there is no image or cornerstone's pixel spacing does not exist,
- * radius is calculated without spacing value
- */
-interface ImageSpacing {
-  columnPixelSpacing: number
-  rowPixelSpacing: number
+interface ScaleRatio {
+  scaleX: number
+  scaleY: number
 }
 
-function calculateRadius(startPoint: Point, endPoint: Point, imageSpacing?: ImageSpacing): number {
+function calculateRadius(startPoint: Point, endPoint: Point, scaleRatio?: ScaleRatio): number {
   const [x1, y1] = startPoint
   const [x2, y2] = endPoint
 
   let distanceX = x2 - x1
   let distanceY = y2 - y1
 
-  if (imageSpacing) {
-    distanceX = (x2 - x1) * imageSpacing.columnPixelSpacing
-    distanceY = (y2 - y1) * imageSpacing.rowPixelSpacing
+  if (scaleRatio) {
+    distanceX = (x2 - x1) * scaleRatio.scaleX
+    distanceY = (y2 - y1) * scaleRatio.scaleY
   }
 
   const radius = Math.sqrt(Math.pow(distanceX, 2) + Math.pow(distanceY, 2))
@@ -42,7 +37,13 @@ export function getCircleRadiusByCenter(centerPoint: Point, endPoint: Point): nu
   return circleRadiusByCenter
 }
 
-/** radius is measured value of circle */
+/**
+ * The 'getCircleRadiusByMeasuringUnit' function's radius is measured value of circle
+
+ * The ImageSpacing uses cornerstone image's columnPixelSpacing and rowPixelSpacing
+ * If there is no image or cornerstone's pixel spacing does not exist,
+ * radius is calculated without spacing value
+ */
 export function getCircleRadiusByMeasuringUnit(
   startPoint: Point,
   endPoint: Point,
@@ -55,7 +56,10 @@ export function getCircleRadiusByMeasuringUnit(
   if (currentImage.columnPixelSpacing && currentImage.rowPixelSpacing) {
     const { columnPixelSpacing, rowPixelSpacing } = currentImage
 
-    return { radius: calculateRadius(startPoint, endPoint, { columnPixelSpacing, rowPixelSpacing }), unit: 'mm' }
+    return {
+      radius: calculateRadius(startPoint, endPoint, { scaleX: columnPixelSpacing, scaleY: rowPixelSpacing }),
+      unit: 'mm',
+    }
   }
 
   const imagerPixelSpacing = currentImage.data.string(IMAGER_PIXEL_SPACING) as string | undefined
@@ -67,7 +71,10 @@ export function getCircleRadiusByMeasuringUnit(
   if (imagerPixelSpacing.length !== 0) {
     const [columnPixelSpacing, rowPixelSpacing] = imagerPixelSpacing.split('\\').map(Number)
 
-    return { radius: calculateRadius(startPoint, endPoint, { columnPixelSpacing, rowPixelSpacing }), unit: 'mm' }
+    return {
+      radius: calculateRadius(startPoint, endPoint, { scaleX: columnPixelSpacing, scaleY: rowPixelSpacing }),
+      unit: 'mm',
+    }
   }
 
   return { radius: calculateRadius(startPoint, endPoint), unit: 'px' }

--- a/libs/insight-viewer/src/utils/common/getCircleRadius.ts
+++ b/libs/insight-viewer/src/utils/common/getCircleRadius.ts
@@ -13,8 +13,17 @@ function getMidPoint(startPoint: Point, endPoint: Point): Point {
   return [midX, midY]
 }
 
-export function getCircleRadius(mouseDownPoint: Point, mouseUpPoint: Point): number {
-  const [midX, midY] = getMidPoint(mouseDownPoint, mouseUpPoint)
+export function getCircleRadius(startPoint: Point, endPoint: Point): number {
+  const [midX, midY] = getMidPoint(startPoint, endPoint)
+
+  const radius = Math.sqrt(Math.pow(midX, 2) + Math.pow(midY, 2)) / 2
+
+  return radius
+}
+
+export function getCircleRadiusByCenter(centerPoint: Point, endPoint: Point): number {
+  const [midX, midY] = getMidPoint(centerPoint, endPoint)
+
   const radius = Math.sqrt(Math.pow(midX, 2) + Math.pow(midY, 2))
 
   return radius
@@ -22,14 +31,14 @@ export function getCircleRadius(mouseDownPoint: Point, mouseUpPoint: Point): num
 
 /** radius is measured value of circle */
 export function getCircleRadiusByMeasuringUnit(
-  mouseDownPoint: Point,
-  mouseUpPoint: Point,
+  startPoint: Point,
+  endPoint: Point,
   currentImage: Image | null
 ): { radius: number; unit: 'px' | 'mm' } {
-  const [midX, midY] = getMidPoint(mouseDownPoint, mouseUpPoint)
+  const [midX, midY] = getMidPoint(startPoint, endPoint)
 
   const calcRadius = (x: number, y: number, col: number, row: number) => {
-    const radius = Math.sqrt(Math.pow(x * col, 2) + Math.pow(y * row, 2))
+    const radius = Math.sqrt(Math.pow(x * col, 2) + Math.pow(y * row, 2)) / 2
 
     return radius
   }

--- a/libs/insight-viewer/src/utils/common/getCircleStartPoint.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getCircleStartPoint.spec.ts
@@ -1,0 +1,18 @@
+import { getCircleStartPoint } from './getCircleStartPoint'
+
+import type { Point } from '../../types'
+
+describe('getCircleStartPoint: ', () => {
+  it('should return the start point of circle', () => {
+    const MOCK_CENTER_POINT_1: Point = [0, 0]
+    const MOCK_RADIUS_1 = 10
+    const MOCK_CENTER_POINT_2: Point = [10, 10]
+    const MOCK_RADIUS_2 = 20
+    const MOCK_CENTER_POINT_3: Point = [20, 20]
+    const MOCK_RADIUS_3 = 30
+
+    expect(getCircleStartPoint(MOCK_CENTER_POINT_1, MOCK_RADIUS_1)).toEqual([-10, 0])
+    expect(getCircleStartPoint(MOCK_CENTER_POINT_2, MOCK_RADIUS_2)).toEqual([-10, 10])
+    expect(getCircleStartPoint(MOCK_CENTER_POINT_3, MOCK_RADIUS_3)).toEqual([-10, 20])
+  })
+})

--- a/libs/insight-viewer/src/utils/common/getCircleStartPoint.ts
+++ b/libs/insight-viewer/src/utils/common/getCircleStartPoint.ts
@@ -1,0 +1,7 @@
+import type { Point } from '../../types'
+
+export function getCircleStartPoint(centerPoint: Point, radius: number): Point {
+  const startPoint: Point = [centerPoint[0] - radius, centerPoint[1]]
+
+  return startPoint
+}

--- a/libs/insight-viewer/src/utils/common/getCurrentMeasurement.ts
+++ b/libs/insight-viewer/src/utils/common/getCurrentMeasurement.ts
@@ -1,0 +1,47 @@
+import { getMeasurement } from './getMeasurement'
+import { getCircleRadiusByCenter } from './getCircleRadius'
+
+import type { EditMode, Point, Measurement, MeasurementMode } from '../../types'
+import type { Image } from '../../Viewer/types'
+
+export function getCurrentMeasurement(
+  isEditing: boolean,
+  editMode: EditMode | null,
+  drawingMode: MeasurementMode,
+  currentTextPosition: Point | null,
+  mouseDownPoint: Point | null,
+  mouseMovePoint: Point,
+  currentPoints: [centerPoint: Point, endPoint: Point],
+  measurements: Measurement[],
+  image: Image | null
+) {
+  let currentMeasurement = null
+  if (drawingMode === 'circle') {
+    if (mouseDownPoint !== null) {
+      currentMeasurement = getMeasurement(
+        [mouseDownPoint, mouseMovePoint],
+        currentTextPosition,
+        drawingMode,
+        measurements,
+        image
+      )
+    }
+    if (isEditing && editMode) {
+      const [currentCenterPoint, currentEndPoint] = currentPoints
+      const radius = getCircleRadiusByCenter(currentCenterPoint, currentEndPoint)
+      const currentStartPoint: Point = [currentCenterPoint[0] - radius, currentCenterPoint[1]]
+
+      currentMeasurement = getMeasurement(
+        [currentStartPoint, currentEndPoint],
+        currentTextPosition,
+        drawingMode,
+        measurements,
+        image
+      )
+    }
+  } else {
+    currentMeasurement = getMeasurement(currentPoints, currentTextPosition, drawingMode, measurements, image)
+  }
+
+  return currentMeasurement
+}

--- a/libs/insight-viewer/src/utils/common/getCurrentMeasurement.ts
+++ b/libs/insight-viewer/src/utils/common/getCurrentMeasurement.ts
@@ -1,5 +1,6 @@
 import { getMeasurement } from './getMeasurement'
 import { getCircleRadiusByCenter } from './getCircleRadius'
+import { getCircleStartPoint } from './getCircleStartPoint'
 
 import type { EditMode, Point, Measurement, MeasurementMode } from '../../types'
 import type { Image } from '../../Viewer/types'
@@ -25,7 +26,7 @@ export function getCurrentMeasurement(
   if (drawingMode === 'circle' && isEditing && editMode) {
     const [currentCenterPoint, currentEndPoint] = prevPoints
     const radius = getCircleRadiusByCenter(currentCenterPoint, currentEndPoint)
-    const currentStartPoint: Point = [currentCenterPoint[0] - radius, currentCenterPoint[1]]
+    const currentStartPoint = getCircleStartPoint(currentCenterPoint, radius)
 
     currentPoints = [currentStartPoint, currentEndPoint]
   }

--- a/libs/insight-viewer/src/utils/common/getCurrentMeasurement.ts
+++ b/libs/insight-viewer/src/utils/common/getCurrentMeasurement.ts
@@ -11,37 +11,26 @@ export function getCurrentMeasurement(
   currentTextPosition: Point | null,
   mouseDownPoint: Point | null,
   mouseMovePoint: Point,
-  currentPoints: [centerPoint: Point, endPoint: Point],
+  prevPoints: [centerPoint: Point, endPoint: Point],
   measurements: Measurement[],
   image: Image | null
 ) {
   let currentMeasurement = null
-  if (drawingMode === 'circle') {
-    if (mouseDownPoint !== null) {
-      currentMeasurement = getMeasurement(
-        [mouseDownPoint, mouseMovePoint],
-        currentTextPosition,
-        drawingMode,
-        measurements,
-        image
-      )
-    }
-    if (isEditing && editMode) {
-      const [currentCenterPoint, currentEndPoint] = currentPoints
-      const radius = getCircleRadiusByCenter(currentCenterPoint, currentEndPoint)
-      const currentStartPoint: Point = [currentCenterPoint[0] - radius, currentCenterPoint[1]]
+  let currentPoints = prevPoints
 
-      currentMeasurement = getMeasurement(
-        [currentStartPoint, currentEndPoint],
-        currentTextPosition,
-        drawingMode,
-        measurements,
-        image
-      )
-    }
-  } else {
-    currentMeasurement = getMeasurement(currentPoints, currentTextPosition, drawingMode, measurements, image)
+  if (drawingMode === 'circle' && mouseDownPoint !== null) {
+    currentPoints = [mouseDownPoint, mouseMovePoint]
   }
+
+  if (drawingMode === 'circle' && isEditing && editMode) {
+    const [currentCenterPoint, currentEndPoint] = prevPoints
+    const radius = getCircleRadiusByCenter(currentCenterPoint, currentEndPoint)
+    const currentStartPoint: Point = [currentCenterPoint[0] - radius, currentCenterPoint[1]]
+
+    currentPoints = [currentStartPoint, currentEndPoint]
+  }
+
+  currentMeasurement = getMeasurement(currentPoints, currentTextPosition, drawingMode, measurements, image)
 
   return currentMeasurement
 }

--- a/libs/insight-viewer/src/utils/common/getDrewAnnotation.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getDrewAnnotation.spec.ts
@@ -87,13 +87,19 @@ describe('getDrewAnnotation: ', () => {
       ],
       type: 'text',
     })
-    expect(getDrewAnnotation(MOCK_IMAGE, MOCK_POINTS_2, MOCK_ID_2, 'circle', 'normal')).toStrictEqual({
-      id: 99,
-      center: [100, 100],
-      labelPosition: [100, 100],
-      lineWidth: 1.5,
-      radius: 42.42640687119285,
-      type: 'circle',
-    })
+    /**
+     * TODO
+     * The test code below was commented out because the circle Annotation is not completed
+     * start point should be a center since the radius calculation logic has changed
+     * by the circle Measurement function change
+     */
+    // expect(getDrewAnnotation(MOCK_IMAGE, MOCK_POINTS_2, MOCK_ID_2, 'circle', 'normal')).toStrictEqual({
+    //   id: 99,
+    //   center: [100, 100],
+    //   labelPosition: [100, 100],
+    //   lineWidth: 1.5,
+    //   radius: 42.42640687119285,
+    //   type: 'circle',
+    // })
   })
 })

--- a/libs/insight-viewer/src/utils/common/getDrewAnnotation.ts
+++ b/libs/insight-viewer/src/utils/common/getDrewAnnotation.ts
@@ -23,6 +23,11 @@ export function getDrewAnnotation(
 
   if (mode === 'circle') {
     const [startPoint, endPoint] = points
+    /**
+     * TODO
+     * start point should be a center since the radius calculation logic has changed
+     * by the circle Measurement function change
+     */
     const { radius } = getCircleRadiusByMeasuringUnit(startPoint, endPoint, image)
     drewAnnotation = {
       ...defaultAnnotationInfo,

--- a/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
@@ -12,8 +12,8 @@ describe('getEditPointPosition: ', () => {
       [50, 50],
     ]
 
-    expect(getEditPointPosition(MOCK_POINT_1, null)).toEqual([0, 0, 10, 10])
-    expect(getEditPointPosition(MOCK_POINT_2, null)).toEqual([30, 30, 50, 50])
+    expect(getEditPointPosition(MOCK_POINT_1, null)).toEqual(null)
+    expect(getEditPointPosition(MOCK_POINT_2, null)).toEqual(null)
   })
 
   it('should return the points with line type editTarget', () => {

--- a/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
@@ -2,7 +2,7 @@ import { Point, Annotation, Measurement } from '../../types'
 import { getEditPointPosition } from './getEditPointPosition'
 
 describe('getEditPointPosition: ', () => {
-  it('should return the points without editTarget', () => {
+  it('should return null without editTarget', () => {
     const MOCK_POINT_1: Point[] = [
       [0, 0],
       [10, 10],

--- a/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
@@ -2,7 +2,7 @@ import { Point, Annotation, Measurement } from '../../types'
 import { getEditPointPosition } from './getEditPointPosition'
 
 describe('getEditPointPosition: ', () => {
-  it('should return null without editTarget', () => {
+  it('should return ruler points when editTarget is null', () => {
     const MOCK_POINT_1: Point[] = [
       [0, 0],
       [10, 10],
@@ -12,8 +12,21 @@ describe('getEditPointPosition: ', () => {
       [50, 50],
     ]
 
-    expect(getEditPointPosition(MOCK_POINT_1, null)).toEqual(null)
-    expect(getEditPointPosition(MOCK_POINT_2, null)).toEqual(null)
+    expect(getEditPointPosition(MOCK_POINT_1, null)).toEqual([0, 0, 10, 10])
+    expect(getEditPointPosition(MOCK_POINT_2, null)).toEqual([30, 30, 50, 50])
+  })
+  it('should return null when editTarget is null but drawingMode is circle ', () => {
+    const MOCK_POINT_1: Point[] = [
+      [0, 0],
+      [10, 10],
+    ]
+    const MOCK_POINT_2: Point[] = [
+      [30, 30],
+      [50, 50],
+    ]
+
+    expect(getEditPointPosition(MOCK_POINT_1, null, 'circle')).toEqual(null)
+    expect(getEditPointPosition(MOCK_POINT_2, null, 'circle')).toEqual(null)
   })
 
   it('should return the points with line type editTarget', () => {

--- a/libs/insight-viewer/src/utils/common/getEditPointPosition.ts
+++ b/libs/insight-viewer/src/utils/common/getEditPointPosition.ts
@@ -5,23 +5,32 @@ import type { Point, Annotation, Measurement } from '../../types'
 
 export type EditPoints = [startX: number, startY: number, endX: number, endY: number]
 
-export function getEditPointPosition(points: Point[], editTarget: Annotation | null): EditPoints | null
-
-export function getEditPointPosition(points: Point[], editTarget: Measurement | null): EditPoints | null
-
-export function getEditPointPosition(points: Point[], editTarget: Measurement | Annotation | null): EditPoints | null {
+export function getEditPointPosition(
+  points: Point[],
+  editTarget: Measurement | Annotation | null,
+  drawingMode?: 'circle' | 'ruler'
+): EditPoints | null {
   // if there's more than 2 points, it cannot edit(can just move)
-  if (points.length !== 2 || editTarget === null) return null
+  if (points.length !== 2) return null
 
-  if (editTarget.type === 'circle') {
+  /**
+   * TODO
+   * drawingMode prop and below code should be deleted if the circle's edit method is changed
+   * when drawing but isn't editing: editTarget === null && drawingMode === 'circle'
+   */
+  if (editTarget === null && drawingMode === 'circle') {
+    return null
+  }
+
+  if (editTarget && editTarget.type === 'circle') {
     const [centerPoint, endPoint] = points
     const radius = getCircleRadiusByCenter(centerPoint, endPoint)
     const editPoints = getCircleEditPoints(centerPoint, radius)
-
     return editPoints
   }
 
   // line annotation or ruler measurement
   const [startPoint, endPoint] = points
+
   return [startPoint[0], startPoint[1], endPoint[0], endPoint[1]]
 }

--- a/libs/insight-viewer/src/utils/common/getEditPointPosition.ts
+++ b/libs/insight-viewer/src/utils/common/getEditPointPosition.ts
@@ -1,9 +1,9 @@
 import { getCircleEditPoints } from './getCircleEditPoints'
-import { getCircleRadius } from '../../utils/common/getCircleRadius'
+import { getCircleRadiusByCenter } from '../../utils/common/getCircleRadius'
 
 import type { Point, Annotation, Measurement } from '../../types'
 
-export type EditPoints = [number, number, number, number]
+export type EditPoints = [startX: number, startY: number, endX: number, endY: number]
 
 export function getEditPointPosition(points: Point[], editTarget: Annotation | null): EditPoints | null
 
@@ -11,18 +11,17 @@ export function getEditPointPosition(points: Point[], editTarget: Measurement | 
 
 export function getEditPointPosition(points: Point[], editTarget: Measurement | Annotation | null): EditPoints | null {
   // if there's more than 2 points, it cannot edit(can just move)
-  if (points.length !== 2) return null
+  if (points.length !== 2 || editTarget === null) return null
 
-  const startPoint = points[0]
-  const endPoint = points[1]
-
-  if (editTarget && editTarget.type === 'circle') {
-    const radius = getCircleRadius(points[0], points[1])
-    const editPoints = getCircleEditPoints(startPoint, radius)
+  if (editTarget.type === 'circle') {
+    const [centerPoint, endPoint] = points
+    const radius = getCircleRadiusByCenter(centerPoint, endPoint)
+    const editPoints = getCircleEditPoints(centerPoint, radius)
 
     return editPoints
   }
 
   // line annotation or ruler measurement
+  const [startPoint, endPoint] = points
   return [startPoint[0], startPoint[1], endPoint[0], endPoint[1]]
 }

--- a/libs/insight-viewer/src/utils/common/getMeasurement.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurement.spec.ts
@@ -5,7 +5,7 @@ import type { Image } from '../../Viewer/types'
 
 describe('getMeasurement: ', () => {
   it('should return the measurement in ruler mode without text, image', () => {
-    const MOCK_POINTS: [mouseDownPoint: Point, mouseUpPoint: Point] = [
+    const MOCK_POINTS: [startPoint: Point, endPoint: Point] = [
       [0, 0],
       [10, 10],
     ]
@@ -53,7 +53,7 @@ describe('getMeasurement: ', () => {
   })
 
   it('should return the measurement in ruler mode with text, image', () => {
-    const MOCK_POINTS: [mouseDownPoint: Point, mouseUpPoint: Point] = [
+    const MOCK_POINTS: [startPoint: Point, endPoint: Point] = [
       [10, 10],
       [20, 20],
     ]
@@ -79,18 +79,18 @@ describe('getMeasurement: ', () => {
   })
 
   it('should return the measurement in circle mode without text, image', () => {
-    const MOCK_POINTS: [mouseDownPoint: Point, mouseUpPoint: Point] = [
+    const MOCK_POINTS: [startPoint: Point, endPoint: Point] = [
       [0, 0],
       [20, 20],
     ]
     const MOCK_MEASUREMENTS: Measurement[] = []
 
     expect(getMeasurement(MOCK_POINTS, null, 'circle', MOCK_MEASUREMENTS, null)).toStrictEqual({
-      centerPoint: [0, 0],
+      centerPoint: [10, 10],
       id: 1,
       lineWidth: 1.5,
-      measuredValue: 28.284271247461902,
-      radius: 28.284271247461902,
+      measuredValue: 14.142135623730951,
+      radius: 14.142135623730951,
       textPoint: null,
       type: 'circle',
       unit: 'px',
@@ -109,11 +109,11 @@ describe('getMeasurement: ', () => {
       },
     ]
     const EXPECTED_2 = {
-      centerPoint: [0, 0],
+      centerPoint: [10, 10],
       id: 3,
       lineWidth: 1.5,
-      measuredValue: 28.284271247461902,
-      radius: 28.284271247461902,
+      measuredValue: 14.142135623730951,
+      radius: 14.142135623730951,
       textPoint: null,
       type: 'circle',
       unit: 'px',
@@ -123,7 +123,7 @@ describe('getMeasurement: ', () => {
   })
 
   it('should return the measurement in circle mode with text, image', () => {
-    const MOCK_POINTS: [mouseDownPoint: Point, mouseUpPoint: Point] = [
+    const MOCK_POINTS: [startPoint: Point, endPoint: Point] = [
       [10, 10],
       [15, 60],
     ]
@@ -136,10 +136,10 @@ describe('getMeasurement: ', () => {
 
     expect(getMeasurement(MOCK_POINTS, MOCK_TEXT_POINT, 'circle', MOCK_MEASUREMENTS, MOCK_IMAGE)).toStrictEqual({
       id: 1,
-      measuredValue: 30.14962686336267,
-      radius: 50.24937810560445,
+      measuredValue: 15.074813431681335,
+      radius: 25.124689052802225,
       lineWidth: 1.5,
-      centerPoint: [10, 10],
+      centerPoint: [12.5, 35],
       textPoint: [50, 50],
       type: 'circle',
       unit: 'mm',

--- a/libs/insight-viewer/src/utils/common/getMeasurement.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurement.ts
@@ -1,17 +1,19 @@
 import { getLineLength } from './getLineLength'
+
+import { getCircleCenterPoint } from './getCircleCenterPoint'
 import { getCircleRadiusByMeasuringUnit, getCircleRadius } from './getCircleRadius'
 
 import type { Image } from '../../Viewer/types'
 import type { Point, Measurement, MeasurementMode } from '../../types'
 
 export function getMeasurement(
-  points: [mouseDownPoint: Point, mouseUpPoint: Point],
+  points: [Point, Point],
   textPoint: Point | null,
   mode: MeasurementMode,
   measurements: Measurement[],
   image: Image | null
 ): Measurement {
-  const [mouseDownPoint, mouseUpPoint] = points
+  const [startPoint, endPoint] = points
   const currentId = measurements.length === 0 ? 1 : Math.max(...measurements.map(({ id }) => id), 0) + 1
 
   const defaultMeasurementInfo: Pick<Measurement, 'id' | 'lineWidth'> = {
@@ -20,13 +22,14 @@ export function getMeasurement(
   }
 
   if (mode === 'circle') {
-    const radiusWithoutUnit = getCircleRadius(mouseDownPoint, mouseUpPoint)
-    const { radius, unit } = getCircleRadiusByMeasuringUnit(mouseDownPoint, mouseUpPoint, image)
+    const centerPoint = getCircleCenterPoint(startPoint, endPoint)
+    const radiusWithoutUnit = getCircleRadius(startPoint, endPoint)
+    const { radius, unit } = getCircleRadiusByMeasuringUnit(startPoint, endPoint, image)
 
     return {
       ...defaultMeasurementInfo,
       type: 'circle',
-      centerPoint: mouseDownPoint,
+      centerPoint: centerPoint,
       textPoint,
       radius: radiusWithoutUnit,
       measuredValue: radius,
@@ -35,12 +38,12 @@ export function getMeasurement(
   }
 
   // Ruler EditMode
-  const { length, unit } = getLineLength(mouseDownPoint, mouseUpPoint, image)
+  const { length, unit } = getLineLength(startPoint, endPoint, image)
   return {
     ...defaultMeasurementInfo,
     type: 'ruler',
     textPoint,
-    startAndEndPoint: [mouseDownPoint, mouseUpPoint],
+    startAndEndPoint: [startPoint, endPoint],
     measuredValue: length,
     unit,
   }

--- a/libs/insight-viewer/src/utils/common/getMeasurementEditingPoints.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurementEditingPoints.spec.ts
@@ -84,7 +84,7 @@ describe('getMeasurementEditingPoints: ', () => {
       [25, 25],
     ])
   })
-  it('should return correct points when edit mode is startPoint and measurement mode is circle', () => {
+  it('should return centerPoint when editMode is startPoint and measurement is circle', () => {
     const MOCK_PREV_POINT_1: [Point, Point] = [
       [0, 0],
       [10, 10],
@@ -110,22 +110,22 @@ describe('getMeasurementEditingPoints: ', () => {
       getMeasurementEditingPoints(MOCK_PREV_POINT_1, MOCK_CURRENT_POINT_1, MOCK_EDIT_POINT_1, 'startPoint', 'circle')
     ).toEqual([
       [0, 0],
-      [5, 5],
+      [7.0710678118654755, 0],
     ])
     expect(
       getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'startPoint', 'circle')
     ).toEqual([
       [10, 20],
-      [15, 15],
+      [17.071067811865476, 20],
     ])
     expect(
       getMeasurementEditingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, MOCK_EDIT_POINT_3, 'startPoint', 'circle')
     ).toEqual([
       [40, 60],
-      [25, 25],
+      [78.07886552931954, 60],
     ])
   })
-  it('should return correct points when edit mode is endPoint and measurement mode is circle', () => {
+  it('should return centerPoint when editMode is endPoint and measurement is circle', () => {
     const MOCK_PREV_POINT_1: [Point, Point] = [
       [0, 0],
       [10, 10],
@@ -151,19 +151,19 @@ describe('getMeasurementEditingPoints: ', () => {
       getMeasurementEditingPoints(MOCK_PREV_POINT_1, MOCK_CURRENT_POINT_1, MOCK_EDIT_POINT_1, 'endPoint', 'circle')
     ).toEqual([
       [0, 0],
-      [5, 5],
+      [7.0710678118654755, 0],
     ])
     expect(
       getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'endPoint', 'circle')
     ).toEqual([
       [10, 20],
-      [15, 15],
+      [17.071067811865476, 20],
     ])
     expect(
       getMeasurementEditingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, MOCK_EDIT_POINT_3, 'endPoint', 'circle')
     ).toEqual([
       [40, 60],
-      [25, 25],
+      [78.07886552931954, 60],
     ])
   })
 

--- a/libs/insight-viewer/src/utils/common/getMeasurementEditingPoints.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurementEditingPoints.ts
@@ -1,5 +1,8 @@
-import { Point, EditMode, MeasurementMode } from '../../types'
 import { getMovedPoints } from './getMovedPoints'
+import { getCircleRadiusByCenter } from './getCircleRadius'
+import { getCircleEndPoint } from './getCircleEndPoint'
+
+import type { Point, EditMode, MeasurementMode } from '../../types'
 
 export function getMeasurementEditingPoints(
   prevPoints: [Point, Point],
@@ -17,7 +20,12 @@ export function getMeasurementEditingPoints(
   }
 
   if (mode === 'circle' && (editMode === 'startPoint' || editMode === 'endPoint')) {
-    return [prevPoints[0], currentPoint]
+    const prevCenter = prevPoints[0]
+
+    const currentRadius = getCircleRadiusByCenter(prevCenter, currentPoint)
+    const movedEndPoint = getCircleEndPoint(prevCenter, currentRadius)
+
+    return [prevCenter, movedEndPoint]
   }
 
   if ((mode === 'circle' || mode === 'ruler') && editMode === 'move') {

--- a/libs/insight-viewer/src/utils/common/getMeasurementPointsByMode.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurementPointsByMode.spec.ts
@@ -1,0 +1,162 @@
+import { getMeasurementPointsByMode } from './getMeasurementPointsByMode'
+
+import type { Point } from '../../types'
+
+describe('getMeasurementPointsByMode: ', () => {
+  const DRAWING_MODE_CIRCLE = 'circle'
+  const DRAWING_MODE_RULER = 'ruler'
+
+  const MOCK_PREV_POINTS_1: [centerPoint: Point, endPoint: Point] = [
+    [0, 0],
+    [10, 10],
+  ]
+  const MOCK_PREV_POINTS_2: [centerPoint: Point, endPoint: Point] = [
+    [13, 15],
+    [1000, 7],
+  ]
+  const MOCK_MOUSE_MOVE_POINT_1: Point = [300, 210]
+  const MOCK_MOUSE_MOVE_POINT_2: Point = [123089, 29]
+
+  it('should return the mouse-down and mouse-move points when drawing mode is circle and mouse-down point is not null', () => {
+    const MOCK_MOUSE_DOWN_POINT_1: Point = [0, 0]
+    const MOCK_MOUSE_DOWN_POINT_2: Point = [10000, 10000]
+
+    const MOCK_EXPECT_RESULT_1: [Point, Point] = [
+      [0, 0],
+      [300, 210],
+    ]
+    const MOCK_EXPECT_RESULT_2: [Point, Point] = [
+      [10000, 10000],
+      [123089, 29],
+    ]
+
+    expect(
+      getMeasurementPointsByMode(
+        false,
+        null,
+        DRAWING_MODE_CIRCLE,
+        MOCK_MOUSE_DOWN_POINT_1,
+        MOCK_MOUSE_MOVE_POINT_1,
+        MOCK_PREV_POINTS_1
+      )
+    ).toStrictEqual(MOCK_EXPECT_RESULT_1)
+
+    expect(
+      getMeasurementPointsByMode(
+        false,
+        null,
+        DRAWING_MODE_CIRCLE,
+        MOCK_MOUSE_DOWN_POINT_2,
+        MOCK_MOUSE_MOVE_POINT_2,
+        MOCK_PREV_POINTS_2
+      )
+    ).toStrictEqual(MOCK_EXPECT_RESULT_2)
+  })
+
+  it('should return the current start and end points when when isEditing is true and editMode is not null of circle', () => {
+    const MOCK_MOUSE_DOWN_POINT_1: Point = [0, 0]
+    const MOCK_MOUSE_DOWN_POINT_2 = null
+
+    const MOCK_EXPECT_RESULT_1: [Point, Point] = [
+      [-14.142135623730951, 0],
+      [10, 10],
+    ]
+    const MOCK_EXPECT_RESULT_2: [Point, Point] = [
+      [-974.0324209467489, 15],
+      [1000, 7],
+    ]
+
+    expect(
+      getMeasurementPointsByMode(
+        true,
+        'move',
+        DRAWING_MODE_CIRCLE,
+        MOCK_MOUSE_DOWN_POINT_1,
+        MOCK_MOUSE_MOVE_POINT_1,
+        MOCK_PREV_POINTS_1
+      )
+    ).toStrictEqual(MOCK_EXPECT_RESULT_1)
+
+    expect(
+      getMeasurementPointsByMode(
+        true,
+        'startPoint',
+        DRAWING_MODE_CIRCLE,
+        MOCK_MOUSE_DOWN_POINT_2,
+        MOCK_MOUSE_MOVE_POINT_2,
+        MOCK_PREV_POINTS_2
+      )
+    ).toStrictEqual(MOCK_EXPECT_RESULT_2)
+  })
+
+  it('should return previous points when mouse-down points of circle is null', () => {
+    const MOCK_MOUSE_DOWN_POINT = null
+
+    const MOCK_EXPECT_RESULT_1 = [
+      [0, 0],
+      [10, 10],
+    ]
+    const MOCK_EXPECT_RESULT_2 = [
+      [13, 15],
+      [1000, 7],
+    ]
+
+    expect(
+      getMeasurementPointsByMode(
+        true,
+        null,
+        DRAWING_MODE_CIRCLE,
+        MOCK_MOUSE_DOWN_POINT,
+        MOCK_MOUSE_MOVE_POINT_1,
+        MOCK_PREV_POINTS_1
+      )
+    ).toStrictEqual(MOCK_EXPECT_RESULT_1)
+
+    expect(
+      getMeasurementPointsByMode(
+        false,
+        null,
+        DRAWING_MODE_CIRCLE,
+        MOCK_MOUSE_DOWN_POINT,
+        MOCK_MOUSE_MOVE_POINT_2,
+        MOCK_PREV_POINTS_2
+      )
+    ).toStrictEqual(MOCK_EXPECT_RESULT_2)
+  })
+
+  it('should return previous points when drawing mode is ruler', () => {
+    const MOCK_MOUSE_DOWN_POINT_1: Point = [0, 0]
+    const MOCK_MOUSE_DOWN_POINT_2: Point = [10000, 10000]
+
+    const MOCK_EXPECT_RESULT_1 = [
+      [0, 0],
+      [10, 10],
+    ]
+    const MOCK_EXPECT_RESULT_2 = [
+      [13, 15],
+      [1000, 7],
+    ]
+
+    expect(
+      getMeasurementPointsByMode(
+        true,
+        'endPoint',
+        DRAWING_MODE_RULER,
+        MOCK_MOUSE_DOWN_POINT_1,
+        MOCK_MOUSE_MOVE_POINT_1,
+        MOCK_PREV_POINTS_1
+      )
+    ).toStrictEqual(MOCK_EXPECT_RESULT_1)
+
+    expect(
+      getMeasurementPointsByMode(
+        false,
+        null,
+        DRAWING_MODE_RULER,
+        MOCK_MOUSE_DOWN_POINT_2,
+        MOCK_MOUSE_MOVE_POINT_2,
+        MOCK_PREV_POINTS_2
+      )
+    ).toStrictEqual(MOCK_EXPECT_RESULT_2)
+  })
+})

--- a/libs/insight-viewer/src/utils/common/getMeasurementPointsByMode.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurementPointsByMode.ts
@@ -1,22 +1,16 @@
-import { getMeasurement } from './getMeasurement'
 import { getCircleRadiusByCenter } from './getCircleRadius'
 import { getCircleStartPoint } from './getCircleStartPoint'
 
-import type { EditMode, Point, Measurement, MeasurementMode } from '../../types'
-import type { Image } from '../../Viewer/types'
+import type { EditMode, Point, MeasurementMode } from '../../types'
 
-export function getCurrentMeasurement(
+export function getMeasurementPointsByMode(
   isEditing: boolean,
   editMode: EditMode | null,
   drawingMode: MeasurementMode,
-  currentTextPosition: Point | null,
   mouseDownPoint: Point | null,
   mouseMovePoint: Point,
-  prevPoints: [centerPoint: Point, endPoint: Point],
-  measurements: Measurement[],
-  image: Image | null
-) {
-  let currentMeasurement = null
+  prevPoints: [centerPoint: Point, endPoint: Point]
+): [Point, Point] {
   let currentPoints = prevPoints
 
   if (drawingMode === 'circle' && mouseDownPoint !== null) {
@@ -31,7 +25,5 @@ export function getCurrentMeasurement(
     currentPoints = [currentStartPoint, currentEndPoint]
   }
 
-  currentMeasurement = getMeasurement(currentPoints, currentTextPosition, drawingMode, measurements, image)
-
-  return currentMeasurement
+  return currentPoints
 }

--- a/libs/insight-viewer/src/utils/common/getMovedPoints.ts
+++ b/libs/insight-viewer/src/utils/common/getMovedPoints.ts
@@ -1,12 +1,12 @@
-import { Point } from '../../types'
+import type { Point } from '../../types'
 
-interface GetMoveRulerPointsProp {
+interface GetMovedPointsProp {
   prevPoints: Point[]
   editStartPoint: Point
   currentPoint: Point
 }
 
-export function getMovedPoints({ prevPoints, editStartPoint, currentPoint }: GetMoveRulerPointsProp): [Point, Point] {
+export function getMovedPoints({ prevPoints, editStartPoint, currentPoint }: GetMovedPointsProp): [Point, Point] {
   const [currentX, currentY] = currentPoint
   const [startEditX, startEditY] = editStartPoint
 


### PR DESCRIPTION
## 📝 Description

[Circle Measurement 구현 방식 변경](https://lunit.atlassian.net/browse/VIEWER-2)
- mouseDown이 circle 그리기의 시작점이 되도록 구현 방식 변경 
- 관련 좌표계 및 Measurement 생성 방식 변경
- 관련 테스트 코드 변경
- 기타 리팩토링 & circle annotation 주석 처리

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [x] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

- mouseDown이 circle의 중심점이 됨
- circle Measurement의 center와 관련된 마우스 좌표값은 mouseDown뿐이므로 startPoint를 기준으로 모든 관련 로직을 계산
- radius를 계산하는 함수 역시, 인자로 startPoint(mouseDown)가 오는지 혹은 centerPoint(mouseDown, mouseUp/mouseMove에 따라 계산된 값)에 따라서 나뉘어져 있지 않음
- editMode가 startPoint 혹은 endPoint일 때 이전의 start와 end 포인트를 돌려줌
- circle이 그려질 때 measurement에 전달되는 현재 좌표값은 startPoint, endPoint로 고정

## 🚀 New behavior

- mouseDown, mouseUp/mouseMove를 받아 두 점 사이의 중점을 계산한 값이 circle의 중심점이 됨
- circle Measurement의 center와 관련된 마우스 좌표값이 mouseDown 및 계산한 center 값이 되면서 관련 로직도 2가지로 나뉘어져 처리됨
- radius를 계산하는 함수는 인자로 startPoint(mouseDown)가 오는지 혹은 centerPoint(mouseDown, mouseUp/mouseMove에 따라 계산된 값)에 따라서 나뉘어짐
- editMode가 startPoint 혹은 endPoint일 때 이전의 center와 end 포인트를 재계산하여 돌려줌
- circle이 그려지는 경우가 2가지로 나뉨. 
   - 1)drawing 혹은 editing 상태(edit 토글 버튼 on)으로 mouseDownPoint가 startPoint로 전달됨
   - 2)editing 상태이며 editMode가 존재할 때로 편집 중인 circle의 center 혹은 radius 값이 변함에 따라 startPoint, endPoint도 재계산되어 measurement에 전달됨
- (기타) 네이밍 리팩토링 & circle annotation의 radius, center 관련 코드 및 테스트 주석 처리(아직 circle annotation은 구현되지 않았으나 기본 골조는 작성된 상태로 measurement와 동일한 함수를 공유하고 있어 @LTakhyunKim 님과 상의 하에 주석 처리했습니다.)

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
