### PR TITLE
VIEWER-64 / modify edit pointer width

### DIFF
--- a/libs/insight-viewer/src/Viewer/Viewer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/Viewer.styles.ts
@@ -35,9 +35,9 @@ const EDIT_POINTER_SELECTED_COLOR = '#FFD600'
 const EDIT_POINTER_HIGHLIGHT_COLOR = '#00FFF0'
 
 // edit stroke width
-const EDIT_DEFAULT_WIDTH = '2px'
-const EDIT_OUTLINE_WIDTH = '3px'
-const EDIT_SELECTED_OUTLINE_WIDTH = '4px'
+const EDIT_DEFAULT_WIDTH = '3px'
+const EDIT_OUTLINE_WIDTH = '4px'
+const EDIT_SELECTED_OUTLINE_WIDTH = '5px'
 
 export const TEXT_SIZE = 14
 export const FONT_WIDTH = 600


### PR DESCRIPTION
## 📝 Description

Edit Pointer 의 width 값을 현재 INSIGHT View figma 기준으로 변경했습니다.
디자인팀 검수를 위해 Draft PR 로 올립니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

edit pointer width 가 figma 기준 -1px 로 설정되어 있습니다. 

Issue Number: https://lunit.atlassian.net/browse/VIEWER-65

## 🚀 New behavior

edit pointer width 를 figma 와 동일하게 수정했습니다.
[8727d66](https://github.com/lunit-io/frontend-components/pull/325/commits/8727d66ee7ea6ae7fc93f3529e8897b477999d31)

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

