### PR TITLE
VIEWER-58 / Hotfix / Annotation Drawer hide label bug fix

### DIFF
--- a/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
@@ -24,6 +24,7 @@ function AnnotationDrawerContainer(): JSX.Element {
   const [annotationMode, setAnnotationMode] = useState<AnnotationMode>('polygon')
   const [lineHeadMode, setLineHeadMode] = useState<LineHeadMode>('normal')
   const [isEditing, setIsEditing] = useState(false)
+  const [isShowLabel, setIsShowLabel] = useState(false)
 
   const { ImageSelect, selected } = useImageSelect()
   const { loadingState, image } = useImage({
@@ -53,6 +54,10 @@ function AnnotationDrawerContainer(): JSX.Element {
     setIsEditing(event.target.checked)
   }
 
+  const handleShowLabelModeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setIsShowLabel(event.target.checked)
+  }
+
   return (
     <Box data-cy-loaded={loadingState}>
       <Box>
@@ -60,6 +65,10 @@ function AnnotationDrawerContainer(): JSX.Element {
       </Box>
       <Box>
         edit mode <Switch data-cy-edit={isEditing} onChange={handleEditModeChange} isChecked={isEditing} />
+      </Box>
+      <Box>
+        show label{' '}
+        <Switch data-cy-show-label={isShowLabel} onChange={handleShowLabelModeChange} isChecked={isShowLabel} />
       </Box>
       <RadioGroup onChange={handleAnnotationModeClick} value={annotationMode}>
         <Stack direction="row">
@@ -100,7 +109,7 @@ function AnnotationDrawerContainer(): JSX.Element {
               annotations={annotations}
               hoveredAnnotation={hoveredAnnotation}
               selectedAnnotation={selectedAnnotation}
-              showAnnotationLabel
+              showAnnotationLabel={isShowLabel}
               onAdd={addAnnotation}
               onFocus={hoverAnnotation}
               onRemove={removeAnnotation}

--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.types.ts
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.types.ts
@@ -7,6 +7,12 @@ export interface AnnotationDrawerProps extends SVGProps<SVGSVGElement> {
 
   isEditing?: boolean
 
+  /**
+   * annotation label notation flag variable
+   * Default value is false
+   */
+  showAnnotationLabel?: boolean
+
   /** When drawing is complete and a new annotation occurs */
   onAdd: (annotation: Annotation) => void
   onSelectAnnotation: (annotation: Annotation | null) => void

--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
@@ -15,6 +15,7 @@ export function AnnotationDrawer({
   width,
   height,
   isEditing = false,
+  showAnnotationLabel = false,
   annotations,
   selectedAnnotation,
   onSelectAnnotation,
@@ -69,6 +70,7 @@ export function AnnotationDrawer({
             <PolylineDrawer
               annotation={annotation}
               isSelectedMode={isSelectedAnnotation}
+              showAnnotationLabel={showAnnotationLabel}
               isPolygonSelected={selectedAnnotation?.type === 'polygon'}
               lineHead={lineHead}
               selectedAnnotationLabel={selectedAnnotation ? selectedAnnotation.label ?? selectedAnnotation.id : null}

--- a/libs/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
@@ -50,6 +50,7 @@ export function AnnotationOverlay({
           height={height}
           annotations={annotations}
           selectedAnnotation={selectedAnnotation}
+          showAnnotationLabel={showAnnotationLabel}
           className={className}
           style={style}
           device={device}

--- a/libs/insight-viewer/src/Viewer/PolylineDrawer/PolylineDrawer.types.ts
+++ b/libs/insight-viewer/src/Viewer/PolylineDrawer/PolylineDrawer.types.ts
@@ -4,6 +4,7 @@ export interface PolylineDrawerProps {
   annotation: PolygonAnnotation | FreeLineAnnotation | LineAnnotation
   isSelectedMode: boolean
   lineHead: LineHeadMode
+  showAnnotationLabel: boolean
   selectedAnnotationLabel: string | number | null
   setAnnotationEditMode: (mode: EditMode) => void
   isPolygonSelected?: boolean

--- a/libs/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
@@ -18,6 +18,7 @@ export function PolylineDrawer({
   lineHead,
   isSelectedMode,
   selectedAnnotationLabel,
+  showAnnotationLabel,
   isPolygonSelected,
   setAnnotationEditMode,
 }: PolylineDrawerProps): ReactElement {
@@ -79,7 +80,7 @@ export function PolylineDrawer({
           />
         </>
       )}
-      {selectedAnnotationLabel && labelPosition && (
+      {showAnnotationLabel && selectedAnnotationLabel && labelPosition && (
         <text style={{ ...textStyle.default }} x={labelPosition[0]} y={labelPosition[1]}>
           {selectedAnnotationLabel}
         </text>


### PR DESCRIPTION
## 📝 Description

Annotation Edit 기능 사용 시 label show 기능을 비활성화한 상태여도
label 이 표기되는 버그를 수정했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Annotation Edit 기능 사용 시, label show option 과 관계없이 항상 보였습니다.
label show 가 false 일 경우엔 label 이 표기되지 않는 것이 정상 동작입니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-58

## 🚀 New behavior

Annotation Edit 기능 사용 시 label show option 에 따라 label 표기 여부가 결정됩니다.
label show 가 false 일 경우엔 label 이 표기되지 않습니다.

Annotation Drawer 및 PolylineDrawer 에 `showAnnotationLabel` prop 추가 
`showAnnotationLabel` 에 따라 text tag conditional render 로 문제 해결 751daa2

Annotation Drawer Docs 에서 label switch button 추가 8d82a0c
위 기능 테스트를 위해 추가했습니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

