### PR TITLE
Hotfix / publish code change

### DIFF
--- a/libs/insight-viewer/project.json
+++ b/libs/insight-viewer/project.json
@@ -29,7 +29,7 @@
     "publish": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "command": "node tools/scripts/publish.mjs test {args.ver} {args.tag}"
+        "command": "node tools/scripts/publish.mjs"
       },
       "dependsOn": [
         {

--- a/tools/scripts/publish.mjs
+++ b/tools/scripts/publish.mjs
@@ -27,8 +27,8 @@ process.chdir(outputPath)
 // Execute "npm publish" to publish
 try {
   const json = JSON.parse(readFileSync(`package.json`).toString())
-  // json.version = version
-  execSync(`npm pack --pack-destination="./dist" --dry-run --tag ${json.version}`)
+
+  execSync(`npm publish --access public --tag ${json.version}`)
 } catch (e) {
   console.error(chalk.bold.red(`Error reading package.json file from library build output.`))
 }

--- a/tools/scripts/publish.mjs
+++ b/tools/scripts/publish.mjs
@@ -1,15 +1,6 @@
-/**
- * This is a minimal script to publish your package to "npm".
- * This is meant to be used as-is or customize as you see fit.
- *
- * This script is executed on "dist/path/to/library" as "cwd" by default.
- *
- * You might need to authenticate with NPM before running this script.
- */
-
 import { readCachedProjectGraph } from '@nrwl/devkit'
 import { execSync } from 'child_process'
-import { readFileSync, writeFileSync } from 'fs'
+import { readFileSync } from 'fs'
 import chalk from 'chalk'
 
 function invariant(condition, message) {
@@ -19,38 +10,25 @@ function invariant(condition, message) {
   }
 }
 
-// Executing publish script: node path/to/publish.mjs {name} --version {version} --tag {tag}
-// Default "tag" to "next" so we won't publish the "latest" tag by accident.
-const [, , name, version, tag = 'next'] = process.argv
-
-// A simple SemVer validation to validate the version
-const validVersion = /^\d+\.\d+\.\d+(-\w+\.\d+)?/
-invariant(
-  version && validVersion.test(version),
-  `No version provided or version did not match Semantic Versioning, expected: #.#.#-tag.# or #.#.#, got ${version}.`
-)
+const PUBLISH_PROJECT_NAME = 'insight-viewer'
 
 const graph = readCachedProjectGraph()
-const project = graph.nodes[name]
-
-invariant(project, `Could not find project "${name}" in the workspace. Is the project.json configured correctly?`)
+const project = graph.nodes[PUBLISH_PROJECT_NAME]
 
 const outputPath = project.data?.targets?.build?.options?.outputPath
+
 invariant(
   outputPath,
-  `Could not find "build.options.outputPath" of project "${name}". Is project.json configured  correctly?`
+  `Could not find "build.options.outputPath" of project "${PUBLISH_PROJECT_NAME}". Is project.json configured  correctly?`
 )
 
 process.chdir(outputPath)
 
-// Updating the version in "package.json" before publishing
+// Execute "npm publish" to publish
 try {
   const json = JSON.parse(readFileSync(`package.json`).toString())
-  json.version = version
-  writeFileSync(`package.json`, JSON.stringify(json, null, 2))
+  // json.version = version
+  execSync(`npm pack --pack-destination="./dist" --dry-run --tag ${json.version}`)
 } catch (e) {
   console.error(chalk.bold.red(`Error reading package.json file from library build output.`))
 }
-
-// Execute "npm publish" to publish
-execSync(`npm publish --access public --tag ${tag}`)


### PR DESCRIPTION
## 📝 Description

INSIGHT Viewer 배포 시 사용되는 publish 코드를 수정했습니다.
수정 방향성은 아래와 같습니다.

1. 기존 publish code 는 workspace 내 다양한 library (project) 를 배포하기 위한 목적입니다.
   INSIGHT Viewer 에서는 다른 project 는 배포하지 않을 예정이므로 이를 INSIGHT Viewer 에 맞게 수정했습니다.
   
2. 현재 배포 프로세스는 `version bump 및 CHANGE_LOG 반영 후 npm 배포를 진행`할 예정입니다.
    그렇기에 tag 는 root package.json 의 version 을 트래킹하면 될 것 같아 수정했습니다.
    

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

배포를 위한 version, project name, tag 설정이 필요합니다.

Issue Number: N/A

## 🚀 New behavior

insight viewer 에서 publish 시 별도의 version, project name, tag 설정을 하지 않습니다.
project name 은 내부의 상수값을 선언하여 대체,
version 은 root package.json 의 version 을 사용
tag 도 마찬가지로 해당 version 을 사용합니다. f48771d

publish command 수정 [928d1a1](https://github.com/lunit-io/frontend-components/pull/307/commits/928d1a1a009b58d5768679cb1052ee38a98c028d)

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
