### PR TITLE
Viewer-52 / Parameterize useImage's HTTP client

### DIFF
--- a/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
@@ -10,6 +10,7 @@ import InsightViewer, {
   LineHeadMode,
 } from '@lunit/insight-viewer'
 import useImageSelect from '../../../components/ImageSelect/useImageSelect'
+import ky from 'ky'
 
 const style = {
   display: 'flex',
@@ -20,6 +21,12 @@ const style = {
 /** Mock svg Size */
 const DEFAULT_SIZE = { width: 700, height: 700 }
 
+const httpClient = async (url: string) => {
+  const http = ky.create({})
+  const res = await http.get(url)
+  return res.arrayBuffer()
+}
+
 function AnnotationDrawerContainer(): JSX.Element {
   const [annotationMode, setAnnotationMode] = useState<AnnotationMode>('polygon')
   const [lineHeadMode, setLineHeadMode] = useState<LineHeadMode>('normal')
@@ -29,6 +36,7 @@ function AnnotationDrawerContainer(): JSX.Element {
   const { ImageSelect, selected } = useImageSelect()
   const { loadingState, image } = useImage({
     wadouri: selected,
+    loader: httpClient,
   })
   const { viewport, setViewport } = useViewport()
   const {

--- a/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
@@ -10,7 +10,6 @@ import InsightViewer, {
   LineHeadMode,
 } from '@lunit/insight-viewer'
 import useImageSelect from '../../../components/ImageSelect/useImageSelect'
-import ky from 'ky'
 
 const style = {
   display: 'flex',
@@ -21,12 +20,6 @@ const style = {
 /** Mock svg Size */
 const DEFAULT_SIZE = { width: 700, height: 700 }
 
-const httpClient = async (url: string) => {
-  const http = ky.create({})
-  const res = await http.get(url)
-  return res.arrayBuffer()
-}
-
 function AnnotationDrawerContainer(): JSX.Element {
   const [annotationMode, setAnnotationMode] = useState<AnnotationMode>('polygon')
   const [lineHeadMode, setLineHeadMode] = useState<LineHeadMode>('normal')
@@ -36,7 +29,6 @@ function AnnotationDrawerContainer(): JSX.Element {
   const { ImageSelect, selected } = useImageSelect()
   const { loadingState, image } = useImage({
     wadouri: selected,
-    loader: httpClient,
   })
   const { viewport, setViewport } = useViewport()
   const {

--- a/apps/insight-viewer-docs/containers/Basic/Code.ts
+++ b/apps/insight-viewer-docs/containers/Basic/Code.ts
@@ -1,4 +1,4 @@
-export const DICOM_CODE = `\
+export const DICOM_CODE_V1 = `\
 import InsightViewer, { useImage } from '@lunit/insight-viewer'
 
 const style = {
@@ -38,6 +38,53 @@ export default function App() {
   )
 }
 `
+
+export const DICOM_CODE_V2 = `\
+import InsightViewer, { useImage } from '@lunit/insight-viewer'
+import ky from 'ky'
+
+const style = {
+  width: '500px',
+  height: '500px'
+}
+
+const httpClient = async (url: string) => {
+  const http = ky.create({})
+  const res = await http.get(url)
+  return res.arrayBuffer()
+}
+
+export default function App() {
+  const { loadingState, image } = useImage({
+    wadouri: IMAGE_ID,
+    loader: httpClient, // optional, but can't use this property with requestInterceptor, onError, timeout
+    /**
+     * required if you want to support more transfer syntaxes
+     * see: https://github.com/cornerstonejs/cornerstoneWADOImageLoader/issues/403
+     */
+    loaderOptions: {
+      webWorkerManagerOptions: {
+        webWorkerTaskPaths: [
+          \`\${window.location.origin}/workers/610.bundle.min.worker.js\`,
+          \`\${window.location.origin}/workers/888.bundle.min.worker.js\`,
+        ],
+        taskConfiguration: {
+          decodeTask: {
+            initializeCodecsOnStartup: false,
+          },
+        },
+      },
+    },
+  })
+
+  return (
+    <div style={style}> // Wrapper size is required because InsightViewer's width/height is '100%'.
+      <InsightViewer image={image} />
+    </div>
+  )
+}
+`
+
 export const WEB_CODE = `\
 import InsightViewer, { useImage } from '@lunit/insight-viewer'
 

--- a/apps/insight-viewer-docs/containers/Basic/DicomImageViewer.tsx
+++ b/apps/insight-viewer-docs/containers/Basic/DicomImageViewer.tsx
@@ -4,7 +4,7 @@ import useImageSelect from '../../components/ImageSelect/useImageSelect'
 import CustomProgress from '../../components/CustomProgress'
 import { ViewerWrapper } from '../../components/Wrapper'
 import CodeBlock from '../../components/CodeBlock'
-import { DICOM_CODE } from './Code'
+import { DICOM_CODE_V1, DICOM_CODE_V2 } from './Code'
 import { CODE_SANDBOX } from '../../const'
 
 export default function DicomImageViewer(): JSX.Element {
@@ -44,7 +44,13 @@ export default function DicomImageViewer(): JSX.Element {
       </ViewerWrapper>
 
       <Box>
-        <CodeBlock code={DICOM_CODE} codeSandbox={CODE_SANDBOX.basic} />
+        <Text>Version 1</Text>
+        <CodeBlock code={DICOM_CODE_V1} codeSandbox={CODE_SANDBOX.basic} />
+      </Box>
+
+      <Box>
+        <Text>Version 2</Text>
+        <CodeBlock code={DICOM_CODE_V2} />
       </Box>
     </>
   )

--- a/libs/insight-viewer/src/hooks/useImage/getImageIdAndScheme.spec.ts
+++ b/libs/insight-viewer/src/hooks/useImage/getImageIdAndScheme.spec.ts
@@ -23,7 +23,7 @@ describe('getImageIdAndScheme()', () => {
     const imageType: ImageId = {
       [IMAGE_LOADER_SCHEME.WADO]: file,
     }
-    expect(getImageIdAndScheme(imageType).id).toEqual(file)
+    expect(getImageIdAndScheme(imageType).imageId).toEqual(file)
     expect(getImageIdAndScheme(imageType).scheme).toEqual(IMAGE_LOADER_SCHEME.WADO)
   })
 
@@ -31,7 +31,7 @@ describe('getImageIdAndScheme()', () => {
     const imageType: ImageId = {
       [IMAGE_LOADER_SCHEME.DICOMFILE]: file,
     }
-    expect(getImageIdAndScheme(imageType).id).toEqual(file)
+    expect(getImageIdAndScheme(imageType).imageId).toEqual(file)
     expect(getImageIdAndScheme(imageType).scheme).toEqual(IMAGE_LOADER_SCHEME.DICOMFILE)
   })
 
@@ -39,7 +39,7 @@ describe('getImageIdAndScheme()', () => {
     const imageType: ImageId = {
       [IMAGE_LOADER_SCHEME.WEB]: file,
     }
-    expect(getImageIdAndScheme(imageType).id).toEqual(file)
+    expect(getImageIdAndScheme(imageType).imageId).toEqual(file)
     expect(getImageIdAndScheme(imageType).scheme).toEqual(IMAGE_LOADER_SCHEME.WEB)
   })
 })

--- a/libs/insight-viewer/src/hooks/useImage/getImageIdAndScheme.ts
+++ b/libs/insight-viewer/src/hooks/useImage/getImageIdAndScheme.ts
@@ -2,7 +2,7 @@ import { IMAGE_LOADER_SCHEME } from '../../const'
 import { ImageId, ImageLoaderScheme } from '../../types'
 
 export interface ImageIdAndScheme {
-  id: string | undefined
+  imageId: string | undefined
   scheme: ImageLoaderScheme | undefined
 }
 
@@ -15,21 +15,21 @@ export function getItem(item: string | string[] | undefined): string | undefined
 export function getImageIdAndScheme(image: ImageId): ImageIdAndScheme {
   if (image[IMAGE_LOADER_SCHEME.WADO])
     return {
-      id: getItem(image[IMAGE_LOADER_SCHEME.WADO]),
+      imageId: getItem(image[IMAGE_LOADER_SCHEME.WADO]),
       scheme: IMAGE_LOADER_SCHEME.WADO,
     }
   if (image[IMAGE_LOADER_SCHEME.DICOMFILE])
     return {
-      id: getItem(image[IMAGE_LOADER_SCHEME.DICOMFILE]),
+      imageId: getItem(image[IMAGE_LOADER_SCHEME.DICOMFILE]),
       scheme: IMAGE_LOADER_SCHEME.DICOMFILE,
     }
   if (image[IMAGE_LOADER_SCHEME.WEB])
     return {
-      id: getItem(image[IMAGE_LOADER_SCHEME.WEB]),
+      imageId: getItem(image[IMAGE_LOADER_SCHEME.WEB]),
       scheme: IMAGE_LOADER_SCHEME.WEB,
     }
   return {
-    id: undefined,
+    imageId: undefined,
     scheme: undefined,
   }
 }

--- a/libs/insight-viewer/src/hooks/useImage/index.ts
+++ b/libs/insight-viewer/src/hooks/useImage/index.ts
@@ -1,9 +1,9 @@
-import { useEffect, useReducer, useRef } from 'react'
+import { useEffect, useMemo, useReducer, useRef } from 'react'
 /**
  * @fileoverview Loads an image(Dicom/Web) and return the loaded image and loading state of it.
  */
-import { LOADING_STATE, CONFIG } from '../../const'
-import { ImageId, HTTP, LoadingState } from '../../types'
+import { LOADING_STATE, CONFIG, IMAGE_LOADER_SCHEME } from '../../const'
+import { ImageId, LoadingState, OnError, RequestInterceptor } from '../../types'
 import { WadoImageLoaderOptions } from '../../utils/cornerstoneHelper'
 import { noop } from '../../utils/common'
 import { useImageLoader } from '../useImageLoader'
@@ -11,18 +11,33 @@ import { imageLoadReducer, INITIAL_IMAGE_LOAD_STATE } from './imageLoadReducer'
 import { loadImage } from './loadImage'
 import { getImageIdAndScheme } from './getImageIdAndScheme'
 import { Image } from '../../Viewer/types'
+import { getHttpClient } from '../../utils/httpClient'
 
 interface OnImageLoaded {
   (): void
 }
+
+interface UseImagePropsV1 {
+  timeout?: number
+  onError?: OnError
+  requestInterceptor?: RequestInterceptor
+  loader?: never
+}
+
+interface UseImagePropsV2 {
+  timeout?: never
+  onError?: never
+  requestInterceptor?: never
+  loader?: (url: string) => Promise<ArrayBuffer>
+}
+
+type Props = UseImagePropsV1 | UseImagePropsV2
 interface UseImage {
   (
-    props: Partial<HTTP> &
-      ImageId & {
-        onImageLoaded?: OnImageLoaded
-        loaderOptions?: WadoImageLoaderOptions
-        timeout?: number
-      }
+    props: ImageId & {
+      onImageLoaded?: OnImageLoaded
+      loaderOptions?: WadoImageLoaderOptions
+    } & Props
   ): {
     loadingState: LoadingState
     image: Image
@@ -34,38 +49,44 @@ interface UseImage {
  * @param requestInterceptor The callback is called before a request is sent.
  *  It use ky.js beforeRequest hook.
  * @param onError The error handler.
+ * @param loader The loader can setup custom http client.
  * @returns <{ image, loadingState }> image is a CornerstoneImage.
  *  loadingState is 'initial'|'loading'|'success'|'fail'
  */
 export const useImage: UseImage = ({
+  onImageLoaded = noop,
+  loaderOptions,
+  loader = undefined,
   requestInterceptor = CONFIG.requestInterceptor,
   onError = CONFIG.onError,
   timeout = CONFIG.timeout,
-  onImageLoaded = noop,
-  loaderOptions,
-  ...rest
+  ...imageIds
 }) => {
-  const { id: imageId, scheme: imageScheme } = getImageIdAndScheme(rest)
   const onImageLoadedRef = useRef<OnImageLoaded>()
-
   const [imageLoad, dispatch] = useReducer(imageLoadReducer, INITIAL_IMAGE_LOAD_STATE)
-  const hasLoader = useImageLoader(rest, onError, loaderOptions)
+  const hasLoader = useImageLoader(imageIds, onError, loaderOptions)
 
+  const { imageId, scheme } = getImageIdAndScheme(imageIds)
+
+  const imageLoader = useMemo(() => {
+    const isLoaderNeeded = scheme === IMAGE_LOADER_SCHEME.WEB
+    return isLoaderNeeded ? undefined : loader || getHttpClient({ requestInterceptor, timeout })
+  }, [loader, requestInterceptor, scheme, timeout])
+
+  //  onImageLoaded 의 경우 별도의 ref에 담지 않고 실행하여도 문제없을 것 같습니다
   useEffect(() => {
     if (onImageLoadedRef?.current) return
     onImageLoadedRef.current = onImageLoaded
   }, [onImageLoaded])
 
   useEffect(() => {
-    if (!hasLoader || !imageId || !imageScheme) return
+    if (!hasLoader || !imageId) return
     dispatch({ type: LOADING_STATE.LOADING })
 
     loadImage({
       imageId,
-      imageScheme,
-      requestInterceptor,
+      loader: imageLoader,
       onError,
-      timeout,
     })
       .then((res) => {
         dispatch({
@@ -77,8 +98,10 @@ export const useImage: UseImage = ({
           onImageLoadedRef.current?.()
         }, 0)
       })
-      .catch(() => dispatch({ type: LOADING_STATE.FAIL }))
-  }, [hasLoader, imageId, imageScheme, requestInterceptor, onError, timeout])
+      .catch((e) => {
+        dispatch({ type: LOADING_STATE.FAIL })
+      })
+  }, [hasLoader, imageId, imageLoader, onError])
 
   return imageLoad
 }

--- a/libs/insight-viewer/src/hooks/useImage/index.ts
+++ b/libs/insight-viewer/src/hooks/useImage/index.ts
@@ -69,7 +69,7 @@ export const useImage: UseImage = ({
   const { imageId, scheme } = getImageIdAndScheme(imageIds)
 
   const imageLoader = useMemo(() => {
-    const isLoaderNeeded = scheme === IMAGE_LOADER_SCHEME.WEB
+    const isLoaderNeeded = scheme === IMAGE_LOADER_SCHEME.DICOMFILE
     return isLoaderNeeded ? undefined : loader || getHttpClient({ requestInterceptor, timeout })
   }, [loader, requestInterceptor, scheme, timeout])
 

--- a/libs/insight-viewer/src/hooks/useImage/loadCornerstoneImage.ts
+++ b/libs/insight-viewer/src/hooks/useImage/loadCornerstoneImage.ts
@@ -1,23 +1,13 @@
 import { loadImage } from '../../utils/cornerstoneHelper'
 import { normalizeError } from '../../utils/common'
-import { getHttpClient } from '../../utils/httpClient'
-import { IMAGE_LOADER_SCHEME } from '../../const'
 import { GetImage } from './types'
 
 /**
  * It calls cornerstone.js loadImage. It is pluggable for unit test.
  */
-export const loadCornerstoneImage: GetImage = async ({ imageId, imageScheme, requestInterceptor, timeout }) => {
+export const loadCornerstoneImage: GetImage = async ({ imageId, loader }) => {
   try {
-    const loadedImage = await loadImage(imageId, {
-      loader:
-        imageScheme === IMAGE_LOADER_SCHEME.DICOMFILE
-          ? undefined
-          : getHttpClient({
-              requestInterceptor,
-              timeout,
-            }),
-    })
+    const loadedImage = await loadImage(imageId, { loader })
 
     return loadedImage
   } catch (e) {

--- a/libs/insight-viewer/src/hooks/useImage/loadImage.spec.ts
+++ b/libs/insight-viewer/src/hooks/useImage/loadImage.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-shadow */
-import { CONFIG, IMAGE_LOADER_SCHEME } from '../../const'
+import { CONFIG } from '../../const'
 import { CornerstoneImage } from '../../utils/cornerstoneHelper'
 import { CORNERSTONE_IMAGE_MOCK } from '../../mocks/const'
 import { loadImage } from './loadImage'
@@ -8,10 +8,8 @@ import { loadCornerstoneImage } from './loadCornerstoneImage'
 const IMAGE_ID = 'wadouri:https://example/CT000000.dcm'
 const defaultParam = {
   onError: CONFIG.onError,
-  requestInterceptor: CONFIG.requestInterceptor,
   imageId: IMAGE_ID,
-  timeout: CONFIG.timeout,
-  imageScheme: IMAGE_LOADER_SCHEME.WADO,
+  loader: undefined,
 }
 const cornerstoneImage = CORNERSTONE_IMAGE_MOCK as unknown as CornerstoneImage
 const mockLoadCornerstoneImage = loadCornerstoneImage as jest.Mock

--- a/libs/insight-viewer/src/hooks/useImage/loadImage.ts
+++ b/libs/insight-viewer/src/hooks/useImage/loadImage.ts
@@ -1,22 +1,20 @@
+import { Loader, OnError } from './../../types/index'
 /**
  * @fileoverview Loads images with cornerstone.js.
  */
 import { normalizeError } from '../../utils/common'
-import { ImageLoaderScheme } from '../../types'
-import { Props } from './types'
 import { loadCornerstoneImage } from './loadCornerstoneImage'
 import { ImageWithoutKey } from '../../Viewer/types'
 
 interface LoadImage {
   ({
     imageId,
-    imageScheme,
-    requestInterceptor,
     onError,
-    timeout,
-  }: Required<Props> & {
-    imageScheme: ImageLoaderScheme
-    timeout: number
+    loader,
+  }: {
+    imageId: string
+    onError: OnError
+    loader: Loader | undefined
   }): Promise<ImageWithoutKey>
 }
 
@@ -26,13 +24,11 @@ interface LoadImage {
  * @returns Promise<CornerstoneImage>.
  * @throws If image fetching fails.
  */
-export const loadImage: LoadImage = async ({ imageId, imageScheme, requestInterceptor, onError, timeout }) => {
+export const loadImage: LoadImage = async ({ imageId, onError, loader }) => {
   try {
     const cornerStoneImage = await loadCornerstoneImage({
       imageId,
-      imageScheme,
-      requestInterceptor,
-      timeout,
+      loader,
     })
 
     return cornerStoneImage

--- a/libs/insight-viewer/src/hooks/useImage/types.ts
+++ b/libs/insight-viewer/src/hooks/useImage/types.ts
@@ -1,13 +1,8 @@
-import { HTTP, RequestInterceptor, ImageLoaderScheme } from '../../types'
+import { HTTP, Loader } from '../../types'
 import { ImageWithoutKey } from '../../Viewer/types'
 
 export type Props = {
   imageId: string
 } & Partial<HTTP>
 
-export type GetImage = (arg: {
-  imageId: string
-  imageScheme: ImageLoaderScheme
-  requestInterceptor: RequestInterceptor
-  timeout: number
-}) => Promise<ImageWithoutKey>
+export type GetImage = (arg: { imageId: string; loader: Loader | undefined }) => Promise<ImageWithoutKey>

--- a/libs/insight-viewer/src/hooks/useMultipleImages/loadCornerstoneImages.ts
+++ b/libs/insight-viewer/src/hooks/useMultipleImages/loadCornerstoneImages.ts
@@ -32,7 +32,7 @@ export const loadCornerstoneImages: LoadCornerstoneImages = ({
   requestInterceptor,
   timeout,
 }) => {
-  const doesNeedLoader = imageScheme === IMAGE_LOADER_SCHEME.DICOMFILE
+  const doesNeedLoader = imageScheme !== IMAGE_LOADER_SCHEME.DICOMFILE
 
   if (!doesNeedLoader) {
     return loadImage(imageId, { loader: undefined })

--- a/libs/insight-viewer/src/hooks/useMultipleImages/loadCornerstoneImages.ts
+++ b/libs/insight-viewer/src/hooks/useMultipleImages/loadCornerstoneImages.ts
@@ -4,25 +4,44 @@ import { IMAGE_LOADER_SCHEME } from '../../const'
 import { getHttpClient } from '../../utils/httpClient'
 import { ImageWithoutKey } from '../../Viewer/types'
 
-interface GetImage {
-  (arg: {
-    imageId: string
-    imageScheme: ImageLoaderScheme
-    requestInterceptor: RequestInterceptor
-    timeout: number
-  }): Promise<ImageWithoutKey>
+interface LoadCornerstoneImagesVer1 {
+  imageScheme: ImageLoaderScheme
+  requestInterceptor: RequestInterceptor
+  timeout: number
+  loader?: never
+}
+
+interface LoadCornerstoneImagesVer2 {
+  imageScheme?: never
+  requestInterceptor?: never
+  timeout?: never
+  loader: (url: string) => Promise<ArrayBuffer>
+}
+
+interface LoadCornerstoneImages {
+  (arg: { imageId: string } & (LoadCornerstoneImagesVer1 | LoadCornerstoneImagesVer2)): Promise<ImageWithoutKey>
 }
 
 /**
  * It calls cornerstone.js loadImage. It is pluggable for unit test.
  */
-export const loadCornerstoneImages: GetImage = ({ imageId, imageScheme, requestInterceptor, timeout }) =>
-  loadImage(imageId, {
-    loader:
-      imageScheme === IMAGE_LOADER_SCHEME.DICOMFILE
-        ? undefined
-        : getHttpClient({
-            requestInterceptor,
-            timeout,
-          }),
-  })
+export const loadCornerstoneImages: LoadCornerstoneImages = ({
+  imageId,
+  loader,
+  imageScheme,
+  requestInterceptor,
+  timeout,
+}) => {
+  const doesNeedLoader = imageScheme === IMAGE_LOADER_SCHEME.DICOMFILE
+
+  if (!doesNeedLoader) {
+    return loadImage(imageId, { loader: undefined })
+  }
+
+  if (loader === undefined) {
+    const httpClient = getHttpClient({ requestInterceptor, timeout })
+    return loadImage(imageId, { loader: httpClient })
+  }
+
+  return loadImage(imageId, { loader })
+}

--- a/libs/insight-viewer/src/types/index.ts
+++ b/libs/insight-viewer/src/types/index.ts
@@ -33,6 +33,8 @@ export interface HTTP {
   requestInterceptor: RequestInterceptor
 }
 
+export type Loader = (url: string) => Promise<ArrayBuffer>
+
 export type OnViewportChange = Dispatch<SetStateAction<Viewport>>
 export type LoadingState = typeof LOADING_STATE[keyof typeof LOADING_STATE]
 export type LoaderType = typeof LOADER_TYPE[keyof typeof LOADER_TYPE]

--- a/libs/insight-viewer/src/utils/cornerstoneHelper/utils.ts
+++ b/libs/insight-viewer/src/utils/cornerstoneHelper/utils.ts
@@ -2,6 +2,7 @@ import cornerstone, { CanvasCoordinate, EnabledElement, PixelCoordinate } from '
 import { DataSet } from 'dicom-parser'
 import { CornerstoneImage, CornerstoneViewport } from './types'
 import { formatCornerstoneViewport } from '../common/formatViewport'
+import { Loader } from '../../types'
 
 export function enable(element: HTMLDivElement): void {
   cornerstone.enable(element)
@@ -42,7 +43,7 @@ export function displayImage(
 
 type LoadImage = Promise<CornerstoneImage & { data: DataSet }>
 
-export function loadImage(imageId: string, options?: Record<string, unknown>): LoadImage {
+export function loadImage(imageId: string, options: { loader: Loader | undefined }): LoadImage {
   /*
     cornerstone.loadImage() 의 원래 리턴 값은 Promise<CornerstoneImage> 이지만,
     options로 인하여 data field 가 추가된 것으로 보임


### PR DESCRIPTION
## 📝 Description

useImage 내부에서 사용하는 HTTP client를 외부에서 쉽게 컨트롤 가능하도록 변경하였습니다.

useImage는 변경하였지만 useImages 도 일관성있게 변경을 해주어야할 것 같습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

requestInterceptor 옵션을 이용하여 제한적 요청 방식 변경 가능

Issue Number: https://lunit.atlassian.net/browse/VIEWER-46

## 🚀 New behavior

requestInterceptor는 그대로 사용가능하며 추가로 loader 옵션을 만들었으며, loader 옵션을 통해 새로운 HTTP client 지정 가능 

## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
