### PR TITLE
VIEWER-63 / modify text point logic for editing text move mode

### DIFF
--- a/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
@@ -23,7 +23,9 @@ export function RulerDrawer({
   const { startAndEndPoint, measuredValue, unit } = measurement
 
   const startAndEndPointOnCanvas = startAndEndPoint.map(pixelToCanvas) as [Point, Point]
-  const textPointOnCanvas = getRulerTextPosition(startAndEndPointOnCanvas)
+  const textPointOnCanvas = measurement.textPoint
+    ? pixelToCanvas(measurement.textPoint)
+    : getRulerTextPosition(startAndEndPointOnCanvas)
 
   const rulerLine = stringifyPoints(startAndEndPointOnCanvas)
   const connectingLine = stringifyPoints(getConnectingLinePoints(startAndEndPointOnCanvas, textPointOnCanvas))


### PR DESCRIPTION
## 📝 Description

Ruler Measurement 의 text move editing 기능이 정상동작하지 않는 버그를 해결했습니다.

위 버그 발생 PR: https://github.com/lunit-io/frontend-components/pull/305
관련 코드 리뷰: https://github.com/lunit-io/frontend-components/pull/305#discussion_r970504231

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Ruler Measurement text move 기능 이용 시 mouse move 에 대한 변경은 화면 상에 확인할 수 없으며,
mouse up 이벤트 시, 해당 지점으로 text 가 이동하는 동작 방식입니다.

https://user-images.githubusercontent.com/88369343/192227889-832ecdc0-2dbc-45b2-a4fd-473e16800ecf.mov


Issue Number: https://lunit.atlassian.net/browse/VIEWER-63

## 🚀 New behavior

Ruler Measurement text move 기능 이용 시 mouse move 에 대한 변경을 화면 상에 확인할 수 있습니다.

startAndEndPoint 를 기반으로 ruler text position 을 구하는 로직을 적용했습니다. 29211db

https://user-images.githubusercontent.com/88369343/192228255-214c066f-634b-4db6-93b7-501b5d84a5cd.mov

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
