### PR TITLE
VIEWER-76 / useViewport reset 동작 버그

### DIFF
--- a/apps/insight-viewer-docs/containers/Interaction/Image1.tsx
+++ b/apps/insight-viewer-docs/containers/Interaction/Image1.tsx
@@ -76,7 +76,7 @@ export default function App(): JSX.Element {
           <Control onChange={handleChange} />
           <WheelControl onChange={handleWheel} />
           <Box>
-            active initial viewport{' '}
+            active initial viewport (scale 0.5){' '}
             <Switch
               onChange={(e) => setIsActiveInitialViewport(e.target.checked)}
               className="toggle-initial-viewport"

--- a/apps/insight-viewer-docs/containers/Interaction/Image1.tsx
+++ b/apps/insight-viewer-docs/containers/Interaction/Image1.tsx
@@ -1,4 +1,5 @@
-import { Box, Text, Button, Stack } from '@chakra-ui/react'
+import { useState } from 'react'
+import { Box, Text, Button, Stack, Switch } from '@chakra-ui/react'
 import InsightViewer, {
   useInteraction,
   useViewport,
@@ -24,6 +25,7 @@ const MIN_SCALE = 0.178
 const MAX_SCALE = 3
 
 export default function App(): JSX.Element {
+  const [isActiveInitialViewport, setIsActiveInitialViewport] = useState<boolean>(false)
   const { loadingStates, images } = useMultipleImages({
     wadouri: IMAGES,
   })
@@ -32,9 +34,7 @@ export default function App(): JSX.Element {
     max: images.length - 1,
   })
   const { interaction, setInteraction } = useInteraction()
-  const { viewport, setViewport, resetViewport } = useViewport({
-    scale: 1,
-  })
+  const { viewport, setViewport, resetViewport } = useViewport(isActiveInitialViewport ? { scale: 0.5 } : undefined)
 
   function handleChange(type: string) {
     return (value: string) => {
@@ -75,6 +75,14 @@ export default function App(): JSX.Element {
         <Box>
           <Control onChange={handleChange} />
           <WheelControl onChange={handleWheel} />
+          <Box>
+            active initial viewport{' '}
+            <Switch
+              onChange={(e) => setIsActiveInitialViewport(e.target.checked)}
+              className="toggle-initial-viewport"
+              isChecked={isActiveInitialViewport}
+            />
+          </Box>
           <Box mb={6}>
             <Text className="test">
               frame: <span className="frame">{frame}</span>

--- a/libs/insight-viewer/src/hooks/useViewport.ts
+++ b/libs/insight-viewer/src/hooks/useViewport.ts
@@ -25,7 +25,7 @@ export function useViewport(initialViewport?: Partial<BasicViewport>): {
   function resetViewport() {
     setViewport({
       ...viewport,
-      _resetViewport: initialViewport,
+      _resetViewport: initialViewport ?? {},
     })
   }
 


### PR DESCRIPTION
## 📝 Description

useViewport 의 initial viewport parameter 가 undefined 일 경우,
reset 이 동작하지 않는 버그를 수정했습니다.

위 내용을 테스트할 수 있도록 `interaction docs` 에 initial viewport toggle switch 를 추가했습니다.

- `switch off` 상태에서 reset 을 누를 경우 `default viewport` 로 초기화됩니다.

- `switch on` 상태에서 reset 을 누를 경우,
`docs 내에 설정한 initial viewport scale 0.5` 로 초기화됩니다.

위와 같이 동작하는지 확인 부탁드립니다.
- [테스트 환경](https://insight-viewer--pr-339.f.lunit.io/interaction)

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

useViewport hook 의 initial viewport parameter 가 undefined 일 경우,
reset 기능이 동작하지 않습니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-76

## 🚀 New behavior

useViewport hook 의 initial viewport parameter 가 undefined 일 경우,
default viewport 로 reset 됩니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

라이브러리 사용 앱에서 더이상 useViewport initial viewport 에 default value 를 할당하지 않아도 괜찮습니다.
