### PR TITLE
VIEWER-64 / Modify connecting line

### DIFF
--- a/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
@@ -1,18 +1,7 @@
 import React, { ReactElement } from 'react'
-import useTextBox from '../../hooks/useTextBox'
-import { useOverlayContext } from '../../contexts'
-
-import { getCircleEndPoint } from '../../utils/common/getCircleEndPoint'
-import { getCircleRadiusByCenter } from '../../utils/common/getCircleRadius'
-import { getCircleTextPosition } from '../../utils/common/getCircleTextPosition'
-import { getCircleConnectingLine } from '../../utils/common/getCircleConnectingLine'
-import { calculateCircleArea } from '../../utils/common/calculateCircleArea'
-import { modifyConnectingLine } from '../../utils/common/modifyConnectingLine'
-import { stringifyPoints } from '../../utils/common/stringifyPoints'
+import useCircleMeasurement from '../../hooks/useCircleMeasurement'
 
 import { svgWrapperStyle, textStyle } from '../Viewer.styles'
-import { HALF_OF_RULER_TEXT_BOX } from '../../const'
-
 import type { CircleDrawerProps } from './CircleDrawer.types'
 
 export function CircleDrawer({
@@ -20,67 +9,47 @@ export function CircleDrawer({
   measurement,
   setMeasurementEditMode,
 }: CircleDrawerProps): ReactElement | null {
-  const { pixelToCanvas } = useOverlayContext()
-  const [textBox, ref] = useTextBox()
-  const { centerPoint, radius, measuredValue, unit } = measurement
+  const { centerPointOnCanvas, formattedValue, ref, drawingRadius, textBoxPoint, connectingLine, visibility } =
+    useCircleMeasurement(measurement)
 
-  const endPoint = getCircleEndPoint(centerPoint, radius)
-  const [centerPointOnCanvas, endPointOnCanvas] = [centerPoint, endPoint].map(pixelToCanvas)
-  const drawingRadius = getCircleRadiusByCenter(centerPointOnCanvas, endPointOnCanvas)
-
-  const textPointOnCanvas = measurement.textPoint
-    ? pixelToCanvas(measurement.textPoint)
-    : getCircleTextPosition(centerPointOnCanvas, drawingRadius)
-
-  const area = calculateCircleArea(measuredValue)
-
-  const connectingLineToTextBoxCenter = getCircleConnectingLine(
-    [centerPointOnCanvas, endPointOnCanvas],
-    textPointOnCanvas
-  )
-  const connectingLineToTextBoxEdge = modifyConnectingLine({ textBox, connectingLineToTextBoxCenter })
-  const connectingLine = stringifyPoints(connectingLineToTextBoxEdge)
-
-  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
+  const handleMoveOnMouseDown = () => setMeasurementEditMode('move')
+  const handleTextMoveOnMouseDown = () => setMeasurementEditMode('textMove')
 
   return (
     <>
       <circle
-        onMouseDown={() => setMeasurementEditMode('move')}
+        onMouseDown={handleMoveOnMouseDown}
         style={svgWrapperStyle.outline}
         cx={centerPointOnCanvas[0]}
         cy={centerPointOnCanvas[1]}
         r={drawingRadius}
       />
       <circle
-        onMouseDown={() => setMeasurementEditMode('move')}
+        onMouseDown={handleMoveOnMouseDown}
         style={svgWrapperStyle[isSelectedMode ? 'select' : 'default']}
         cx={centerPointOnCanvas[0]}
         cy={centerPointOnCanvas[1]}
         r={drawingRadius}
       />
       <circle
-        onMouseDown={() => setMeasurementEditMode('move')}
+        onMouseDown={handleMoveOnMouseDown}
         style={{ ...svgWrapperStyle.extendsArea, cursor: isSelectedMode ? 'grab' : 'pointer' }}
         cx={centerPointOnCanvas[0]}
         cy={centerPointOnCanvas[1]}
         r={drawingRadius}
       />
-      <polyline style={svgWrapperStyle.dashLine} points={connectingLine} />
+      <polyline style={{ ...svgWrapperStyle.dashLine, visibility }} points={connectingLine} />
       <text
         ref={ref}
-        onMouseDown={() => setMeasurementEditMode('textMove')}
+        onMouseDown={handleTextMoveOnMouseDown}
         style={{
           ...textStyle[isSelectedMode ? 'select' : 'default'],
-          visibility: textBox !== null ? 'visible' : 'hidden',
+          visibility,
         }}
-        x={textPointOnCanvas[0]}
-        y={textPointOnCanvas[1] + textCenterModifier}
+        x={textBoxPoint[0]}
+        y={textBoxPoint[1]}
       >
-        {`Area = ${area.toLocaleString(undefined, {
-          minimumFractionDigits: 1,
-          maximumFractionDigits: 1,
-        })}${unit}2`}
+        {formattedValue}
       </text>
     </>
   )

--- a/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
@@ -22,12 +22,10 @@ export function CircleDrawer({
 }: CircleDrawerProps): ReactElement | null {
   const { pixelToCanvas } = useOverlayContext()
   const [textBox, ref] = useTextBox()
-
   const { centerPoint, radius, measuredValue, unit } = measurement
+
   const endPoint = getCircleEndPoint(centerPoint, radius)
-
   const [centerPointOnCanvas, endPointOnCanvas] = [centerPoint, endPoint].map(pixelToCanvas)
-
   const drawingRadius = getCircleRadiusByCenter(centerPointOnCanvas, endPointOnCanvas)
 
   const textPointOnCanvas = measurement.textPoint
@@ -36,14 +34,14 @@ export function CircleDrawer({
 
   const area = calculateCircleArea(measuredValue)
 
-  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
-
   const connectingLineToTextBoxCenter = getCircleConnectingLine(
     [centerPointOnCanvas, endPointOnCanvas],
     textPointOnCanvas
   )
   const connectingLineToTextBoxEdge = modifyConnectingLine({ textBox, connectingLineToTextBoxCenter })
   const connectingLine = stringifyPoints(connectingLineToTextBoxEdge)
+
+  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
 
   return (
     <>

--- a/libs/insight-viewer/src/Viewer/CircleViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/CircleViewer/index.tsx
@@ -7,7 +7,7 @@ import type { CircleViewerProps } from './CircleViewer.types'
 export function CircleViewer({ measurement, hoveredMeasurement }: CircleViewerProps): ReactElement {
   const { centerPointOnCanvas, formattedValue, ref, drawingRadius, textBoxPoint, connectingLine, visibility } =
     useCircleMeasurement(measurement)
-  const isHoveredMeasurement = measurement === hoveredMeasurement
+  const isHoveredMeasurement = measurement === hoveredMeasurement || undefined
 
   return (
     <>
@@ -15,7 +15,7 @@ export function CircleViewer({ measurement, hoveredMeasurement }: CircleViewerPr
         style={{
           ...svgWrapperStyle[isHoveredMeasurement ? 'hoveredOutline' : 'outline'],
         }}
-        data-focus={isHoveredMeasurement || undefined}
+        data-focus={isHoveredMeasurement}
         cx={centerPointOnCanvas[0]}
         cy={centerPointOnCanvas[1]}
         r={drawingRadius}
@@ -24,7 +24,7 @@ export function CircleViewer({ measurement, hoveredMeasurement }: CircleViewerPr
         style={{
           ...svgWrapperStyle.extendsArea,
         }}
-        data-focus={isHoveredMeasurement || undefined}
+        data-focus={isHoveredMeasurement}
         cx={centerPointOnCanvas[0]}
         cy={centerPointOnCanvas[1]}
         r={drawingRadius}
@@ -33,7 +33,7 @@ export function CircleViewer({ measurement, hoveredMeasurement }: CircleViewerPr
         style={{
           ...svgWrapperStyle.default,
         }}
-        data-focus={isHoveredMeasurement || undefined}
+        data-focus={isHoveredMeasurement}
         cx={centerPointOnCanvas[0]}
         cy={centerPointOnCanvas[1]}
         r={drawingRadius}

--- a/libs/insight-viewer/src/Viewer/CircleViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/CircleViewer/index.tsx
@@ -18,12 +18,10 @@ import type { CircleViewerProps } from './CircleViewer.types'
 export function CircleViewer({ measurement, hoveredMeasurement }: CircleViewerProps): ReactElement {
   const [textBox, ref] = useTextBox()
   const { pixelToCanvas } = useOverlayContext()
-
   const { centerPoint, radius, measuredValue, unit } = measurement
 
   const endPoint = getCircleEndPoint(centerPoint, radius)
   const [centerPointOnCanvas, endPointOnCanvas] = [centerPoint, endPoint].map(pixelToCanvas)
-
   const drawingRadius = getCircleRadiusByCenter(centerPointOnCanvas, endPointOnCanvas)
 
   const textPointOnCanvas = measurement.textPoint
@@ -32,15 +30,15 @@ export function CircleViewer({ measurement, hoveredMeasurement }: CircleViewerPr
 
   const area = calculateCircleArea(measuredValue)
 
-  const isHoveredMeasurement = measurement === hoveredMeasurement
-  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
-
   const connectingLineToTextBoxCenter = getCircleConnectingLine(
     [centerPointOnCanvas, endPointOnCanvas],
     textPointOnCanvas
   )
   const connectingLineToTextBoxEdge = modifyConnectingLine({ textBox, connectingLineToTextBoxCenter })
   const connectingLine = stringifyPoints(connectingLineToTextBoxEdge)
+
+  const isHoveredMeasurement = measurement === hoveredMeasurement
+  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
 
   return (
     <>

--- a/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
@@ -1,44 +1,18 @@
 import React, { ReactElement } from 'react'
-import useTextBox from '../../hooks/useTextBox'
-import { useOverlayContext } from '../../contexts'
+import useRulerMeasurement from '../../hooks/useRulerMeasurement'
 
-import { getRulerTextPosition } from '../../utils/common/getRulerTextPosition'
-import { modifyConnectingLine } from '../../utils/common/modifyConnectingLine'
-import { stringifyPoints } from '../../utils/common/stringifyPoints'
-
-import { HALF_OF_RULER_TEXT_BOX } from '../../const'
 import { svgWrapperStyle, textStyle } from '../Viewer.styles'
-
-import type { Point } from '../../types'
 import type { RulerDrawerProps } from './RulerDrawer.types'
-import { getConnectingLinePoints } from '../../utils/common/getConnectingLinePoints'
 
 export function RulerDrawer({
   measurement,
   isSelectedMode,
   setMeasurementEditMode,
 }: RulerDrawerProps): ReactElement | null {
-  const { pixelToCanvas } = useOverlayContext()
-  const [textBox, ref] = useTextBox()
-  const { startAndEndPoint, measuredValue, unit } = measurement
-
-  const startAndEndPointOnCanvas = startAndEndPoint.map(pixelToCanvas) as [Point, Point]
-  const textPointOnCanvas = measurement.textPoint
-    ? pixelToCanvas(measurement.textPoint)
-    : getRulerTextPosition(startAndEndPointOnCanvas)
-  const connectingLineToTextBoxCenter = getConnectingLinePoints(startAndEndPointOnCanvas, textPointOnCanvas)
-
-  const connectingLineToTextBoxEdge = modifyConnectingLine({
-    textBox,
-    connectingLineToTextBoxCenter,
-  })
-  const connectingLine = stringifyPoints(connectingLineToTextBoxEdge)
-  const rulerLine = stringifyPoints(startAndEndPointOnCanvas)
+  const { rulerLine, ref, connectingLine, formattedValue, textBoxPoint, visibility } = useRulerMeasurement(measurement)
 
   const handleMoveOnMouseDown = () => setMeasurementEditMode('move')
   const handleTextMoveOnMouseDown = () => setMeasurementEditMode('textMove')
-
-  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
 
   return (
     <>
@@ -55,19 +29,15 @@ export function RulerDrawer({
         style={svgWrapperStyle[isSelectedMode ? 'select' : 'default']}
         points={rulerLine}
       />
-      <polyline
-        style={{ ...svgWrapperStyle.dashLine, visibility: textBox !== null ? 'visible' : 'hidden' }}
-        points={connectingLine}
-      />
+      <polyline style={{ ...svgWrapperStyle.dashLine, visibility }} points={connectingLine} />
       <text
         ref={ref}
         onMouseDown={handleTextMoveOnMouseDown}
-        style={{ ...textStyle[isSelectedMode ? 'select' : 'default'] }}
-        x={textPointOnCanvas[0]}
-        y={textPointOnCanvas[1] + textCenterModifier}
+        style={{ ...textStyle[isSelectedMode ? 'select' : 'default'], visibility }}
+        x={textBoxPoint[0]}
+        y={textBoxPoint[1]}
       >
-        {measuredValue.toFixed(1)}
-        {unit}
+        {formattedValue}
       </text>
     </>
   )

--- a/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
@@ -11,6 +11,7 @@ import { svgWrapperStyle, textStyle } from '../Viewer.styles'
 
 import type { Point } from '../../types'
 import type { RulerDrawerProps } from './RulerDrawer.types'
+import { getConnectingLinePoints } from '../../utils/common/getConnectingLinePoints'
 
 export function RulerDrawer({
   measurement,
@@ -26,14 +27,15 @@ export function RulerDrawer({
     ? pixelToCanvas(measurement.textPoint)
     : getRulerTextPosition(startAndEndPointOnCanvas)
 
-  const rulerLine = stringifyPoints(startAndEndPointOnCanvas)
+  const connectingLineToTextBoxCenter = getConnectingLinePoints(startAndEndPointOnCanvas, textPointOnCanvas)
   const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
 
   const connectingLineToTextBoxEdge = modifyConnectingLine({
     textBox,
-    connectingLineToTextBoxCenter: [startAndEndPointOnCanvas[1], textPointOnCanvas],
+    connectingLineToTextBoxCenter,
   })
   const connectingLine = stringifyPoints(connectingLineToTextBoxEdge)
+  const rulerLine = stringifyPoints(startAndEndPointOnCanvas)
 
   const handleMoveOnMouseDown = () => setMeasurementEditMode('move')
   const handleTextMoveOnMouseDown = () => setMeasurementEditMode('textMove')

--- a/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
@@ -55,7 +55,10 @@ export function RulerDrawer({
         style={svgWrapperStyle[isSelectedMode ? 'select' : 'default']}
         points={rulerLine}
       />
-      <polyline style={svgWrapperStyle.dashLine} points={connectingLine} />
+      <polyline
+        style={{ ...svgWrapperStyle.dashLine, visibility: textBox !== null ? 'visible' : 'hidden' }}
+        points={connectingLine}
+      />
       <text
         ref={ref}
         onMouseDown={handleTextMoveOnMouseDown}

--- a/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
@@ -26,9 +26,7 @@ export function RulerDrawer({
   const textPointOnCanvas = measurement.textPoint
     ? pixelToCanvas(measurement.textPoint)
     : getRulerTextPosition(startAndEndPointOnCanvas)
-
   const connectingLineToTextBoxCenter = getConnectingLinePoints(startAndEndPointOnCanvas, textPointOnCanvas)
-  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
 
   const connectingLineToTextBoxEdge = modifyConnectingLine({
     textBox,
@@ -39,6 +37,8 @@ export function RulerDrawer({
 
   const handleMoveOnMouseDown = () => setMeasurementEditMode('move')
   const handleTextMoveOnMouseDown = () => setMeasurementEditMode('textMove')
+
+  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
 
   return (
     <>

--- a/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
@@ -61,7 +61,10 @@ export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProp
       {measuredValue ? (
         <text
           ref={ref}
-          style={{ ...textStyle[isHoveredMeasurement ? 'hover' : 'default'] }}
+          style={{
+            ...textStyle[isHoveredMeasurement ? 'hover' : 'default'],
+            visibility: textBox !== null ? 'visible' : 'hidden',
+          }}
           x={textPointOnCanvas[0]}
           y={textPointOnCanvas[1] + textCenterModifier}
         >

--- a/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
@@ -17,7 +17,6 @@ export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProp
   const { pixelToCanvas } = useOverlayContext()
   const [textBox, ref] = useTextBox()
   const { startAndEndPoint, measuredValue, unit } = measurement
-  const isHoveredMeasurement = measurement === hoveredMeasurement
 
   const startAndEndPointOnCanvas = startAndEndPoint.map(pixelToCanvas) as [Point, Point]
   const textPointOnCanvas = measurement.textPoint
@@ -25,7 +24,6 @@ export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProp
     : getRulerTextPosition(startAndEndPointOnCanvas)
 
   const connectingLineToTextBoxCenter = getConnectingLinePoints(startAndEndPointOnCanvas, textPointOnCanvas)
-  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
 
   const connectingLineToTextBoxEdge = modifyConnectingLine({
     textBox,
@@ -33,6 +31,9 @@ export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProp
   })
   const connectingLine = stringifyPoints(connectingLineToTextBoxEdge)
   const rulerLine = stringifyPoints(startAndEndPointOnCanvas)
+
+  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
+  const isHoveredMeasurement = measurement === hoveredMeasurement
 
   return (
     <>

--- a/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
@@ -6,7 +6,7 @@ import type { RulerViewerProps } from './RulerViewer.types'
 
 export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProps): ReactElement {
   const { rulerLine, ref, connectingLine, formattedValue, textBoxPoint, visibility } = useRulerMeasurement(measurement)
-  const isHoveredMeasurement = measurement === hoveredMeasurement
+  const isHoveredMeasurement = measurement === hoveredMeasurement || undefined
 
   return (
     <>
@@ -14,21 +14,21 @@ export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProp
         style={{
           ...svgWrapperStyle[isHoveredMeasurement ? 'hoveredOutline' : 'outline'],
         }}
-        data-select={isHoveredMeasurement || undefined}
+        data-select={isHoveredMeasurement}
         points={rulerLine}
       />
       <polyline
         style={{
           ...svgWrapperStyle.extendsArea,
         }}
-        data-select={isHoveredMeasurement || undefined}
+        data-select={isHoveredMeasurement}
         points={rulerLine}
       />
       <polyline
         style={{
           ...svgWrapperStyle.default,
         }}
-        data-select={isHoveredMeasurement || undefined}
+        data-select={isHoveredMeasurement}
         points={rulerLine}
       />
       <polyline style={{ ...svgWrapperStyle.dashLine, visibility }} points={connectingLine} />

--- a/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
@@ -11,6 +11,7 @@ import { textStyle, svgWrapperStyle } from '../Viewer.styles'
 
 import type { Point } from '../../types'
 import type { RulerViewerProps } from './RulerViewer.types'
+import { getConnectingLinePoints } from '../../utils/common/getConnectingLinePoints'
 
 export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProps): ReactElement {
   const { pixelToCanvas } = useOverlayContext()
@@ -23,14 +24,15 @@ export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProp
     ? pixelToCanvas(measurement.textPoint)
     : getRulerTextPosition(startAndEndPointOnCanvas)
 
-  const rulerLine = stringifyPoints(startAndEndPointOnCanvas)
+  const connectingLineToTextBoxCenter = getConnectingLinePoints(startAndEndPointOnCanvas, textPointOnCanvas)
   const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
 
   const connectingLineToTextBoxEdge = modifyConnectingLine({
     textBox,
-    connectingLineToTextBoxCenter: [startAndEndPointOnCanvas[1], textPointOnCanvas],
+    connectingLineToTextBoxCenter,
   })
   const connectingLine = stringifyPoints(connectingLineToTextBoxEdge)
+  const rulerLine = stringifyPoints(startAndEndPointOnCanvas)
 
   return (
     <>

--- a/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerViewer/index.tsx
@@ -1,38 +1,11 @@
 import React, { ReactElement } from 'react'
-import useTextBox from '../../hooks/useTextBox'
-import { useOverlayContext } from '../../contexts'
+import useRulerMeasurement from '../../hooks/useRulerMeasurement'
 
-import { getRulerTextPosition } from '../../utils/common/getRulerTextPosition'
-import { modifyConnectingLine } from '../../utils/common/modifyConnectingLine'
-import { stringifyPoints } from '../../utils/common/stringifyPoints'
-
-import { HALF_OF_RULER_TEXT_BOX } from '../../const'
 import { textStyle, svgWrapperStyle } from '../Viewer.styles'
-
-import type { Point } from '../../types'
 import type { RulerViewerProps } from './RulerViewer.types'
-import { getConnectingLinePoints } from '../../utils/common/getConnectingLinePoints'
 
 export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProps): ReactElement {
-  const { pixelToCanvas } = useOverlayContext()
-  const [textBox, ref] = useTextBox()
-  const { startAndEndPoint, measuredValue, unit } = measurement
-
-  const startAndEndPointOnCanvas = startAndEndPoint.map(pixelToCanvas) as [Point, Point]
-  const textPointOnCanvas = measurement.textPoint
-    ? pixelToCanvas(measurement.textPoint)
-    : getRulerTextPosition(startAndEndPointOnCanvas)
-
-  const connectingLineToTextBoxCenter = getConnectingLinePoints(startAndEndPointOnCanvas, textPointOnCanvas)
-
-  const connectingLineToTextBoxEdge = modifyConnectingLine({
-    textBox,
-    connectingLineToTextBoxCenter,
-  })
-  const connectingLine = stringifyPoints(connectingLineToTextBoxEdge)
-  const rulerLine = stringifyPoints(startAndEndPointOnCanvas)
-
-  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
+  const { rulerLine, ref, connectingLine, formattedValue, textBoxPoint, visibility } = useRulerMeasurement(measurement)
   const isHoveredMeasurement = measurement === hoveredMeasurement
 
   return (
@@ -58,21 +31,19 @@ export function RulerViewer({ measurement, hoveredMeasurement }: RulerViewerProp
         data-select={isHoveredMeasurement || undefined}
         points={rulerLine}
       />
-      <polyline style={svgWrapperStyle.dashLine} points={connectingLine} />
-      {measuredValue ? (
-        <text
-          ref={ref}
-          style={{
-            ...textStyle[isHoveredMeasurement ? 'hover' : 'default'],
-            visibility: textBox !== null ? 'visible' : 'hidden',
-          }}
-          x={textPointOnCanvas[0]}
-          y={textPointOnCanvas[1] + textCenterModifier}
-        >
-          {measuredValue.toFixed(1)}
-          {unit}
-        </text>
-      ) : null}
+      <polyline style={{ ...svgWrapperStyle.dashLine, visibility }} points={connectingLine} />
+      <text
+        ref={ref}
+        style={{
+          ...textStyle[isHoveredMeasurement ? 'hover' : 'default'],
+          visibility,
+        }}
+        x={textBoxPoint[0]}
+        y={textBoxPoint[1]}
+      >
+        {formattedValue}
+      </text>
+      )
     </>
   )
 }

--- a/libs/insight-viewer/src/hooks/useCircleMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useCircleMeasurement/index.ts
@@ -12,6 +12,12 @@ import { stringifyPoints } from '../../utils/common/stringifyPoints'
 import { HALF_OF_RULER_TEXT_BOX } from '../../const'
 import type { CircleMeasurement, Point } from '../../types'
 
+const formatCircleValue = (area: number, unit: string) =>
+  `Area = ${area.toLocaleString(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  })}${unit}2`
+
 const useCircleMeasurement = ({ centerPoint, radius, measuredValue, textPoint, unit }: CircleMeasurement) => {
   const { pixelToCanvas } = useOverlayContext()
   const [textBox, ref] = useTextBox()
@@ -24,6 +30,7 @@ const useCircleMeasurement = ({ centerPoint, radius, measuredValue, textPoint, u
     ? pixelToCanvas(textPoint)
     : getCircleTextPosition(centerPointOnCanvas, drawingRadius)
   const area = calculateCircleArea(measuredValue)
+
   const connectingLineToTextBoxCenter = getCircleConnectingLine(
     [centerPointOnCanvas, endPointOnCanvas],
     textPointOnCanvas
@@ -34,10 +41,7 @@ const useCircleMeasurement = ({ centerPoint, radius, measuredValue, textPoint, u
   const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
   const textBoxPoint: Point = [textPointOnCanvas[0], textPointOnCanvas[1] + textCenterModifier]
   const visibility: 'visible' | 'hidden' = textBox !== null ? 'visible' : 'hidden'
-  const formattedValue = `Area = ${area.toLocaleString(undefined, {
-    minimumFractionDigits: 1,
-    maximumFractionDigits: 1,
-  })}${unit}2`
+  const formattedValue = formatCircleValue(area, unit)
 
   return {
     centerPointOnCanvas,

--- a/libs/insight-viewer/src/hooks/useCircleMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useCircleMeasurement/index.ts
@@ -1,0 +1,54 @@
+import useTextBox from '../useTextBox'
+import { useOverlayContext } from '../../contexts'
+
+import { calculateCircleArea } from '../../utils/common/calculateCircleArea'
+import { getCircleConnectingLine } from '../../utils/common/getCircleConnectingLine'
+import { getCircleEndPoint } from '../../utils/common/getCircleEndPoint'
+import { getCircleRadiusByCenter } from '../../utils/common/getCircleRadius'
+import { getCircleTextPosition } from '../../utils/common/getCircleTextPosition'
+import { modifyConnectingLine } from '../../utils/common/modifyConnectingLine'
+import { stringifyPoints } from '../../utils/common/stringifyPoints'
+
+import { HALF_OF_RULER_TEXT_BOX } from '../../const'
+import type { CircleMeasurement, Point } from '../../types'
+
+const useCircleMeasurement = ({ centerPoint, radius, measuredValue, textPoint, unit }: CircleMeasurement) => {
+  const { pixelToCanvas } = useOverlayContext()
+  const [textBox, ref] = useTextBox()
+
+  const endPoint = getCircleEndPoint(centerPoint, radius)
+  const [centerPointOnCanvas, endPointOnCanvas] = [centerPoint, endPoint].map(pixelToCanvas)
+  const drawingRadius = getCircleRadiusByCenter(centerPointOnCanvas, endPointOnCanvas)
+
+  const textPointOnCanvas = textPoint
+    ? pixelToCanvas(textPoint)
+    : getCircleTextPosition(centerPointOnCanvas, drawingRadius)
+  const area = calculateCircleArea(measuredValue)
+  const connectingLineToTextBoxCenter = getCircleConnectingLine(
+    [centerPointOnCanvas, endPointOnCanvas],
+    textPointOnCanvas
+  )
+  const connectingLineToTextBoxEdge = modifyConnectingLine({ textBox, connectingLineToTextBoxCenter })
+  const connectingLine = stringifyPoints(connectingLineToTextBoxEdge)
+
+  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
+  const textBoxPoint: Point = [textPointOnCanvas[0], textPointOnCanvas[1] + textCenterModifier]
+  const visibility: 'visible' | 'hidden' = textBox !== null ? 'visible' : 'hidden'
+  const formattedValue = `Area = ${area.toLocaleString(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  })}${unit}2`
+
+  return {
+    centerPointOnCanvas,
+    endPointOnCanvas,
+    ref,
+    formattedValue,
+    drawingRadius,
+    connectingLine,
+    textBoxPoint,
+    visibility,
+  }
+}
+
+export default useCircleMeasurement

--- a/libs/insight-viewer/src/hooks/useRulerMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useRulerMeasurement/index.ts
@@ -1,0 +1,35 @@
+import useTextBox from '../useTextBox'
+import { useOverlayContext } from '../../contexts'
+
+import { modifyConnectingLine } from '../../utils/common/modifyConnectingLine'
+import { stringifyPoints } from '../../utils/common/stringifyPoints'
+import { getRulerTextPosition } from '../../utils/common/getRulerTextPosition'
+import { getConnectingLinePoints } from '../../utils/common/getConnectingLinePoints'
+
+import { HALF_OF_RULER_TEXT_BOX } from '../../const'
+import type { Point, RulerMeasurement } from '../../types'
+
+const useRulerMeasurement = ({ startAndEndPoint, measuredValue, unit, textPoint }: RulerMeasurement) => {
+  const { pixelToCanvas } = useOverlayContext()
+  const [textBox, ref] = useTextBox()
+
+  const startAndEndPointOnCanvas = startAndEndPoint.map(pixelToCanvas) as [Point, Point]
+  const textPointOnCanvas = textPoint ? pixelToCanvas(textPoint) : getRulerTextPosition(startAndEndPointOnCanvas)
+  const connectingLineToTextBoxCenter = getConnectingLinePoints(startAndEndPointOnCanvas, textPointOnCanvas)
+
+  const connectingLineToTextBoxEdge = modifyConnectingLine({
+    textBox,
+    connectingLineToTextBoxCenter,
+  })
+  const connectingLine = stringifyPoints(connectingLineToTextBoxEdge)
+  const rulerLine = stringifyPoints(startAndEndPointOnCanvas)
+
+  const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
+  const textBoxPoint: Point = [textPointOnCanvas[0], textPointOnCanvas[1] + textCenterModifier]
+  const visibility: 'visible' | 'hidden' = textBox !== null ? 'visible' : 'hidden'
+  const formattedValue = `${measuredValue.toFixed(1)}${unit}`
+
+  return { rulerLine, ref, connectingLine, formattedValue, textBoxPoint, visibility }
+}
+
+export default useRulerMeasurement

--- a/libs/insight-viewer/src/hooks/useRulerMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useRulerMeasurement/index.ts
@@ -9,6 +9,8 @@ import { getConnectingLinePoints } from '../../utils/common/getConnectingLinePoi
 import { HALF_OF_RULER_TEXT_BOX } from '../../const'
 import type { Point, RulerMeasurement } from '../../types'
 
+const formatRulerValue = (measuredValue: number, unit: string) => `${measuredValue.toFixed(1)}${unit}`
+
 const useRulerMeasurement = ({ startAndEndPoint, measuredValue, unit, textPoint }: RulerMeasurement) => {
   const { pixelToCanvas } = useOverlayContext()
   const [textBox, ref] = useTextBox()
@@ -27,7 +29,7 @@ const useRulerMeasurement = ({ startAndEndPoint, measuredValue, unit, textPoint 
   const textCenterModifier = textBox ? textBox.height / 2 - HALF_OF_RULER_TEXT_BOX : 0
   const textBoxPoint: Point = [textPointOnCanvas[0], textPointOnCanvas[1] + textCenterModifier]
   const visibility: 'visible' | 'hidden' = textBox !== null ? 'visible' : 'hidden'
-  const formattedValue = `${measuredValue.toFixed(1)}${unit}`
+  const formattedValue = formatRulerValue(measuredValue, unit)
 
   return { rulerLine, ref, connectingLine, formattedValue, textBoxPoint, visibility }
 }

--- a/libs/insight-viewer/src/hooks/useTextBox/index.ts
+++ b/libs/insight-viewer/src/hooks/useTextBox/index.ts
@@ -1,0 +1,16 @@
+import { useCallback, useState } from 'react'
+
+const useTextBox = () => {
+  const [textBox, setTextBox] = useState<{ height: number; width: number } | null>(null)
+
+  const textBoxRef = useCallback((ref: SVGTextElement) => {
+    if (ref !== null) {
+      const { width, height } = ref.getBBox()
+      setTextBox({ width, height })
+    }
+  }, [])
+
+  return [textBox, textBoxRef] as const
+}
+
+export default useTextBox

--- a/libs/insight-viewer/src/utils/common/modifyConnectingLine.spec.ts
+++ b/libs/insight-viewer/src/utils/common/modifyConnectingLine.spec.ts
@@ -1,0 +1,29 @@
+import { Point } from '../../types'
+import { modifyConnectingLine } from './modifyConnectingLine'
+
+describe('modifyConnectingLine', () => {
+  it('should return connectingLineToTextBoxCenter when textBox is null ', () => {
+    const connectingLineToTextBoxCenter: [Point, Point] = [
+      [1, 2],
+      [3, 4],
+    ]
+    const textBox = null
+
+    expect(modifyConnectingLine({ textBox, connectingLineToTextBoxCenter })).toEqual(connectingLineToTextBoxCenter)
+  })
+  it('should return connecting line', () => {
+    const connectingLineToTextBoxCenter: [Point, Point] = [
+      [1, 2],
+      [3, 4],
+    ]
+    const textBox = {
+      width: 100,
+      height: 100,
+    }
+
+    expect(modifyConnectingLine({ textBox, connectingLineToTextBoxCenter })).toEqual([
+      [1, 2],
+      [3, -46],
+    ])
+  })
+})

--- a/libs/insight-viewer/src/utils/common/modifyConnectingLine.ts
+++ b/libs/insight-viewer/src/utils/common/modifyConnectingLine.ts
@@ -1,7 +1,7 @@
 import { Point } from '../../types'
 
-const calcDistance = (pointA: Point, pointB: Point) => {
-  return Math.sqrt(Math.pow(pointA[0] - pointB[0], 2) + Math.pow(pointA[1] - pointB[1], 2))
+const getDistance = (pointA: Point, pointB: Point) => {
+  return Math.pow(pointA[0] - pointB[0], 2) + Math.pow(pointA[1] - pointB[1], 2)
 }
 
 const getIntersectedPoint = (width: number, height: number, line: [Point, Point]): Point => {
@@ -30,7 +30,7 @@ const getIntersectedPoint = (width: number, height: number, line: [Point, Point]
 }
 
 const findTheMostClosePoint = (targetPoint: Point, comparedPoints: Point[]) => {
-  const distances = comparedPoints.map((point) => calcDistance(targetPoint, point))
+  const distances = comparedPoints.map((point) => getDistance(targetPoint, point))
   const minDistance = Math.min(...distances)
   const index = distances.indexOf(minDistance)
 

--- a/libs/insight-viewer/src/utils/common/modifyConnectingLine.ts
+++ b/libs/insight-viewer/src/utils/common/modifyConnectingLine.ts
@@ -1,0 +1,77 @@
+import { Point } from '../../types'
+
+const calcDistance = (pointA: Point, pointB: Point) => {
+  return Math.sqrt(Math.pow(pointA[0] - pointB[0], 2) + Math.pow(pointA[1] - pointB[1], 2))
+}
+
+const getIntersectedPoint = (width: number, height: number, line: [Point, Point]): Point => {
+  const centerWeight = width / 2
+  const centerHeight = height / 2
+
+  const [x1, y1] = line[0]
+  const [x2, y2] = line[1]
+
+  const dx = x1 - x2
+  const dy = y1 - y2
+
+  if (dx === 0 && dy === 0) return [x2, y2]
+
+  const tanPhi = centerHeight / centerWeight
+  const tanTheta = Math.abs(dy / dx)
+
+  const quadrantX = Math.sign(dx)
+  const quadrantY = Math.sign(dy)
+
+  if (tanTheta > tanPhi) {
+    return [x2 + (centerHeight / tanTheta) * quadrantX, y2 + centerHeight * quadrantY]
+  } else {
+    return [x2 + centerWeight * quadrantX, y2 + centerWeight * tanTheta * quadrantY]
+  }
+}
+
+const findTheMostClosePoint = (targetPoint: Point, comparedPoints: Point[]) => {
+  const distances = comparedPoints.map((point) => calcDistance(targetPoint, point))
+  const minDistance = Math.min(...distances)
+  const index = distances.indexOf(minDistance)
+
+  return comparedPoints[index]
+}
+
+const getPointsOfTextBox = ({
+  textBoxCenter,
+  textBoxWidth,
+  textBoxHeight,
+}: {
+  textBoxCenter: Point
+  textBoxWidth: number
+  textBoxHeight: number
+}) => {
+  const textBoxCenterUp: Point = [textBoxCenter[0], textBoxCenter[1] - textBoxHeight / 2]
+  const textBoxCenterDown: Point = [textBoxCenter[0], textBoxCenter[1] + textBoxHeight / 2]
+  const textBoxCenterLeft: Point = [textBoxCenter[0] - textBoxWidth / 2, textBoxCenter[1]]
+  const textBoxCenterRight: Point = [textBoxCenter[0] + textBoxWidth / 2, textBoxCenter[1]]
+
+  return [textBoxCenterUp, textBoxCenterDown, textBoxCenterLeft, textBoxCenterRight]
+}
+
+export const modifyConnectingLine = ({
+  textBox,
+  connectingLineToTextBoxCenter,
+}: {
+  textBox: { width: number; height: number } | null
+  connectingLineToTextBoxCenter: [Point, Point]
+}) => {
+  if (!textBox) return connectingLineToTextBoxCenter
+
+  const { width: textBoxWidth, height: textBoxHeight } = textBox
+  const intersectedPoint = getIntersectedPoint(textBoxWidth, textBoxHeight, connectingLineToTextBoxCenter)
+  const [startPoint, textBoxCenter] = connectingLineToTextBoxCenter
+  const textBoxPoints = getPointsOfTextBox({
+    textBoxCenter,
+    textBoxWidth,
+    textBoxHeight,
+  })
+  const newEndPoint = findTheMostClosePoint(intersectedPoint, textBoxPoints)
+
+  return [startPoint, newEndPoint]
+}

--- a/libs/insight-viewer/src/utils/common/stringifyPoints.spec.ts
+++ b/libs/insight-viewer/src/utils/common/stringifyPoints.spec.ts
@@ -1,0 +1,26 @@
+import { Point } from './../../types/index'
+import { stringifyPoints } from './stringifyPoints'
+
+describe('stringifyPoints', () => {
+  it('should stringify points', () => {
+    const points1: Point[] = [
+      [1, 2],
+      [3, 4],
+    ]
+    const points2: Point[] = [
+      [1, 2],
+      [3, 4],
+      [5, 2],
+      [3, 6],
+    ]
+    const points3: Point[] = [
+      [100, 299],
+      [332, 411],
+      [511, 211],
+    ]
+
+    expect(stringifyPoints(points1)).toBe('1,2 3,4')
+    expect(stringifyPoints(points2)).toBe('1,2 3,4 5,2 3,6')
+    expect(stringifyPoints(points3)).toBe('100,299 332,411 511,211')
+  })
+})

--- a/libs/insight-viewer/src/utils/common/stringifyPoints.ts
+++ b/libs/insight-viewer/src/utils/common/stringifyPoints.ts
@@ -1,0 +1,5 @@
+import { Point } from '../../types'
+
+export const stringifyPoints = (points: Point[]): string => {
+  return points.map((point) => `${point[0]},${point[1]}`).join(' ')
+}


### PR DESCRIPTION
## 📝 Description

Measurement 를 그릴시TextBox와 Measurement 객체간에 연결된 선들이 TextBox 영역을 침범하던 것을 수정하였습니다

https://lunit.atlassian.net/browse/VIEWER-64

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

![image](https://user-images.githubusercontent.com/97934818/192446394-ffcedb75-a9a4-4a0c-9a37-e578e4460c69.png)


## 🚀 New behavior/

![image](https://user-images.githubusercontent.com/97934818/192446580-f36a783e-b67e-4ee9-bfc7-1a68f95708ca.png)

TextBox에 연결된 선이 아래의 그림과 같이 TextBox의 테두리 위의 점 4개 중 하나로 연결됩니다.
연결되는 점의 위치는 기존 TextBox의 중심으로 연결되며 TextBox의 테두리와 교차하던 점으로 부터 가장 가까운 곳으로 선택이 됩니다.

![image](https://user-images.githubusercontent.com/97934818/192446817-effa909c-477c-4c2a-a584-f993dc352f89.png)


## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
