### PR TITLE
VIEWER-79 / delete unused onMouseDown event to Drawer component

### DIFF
--- a/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
@@ -18,14 +18,12 @@ export function CircleDrawer({
   return (
     <>
       <circle
-        onMouseDown={handleMoveOnMouseDown}
         style={svgWrapperStyle.outline}
         cx={centerPointOnCanvas[0]}
         cy={centerPointOnCanvas[1]}
         r={drawingRadius}
       />
       <circle
-        onMouseDown={handleMoveOnMouseDown}
         style={svgWrapperStyle[isSelectedMode ? 'select' : 'default']}
         cx={centerPointOnCanvas[0]}
         cy={centerPointOnCanvas[1]}

--- a/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
@@ -16,17 +16,12 @@ export function RulerDrawer({
 
   return (
     <>
-      <polyline onMouseDown={handleMoveOnMouseDown} style={svgWrapperStyle.outline} points={rulerLine} />
+      <polyline style={svgWrapperStyle.outline} points={rulerLine} />
+      <polyline data-cy-move style={svgWrapperStyle[isSelectedMode ? 'select' : 'default']} points={rulerLine} />
       <polyline
         data-cy-move
         onMouseDown={handleMoveOnMouseDown}
         style={{ ...svgWrapperStyle.extendsArea, cursor: isSelectedMode ? 'grab' : 'pointer' }}
-        points={rulerLine}
-      />
-      <polyline
-        data-cy-move
-        onMouseDown={handleMoveOnMouseDown}
-        style={svgWrapperStyle[isSelectedMode ? 'select' : 'default']}
         points={rulerLine}
       />
       <polyline style={{ ...svgWrapperStyle.dashLine, visibility }} points={connectingLine} />

--- a/libs/insight-viewer/src/components/EditPointer/index.tsx
+++ b/libs/insight-viewer/src/components/EditPointer/index.tsx
@@ -24,11 +24,16 @@ export function EditPointer({
   return (
     <>
       <circle
-        onMouseDown={() => setEditMode(editMode)}
         cx={cx}
         cy={cy}
         r={EDIT_CIRCLE_RADIUS}
         style={editPointerStyle[isSelectedMode ? 'selectedOutline' : 'outline']}
+      />
+      <circle
+        cx={cx}
+        cy={cy}
+        r={EDIT_CIRCLE_RADIUS}
+        style={editPointerStyle[isSelectedMode ? 'select' : isHighlightMode ? 'highlight' : 'default']}
       />
       <circle
         onMouseDown={() => setEditMode(editMode)}
@@ -36,13 +41,6 @@ export function EditPointer({
         cy={cy}
         r={EDIT_CIRCLE_RADIUS}
         style={editPointerStyle.extendsArea}
-      />
-      <circle
-        onMouseDown={() => setEditMode(editMode)}
-        cx={cx}
-        cy={cy}
-        r={EDIT_CIRCLE_RADIUS}
-        style={editPointerStyle[isSelectedMode ? 'select' : isHighlightMode ? 'highlight' : 'default']}
       />
     </>
   )


### PR DESCRIPTION
## 📝 Description

Measurement Drawer 내 모든 polyline 혹은 circle element 에 `onMouseDown 이벤트`를 일부 삭제조치 했습니다.
DOM 레이어상 제일 상위에 있으며 영역이 제일 넓은 `extends area` 에서만 이벤트 등록을 했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

drawer 관련 모든 svg element 에 onMouseDown 이벤트를 등록했습니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-79

## 🚀 New behavior

drawer 내 extends area svg element 에 onMouseDown 이벤트를 등록했습니다.
그 외 마우스 이벤트는 삭제 조치했습니다. 7e32297

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
