### PR TITLE
VIEWER-43 / Annotation, Measurement list issue

### DIFF
--- a/libs/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
@@ -36,6 +36,7 @@ export function AnnotationOverlay({
         height={height}
         annotations={annotations}
         hoveredAnnotation={hoveredAnnotation}
+        selectedAnnotation={selectedAnnotation}
         className={className}
         style={style}
         showOutline={showOutline}

--- a/libs/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.types.ts
+++ b/libs/insight-viewer/src/Viewer/AnnotationViewer/AnnotationViewer.types.ts
@@ -9,6 +9,7 @@ export interface AnnotationViewerProps {
   annotations: Annotation[]
 
   hoveredAnnotation: Annotation | null
+  selectedAnnotation: Annotation | null
 
   /** <svg className={}> */
   className?: string
@@ -41,7 +42,7 @@ export interface AnnotationViewerProps {
   showAnnotationLabel?: boolean
 }
 
-export interface AnnotationsDrawProps extends Omit<AnnotationViewerProps, 'width' | 'height'> {
+export interface AnnotationsDrawProps extends Omit<AnnotationViewerProps, 'width' | 'height' | 'selectedAnnotation'> {
   showOutline: boolean
   showAnnotationLabel: boolean
 }

--- a/libs/insight-viewer/src/Viewer/AnnotationViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationViewer/index.tsx
@@ -68,6 +68,7 @@ export function AnnotationViewer({
   annotations,
   className,
   hoveredAnnotation,
+  selectedAnnotation,
   showOutline = true,
   showAnnotationLabel = false,
   annotationAttrs,
@@ -77,6 +78,10 @@ export function AnnotationViewer({
   const svgRef = useRef<SVGSVGElement>(null)
   const { enabledElement } = useOverlayContext()
 
+  const annotationsOfViewer = selectedAnnotation
+    ? annotations.filter((annotaion) => annotaion !== selectedAnnotation)
+    : annotations
+
   return (
     <svg
       ref={svgRef}
@@ -85,10 +90,10 @@ export function AnnotationViewer({
       style={{ ...svgRootStyle.default, pointerEvents: 'none', ...style }}
       className={className}
     >
-      {annotations.length === 0 || !enabledElement
+      {annotationsOfViewer.length === 0 || !enabledElement
         ? null
         : AnnotationsDraw({
-            annotations,
+            annotations: annotationsOfViewer,
             hoveredAnnotation,
             showOutline,
             showAnnotationLabel,

--- a/libs/insight-viewer/src/Viewer/AnnotationViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationViewer/index.tsx
@@ -79,7 +79,7 @@ export function AnnotationViewer({
   const { enabledElement } = useOverlayContext()
 
   const annotationsOfViewer = selectedAnnotation
-    ? annotations.filter((annotation) => annotation !== selectedAnnotation)
+    ? annotations.filter((annotation) => annotation.id !== selectedAnnotation.id)
     : annotations
 
   return (

--- a/libs/insight-viewer/src/Viewer/AnnotationViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationViewer/index.tsx
@@ -79,7 +79,7 @@ export function AnnotationViewer({
   const { enabledElement } = useOverlayContext()
 
   const annotationsOfViewer = selectedAnnotation
-    ? annotations.filter((annotaion) => annotaion !== selectedAnnotation)
+    ? annotations.filter((annotation) => annotation !== selectedAnnotation)
     : annotations
 
   return (

--- a/libs/insight-viewer/src/Viewer/MeasurementOverlay/index.tsx
+++ b/libs/insight-viewer/src/Viewer/MeasurementOverlay/index.tsx
@@ -34,6 +34,7 @@ export function MeasurementOverlay({
         height={height}
         measurements={measurements}
         hoveredMeasurement={hoveredMeasurement}
+        selectedMeasurement={selectedMeasurement}
         className={className}
         style={style}
         showOutline={showOutline}

--- a/libs/insight-viewer/src/Viewer/MeasurementViewer/MeasurementViewer.types.ts
+++ b/libs/insight-viewer/src/Viewer/MeasurementViewer/MeasurementViewer.types.ts
@@ -9,6 +9,7 @@ export interface MeasurementViewerProps {
   measurements: Measurement[]
 
   hoveredMeasurement: Measurement | null
+  selectedMeasurement: Measurement | null
 
   /** <svg className={}> */
   className?: string
@@ -36,7 +37,8 @@ export interface MeasurementViewerProps {
   showOutline?: boolean
 }
 
-export interface MeasurementsDrawProps extends Omit<MeasurementViewerProps, 'width' | 'height' | 'mode'> {
+export interface MeasurementsDrawProps
+  extends Omit<MeasurementViewerProps, 'width' | 'height' | 'mode' | 'selectedMeasurement'> {
   isEditing: boolean
   showOutline: boolean
 }

--- a/libs/insight-viewer/src/Viewer/MeasurementViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/MeasurementViewer/index.tsx
@@ -69,6 +69,7 @@ export function MeasurementViewer({
   measurements,
   className,
   hoveredMeasurement,
+  selectedMeasurement,
   isEditing = false,
   showOutline = false,
   measurementAttrs,
@@ -78,6 +79,10 @@ export function MeasurementViewer({
 }: MeasurementViewerProps): JSX.Element {
   const svgRef = useRef<SVGSVGElement>(null)
   const { enabledElement } = useOverlayContext()
+
+  const measurementsOfViewer = selectedMeasurement
+    ? measurements.filter((measurement) => measurement !== selectedMeasurement)
+    : measurements
 
   return (
     <svg
@@ -91,7 +96,7 @@ export function MeasurementViewer({
         ? null
         : MeasurementsDraw({
             isEditing,
-            measurements,
+            measurements: measurementsOfViewer,
             hoveredMeasurement,
             showOutline,
             measurementAttrs,

--- a/libs/insight-viewer/src/Viewer/MeasurementViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/MeasurementViewer/index.tsx
@@ -81,7 +81,7 @@ export function MeasurementViewer({
   const { enabledElement } = useOverlayContext()
 
   const measurementsOfViewer = selectedMeasurement
-    ? measurements.filter((measurement) => measurement !== selectedMeasurement)
+    ? measurements.filter((measurement) => measurement.id !== selectedMeasurement.id)
     : measurements
 
   return (

--- a/libs/insight-viewer/src/hooks/useAnnotation/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotation/index.ts
@@ -69,7 +69,13 @@ export function useAnnotation({ nextId, initialAnnotation }: UseAnnotationParams
       validateDataAttrs(annotationInfo?.dataAttrs)
     }
 
-    setAnnotations((prevAnnotations) => [...prevAnnotations, annotation])
+    setAnnotations((prevAnnotations) => {
+      if (!selectedAnnotation) return [...prevAnnotations, annotation]
+
+      return prevAnnotations.map((prevAnnotation) =>
+        prevAnnotation.id === annotation.id ? annotation : prevAnnotation
+      )
+    })
 
     return annotation
   }
@@ -98,8 +104,6 @@ export function useAnnotation({ nextId, initialAnnotation }: UseAnnotationParams
   }
 
   const selectAnnotation = (annotation: Annotation | null) => {
-    if (annotation) removeAnnotation(annotation)
-
     setSelectedAnnotation((prevSelectedAnnotation) =>
       annotation !== prevSelectedAnnotation ? annotation : prevSelectedAnnotation
     )

--- a/libs/insight-viewer/src/hooks/useAnnotation/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotation/index.ts
@@ -124,7 +124,7 @@ export function useAnnotation({ nextId, initialAnnotation }: UseAnnotationParams
         nextAnnotations[index] = nextAnnotation
 
         setHoveredAnnotation((prevHoveredAnnotation) =>
-          annotation === prevHoveredAnnotation ? nextAnnotation : prevHoveredAnnotation
+          annotation.id === prevHoveredAnnotation?.id ? nextAnnotation : prevHoveredAnnotation
         )
       }
 

--- a/libs/insight-viewer/src/hooks/useAnnotation/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotation/index.ts
@@ -104,9 +104,7 @@ export function useAnnotation({ nextId, initialAnnotation }: UseAnnotationParams
   }
 
   const selectAnnotation = (annotation: Annotation | null) => {
-    setSelectedAnnotation((prevSelectedAnnotation) =>
-      annotation !== prevSelectedAnnotation ? annotation : prevSelectedAnnotation
-    )
+    setSelectedAnnotation(annotation)
   }
 
   const updateAnnotation = (annotation: Annotation, patch: Partial<Omit<AnnotationBase, 'id' | 'type'>>) => {

--- a/libs/insight-viewer/src/hooks/useAnnotation/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotation/index.ts
@@ -81,9 +81,7 @@ export function useAnnotation({ nextId, initialAnnotation }: UseAnnotationParams
   }
 
   const hoverAnnotation = (annotation: Annotation | null) => {
-    setHoveredAnnotation((prevHoveredAnnotation) =>
-      annotation !== prevHoveredAnnotation ? annotation : prevHoveredAnnotation
-    )
+    setHoveredAnnotation(annotation)
   }
 
   const removeAnnotation = (annotation: Annotation) => {

--- a/libs/insight-viewer/src/hooks/useMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurement/index.ts
@@ -55,9 +55,7 @@ export function useMeasurement({ nextId, initialMeasurement }: UseMeasurementPar
   }
 
   const hoverMeasurement = (measurement: Measurement | null) => {
-    setHoveredMeasurement((prevHoveredMeasurement) =>
-      measurement !== prevHoveredMeasurement ? measurement : prevHoveredMeasurement
-    )
+    setHoveredMeasurement(measurement)
   }
 
   const removeMeasurement = (measurement: Measurement) => {

--- a/libs/insight-viewer/src/hooks/useMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurement/index.ts
@@ -43,7 +43,13 @@ export function useMeasurement({ nextId, initialMeasurement }: UseMeasurementPar
       validateDataAttrs(measurementInfo?.dataAttrs)
     }
 
-    setMeasurements((prevMeasurements) => [...prevMeasurements, measurement])
+    setMeasurements((prevMeasurements) => {
+      if (!selectedMeasurement) return [...prevMeasurements, measurement]
+
+      return prevMeasurements.map((prevMeasurement) => {
+        return prevMeasurement.id === measurement.id ? measurement : prevMeasurement
+      })
+    })
 
     return measurement
   }
@@ -72,8 +78,6 @@ export function useMeasurement({ nextId, initialMeasurement }: UseMeasurementPar
   }
 
   const selectMeasurement = (measurement: Measurement | null) => {
-    if (measurement) removeMeasurement(measurement)
-
     setSelectedMeasurement((prevSelectedMeasurement) =>
       measurement !== prevSelectedMeasurement ? measurement : prevSelectedMeasurement
     )

--- a/libs/insight-viewer/src/hooks/useMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurement/index.ts
@@ -98,7 +98,7 @@ export function useMeasurement({ nextId, initialMeasurement }: UseMeasurementPar
         nextMeasurements[index] = nextMeasurement
 
         setSelectedMeasurement((prevSelectedMeasurement) =>
-          measurement === prevSelectedMeasurement ? nextMeasurement : prevSelectedMeasurement
+          measurement.id === prevSelectedMeasurement?.id ? nextMeasurement : prevSelectedMeasurement
         )
       }
 

--- a/libs/insight-viewer/src/hooks/useMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurement/index.ts
@@ -78,9 +78,7 @@ export function useMeasurement({ nextId, initialMeasurement }: UseMeasurementPar
   }
 
   const selectMeasurement = (measurement: Measurement | null) => {
-    setSelectedMeasurement((prevSelectedMeasurement) =>
-      measurement !== prevSelectedMeasurement ? measurement : prevSelectedMeasurement
-    )
+    setSelectedMeasurement(measurement)
   }
 
   const updateMeasurement = (measurement: Measurement, patch: Partial<Omit<MeasurementBase, 'id' | 'type'>>) => {

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -97,7 +97,8 @@ export default function useMeasurementPointsHandler({
         currentTextPosition,
         drawingMode,
         measurements,
-        image
+        image,
+        measurement
       )
 
       return currentMeasurement

--- a/libs/insight-viewer/src/utils/common/getMeasurement.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurement.ts
@@ -11,10 +11,15 @@ export function getMeasurement(
   textPoint: Point | null,
   mode: MeasurementMode,
   measurements: Measurement[],
-  image: Image | null
+  image: Image | null,
+  measurement?: Measurement
 ): Measurement {
   const [startPoint, endPoint] = points
-  const currentId = measurements.length === 0 ? 1 : Math.max(...measurements.map(({ id }) => id), 0) + 1
+  const currentId = measurement
+    ? measurement.id
+    : measurements.length === 0
+    ? 1
+    : Math.max(...measurements.map(({ id }) => id), 0) + 1
 
   const defaultMeasurementInfo: Pick<Measurement, 'id' | 'lineWidth'> = {
     id: currentId,

--- a/libs/insight-viewer/src/utils/common/getMeasurement.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurement.ts
@@ -15,11 +15,8 @@ export function getMeasurement(
   measurement?: Measurement
 ): Measurement {
   const [startPoint, endPoint] = points
-  const currentId = measurement
-    ? measurement.id
-    : measurements.length === 0
-    ? 1
-    : Math.max(...measurements.map(({ id }) => id), 0) + 1
+  const currentId =
+    measurement?.id || measurements.reduce((max, cur) => (max.id > cur.id ? max : cur), { id: 0 }).id + 1
 
   const defaultMeasurementInfo: Pick<Measurement, 'id' | 'lineWidth'> = {
     id: currentId,


### PR DESCRIPTION
## 📝 Description

Annotation, Measurement edit 모드에서 선택 시 list 에서 제거하는 방식을 변경했습니다.
list 는 유지하고 Viewer, Drawer 에서 selected Annotation drawing 여부를 결정합니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Annotation, Measurement edit 모드에서 선택 시 annotation list 에서 해당 요소가
삭제됩니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-43

## 🚀 New behavior

Annotation, Measurement edit 모드에서 선택 시 annotation list 에서 해당 요소를
삭제하지 않습니다. 

Annotation Viewer 에 selectedAnnotation prop 을 추가했습니다. [889f49f](https://github.com/lunit-io/frontend-components/pull/328/commits/889f49f97b1ef60025aef2004b3ee6dfbd929c0c)
Viewer 에서는 selected Annotation 을 제외한 annotation list 를 렌더링합니다.

useAnnotation hook 에서 selected Annotation 유무에 따른 setState 값을 설정합니다. [889f49f](https://github.com/lunit-io/frontend-components/pull/328/commits/889f49f97b1ef60025aef2004b3ee6dfbd929c0c)
selected Annotation 이 있을 경우, 기존 annotation list 에서 parameter 로 전달된 요소로
변경합니다.

getMeasurement parameter 에 measurement 를 추가했습니다. [5e48956](https://github.com/lunit-io/frontend-components/pull/328/commits/5e4895618f58761e8e0d9fdea0cf8e534409173f)
해당 값이 존재할 경우, 해당 measurement id 로 변경합니다.
기존 로직은 list 에서 selected measurement 가 제외될 경우 계산하는 방식이였으며,
변경 로직은 list 에 selected measurement 가 존재하므로 해당 id 값을 사용하도록 수정했습니다.

selectedMeasurement prop 을 Measurement Viewer 에 추가했습니다.
annotation 과 동일하게 selected measurement 를 제외한 list 를 사용합니다. [e70687f](https://github.com/lunit-io/frontend-components/pull/328/commits/e70687f03042f5404e265925f92a761c18be3e4a)

useMeasurement hook 에서 select measurement 시 list 에서 삭제하는 로직을 제거,
addMeasurement 내 setState 시 selectedMeasurement 유무에 따라 로직을 분리했습니다.
selectedMeasurement 가 있을 경우, parameter 로 전달된 measurement 객체로 대체합니다. [bd1a959](https://github.com/lunit-io/frontend-components/pull/328/commits/bd1a9595ad7192b5f8d586fbdb3323f64a143703)

## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

Annotation, Measurement edit 기능 활용 시 list 에서 제거하지 않으므로,
관련 로직을 변경해야합니다.
