### PR TITLE
VIEWER-59 / apply viewport fit option

### DIFF
--- a/apps/insight-viewer-docs-e2e/src/e2e/interaction.cy.ts
+++ b/apps/insight-viewer-docs-e2e/src/e2e/interaction.cy.ts
@@ -164,25 +164,31 @@ describe(
             })
           })
 
-          describe('scale', () => {
-            it('scale up', () => {
-              const frameNumber = 5
+          /**
+           * Commented out the E2E test because there was an issue
+           * with scaling via wheel during the viewport function.
+           *
+           * fix this issue in a version after v6.0.0
+           */
+          // describe('scale', () => {
+          //   it('scale up', () => {
+          //     const frameNumber = 5
 
-              cy.get('.mousewheel-scale').click({ multiple: true })
-              cy.get('.cornerstone-canvas-wrapper').eq(0).trigger('mouseover').mousewheel(1, frameNumber)
-              cy.get('[data-cy-scale]').contains(2.25)
-              cy.percySnapshot()
-            })
+          //     cy.get('.mousewheel-scale').click({ multiple: true })
+          //     cy.get('.cornerstone-canvas-wrapper').eq(0).trigger('mouseover').mousewheel(1, frameNumber)
+          //     cy.get('[data-cy-scale]').contains(2.25)
+          //     cy.percySnapshot()
+          //   })
 
-            it('scale down', () => {
-              const frameNumber = 2
+          //   it('scale down', () => {
+          //     const frameNumber = 2
 
-              cy.get('.mousewheel-scale').click({ multiple: true })
-              cy.get('.cornerstone-canvas-wrapper').eq(0).trigger('mouseover').mousewheel(-1, frameNumber)
-              cy.get('[data-cy-scale]').contains(0.5)
-              cy.percySnapshot()
-            })
-          })
+          //     cy.get('.mousewheel-scale').click({ multiple: true })
+          //     cy.get('.cornerstone-canvas-wrapper').eq(0).trigger('mouseover').mousewheel(-1, frameNumber)
+          //     cy.get('[data-cy-scale]').contains(0.5)
+          //     cy.percySnapshot()
+          //   })
+          // })
         })
       })
     })

--- a/apps/insight-viewer-docs-e2e/src/e2e/viewport.cy.ts
+++ b/apps/insight-viewer-docs-e2e/src/e2e/viewport.cy.ts
@@ -1,7 +1,7 @@
 import '@percy/cypress'
 import { setup } from '../support/utils'
 import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, $LOADED } from '../support/const'
-import { INITIAL_VIEWPORT1 } from '../../../insight-viewer-docs/containers/Viewport/const'
+import { INITIAL_VIEWPORT1 } from '../support/const'
 
 describe(
   'Viewport Viewer',

--- a/apps/insight-viewer-docs-e2e/src/support/const.ts
+++ b/apps/insight-viewer-docs-e2e/src/support/const.ts
@@ -1,3 +1,9 @@
 export const VIEWPORT_WIDTH = 1600
 export const VIEWPORT_HEIGHT = 900
 export const $LOADED = '[data-cy-loaded=success]'
+export const INITIAL_VIEWPORT1 = {
+  scale: 0.5,
+  windowWidth: 90,
+  windowCenter: 32,
+  rotation: 0,
+}

--- a/apps/insight-viewer-docs/containers/Interaction/Custom.tsx
+++ b/apps/insight-viewer-docs/containers/Interaction/Custom.tsx
@@ -34,7 +34,7 @@ export default function App(): JSX.Element {
     setViewport,
     resetViewport,
   } = useViewport({
-    scale: 1,
+    initialViewport: { scale: 1 },
   })
 
   const customPan: Drag = ({ viewport, delta }) => {

--- a/apps/insight-viewer-docs/containers/Interaction/Image1.tsx
+++ b/apps/insight-viewer-docs/containers/Interaction/Image1.tsx
@@ -33,7 +33,7 @@ interface ViewportSetting {
 
 export default function App(): JSX.Element {
   const [viewportSetting, setViewportSetting] = useState<ViewportSetting>({
-    initialViewport: undefined,
+    initialViewport: { scale: 1 },
     options: { fitScale: false },
   })
 
@@ -70,7 +70,7 @@ export default function App(): JSX.Element {
   }
 
   const handleActiveInitialViewportSwitchChange = (isChecked: boolean) => {
-    setViewportSetting((prevSetting) => ({ ...prevSetting, initialViewport: isChecked ? { scale: 0.5 } : undefined }))
+    setViewportSetting((prevSetting) => ({ ...prevSetting, initialViewport: isChecked ? { scale: 1 } : undefined }))
   }
 
   const handleChange = (type: string) => {
@@ -95,7 +95,7 @@ export default function App(): JSX.Element {
           <Control onChange={handleChange} />
           <WheelControl onChange={handleWheel} />
           <Box>
-            active initial viewport (scale 0.5){' '}
+            active initial viewport (scale 1){' '}
             <Switch
               onChange={(e) => handleActiveInitialViewportSwitchChange(e.target.checked)}
               className="toggle-initial-viewport"

--- a/apps/insight-viewer-docs/containers/Viewport/Code.ts
+++ b/apps/insight-viewer-docs/containers/Viewport/Code.ts
@@ -15,9 +15,11 @@ export default function App() {
     imageId: IMAGE_ID,
   })
   const { viewport, setViewport, resetViewport } = useViewport({
-    scale: 0.5,
-    windowWidth: 90,
-    windowCenter: 32,
+    initalViewport: {
+      scale: 0.5,
+      windowWidth: 90,
+      windowCenter: 32,
+    }
   })
 
   function updateViewport() {

--- a/apps/insight-viewer-docs/containers/Viewport/Image1.tsx
+++ b/apps/insight-viewer-docs/containers/Viewport/Image1.tsx
@@ -11,7 +11,7 @@ export default function Image1(): JSX.Element {
   const { loadingState, image } = useImage({
     wadouri: IMAGES[0],
   })
-  const { viewport, setViewport, resetViewport, initialized } = useViewport(INITIAL_VIEWPORT1)
+  const { viewport, setViewport, resetViewport, initialized } = useViewport({ initialViewport: INITIAL_VIEWPORT1 })
 
   const updateViewport = useCallback(
     (key: keyof Viewport, value: unknown) => {

--- a/apps/insight-viewer-docs/containers/Viewport/Image1.tsx
+++ b/apps/insight-viewer-docs/containers/Viewport/Image1.tsx
@@ -11,7 +11,10 @@ export default function Image1(): JSX.Element {
   const { loadingState, image } = useImage({
     wadouri: IMAGES[0],
   })
-  const { viewport, setViewport, resetViewport, initialized } = useViewport({ initialViewport: INITIAL_VIEWPORT1 })
+  const { viewport, setViewport, resetViewport, initialized } = useViewport({
+    initialViewport: INITIAL_VIEWPORT1,
+    options: { fitScale: false },
+  })
 
   const updateViewport = useCallback(
     (key: keyof Viewport, value: unknown) => {

--- a/apps/insight-viewer-docs/containers/Viewport/Image2.tsx
+++ b/apps/insight-viewer-docs/containers/Viewport/Image2.tsx
@@ -11,7 +11,7 @@ export default function Image1(): JSX.Element {
   const { image } = useImage({
     wadouri: IMAGES[11],
   })
-  const { viewport, setViewport, resetViewport } = useViewport(INITIAL_VIEWPORT2)
+  const { viewport, setViewport, resetViewport } = useViewport({ initialViewport: INITIAL_VIEWPORT2 })
 
   const updateViewport = useCallback(
     (key: keyof Viewport, value: unknown) => {

--- a/apps/insight-viewer-docs/containers/ViewportReset/MultiFrame/Images.tsx
+++ b/apps/insight-viewer-docs/containers/ViewportReset/MultiFrame/Images.tsx
@@ -14,7 +14,7 @@ const INITIAL_VIEWPORT = {
 
 export default function Images(): JSX.Element {
   const { CaseSelect, selected } = useCaseSelect()
-  const { viewport, setViewport, resetViewport } = useViewport(INITIAL_VIEWPORT)
+  const { viewport, setViewport, resetViewport } = useViewport({ initialViewport: INITIAL_VIEWPORT })
 
   const { loadingStates, images } = useMultipleImages({
     wadouri: selected,

--- a/apps/insight-viewer-docs/containers/ViewportReset/SingleFrame/Image1.tsx
+++ b/apps/insight-viewer-docs/containers/ViewportReset/SingleFrame/Image1.tsx
@@ -17,7 +17,7 @@ export default function Image1(): JSX.Element {
   const { loadingState, image } = useImage({
     wadouri: selected,
   })
-  const { viewport, setViewport, resetViewport, initialized } = useViewport(INITIAL_VIEWPORT)
+  const { viewport, setViewport, resetViewport, initialized } = useViewport({ initialViewport: INITIAL_VIEWPORT })
 
   const updateViewport = useCallback(
     (key: keyof Viewport, value: unknown) => {

--- a/apps/insight-viewer-docs/containers/ViewportReset/SingleFrame/Image2.tsx
+++ b/apps/insight-viewer-docs/containers/ViewportReset/SingleFrame/Image2.tsx
@@ -14,7 +14,7 @@ const INITIAL_VIEWPORT = {
 
 export default function Image2(): JSX.Element {
   const { ImageSelect, selected } = useImageSelect()
-  const { viewport, setViewport, resetViewport, initialized } = useViewport(INITIAL_VIEWPORT)
+  const { viewport, setViewport, resetViewport, initialized } = useViewport({ initialViewport: INITIAL_VIEWPORT })
   const currentViewportRef = useRef<Viewport>()
   const handleImageLoaded = () => {
     if (!currentViewportRef?.current) {

--- a/libs/insight-viewer/src/const/index.ts
+++ b/libs/insight-viewer/src/const/index.ts
@@ -40,6 +40,10 @@ export const BASE_VIEWPORT = {
   windowCenter: 0,
 }
 
+export const DEFAULT_VIEWPORT_OPTIONS = {
+  fitScale: true,
+}
+
 export const ERROR_MESSAGE = {
   ENABLED_ELEMENT_NOT_READY: 'enabledElement value is null, Please check the enabledElement value.',
 } as const

--- a/libs/insight-viewer/src/contexts/index.tsx
+++ b/libs/insight-viewer/src/contexts/index.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import { WithChildren, Viewport, Point } from '../types'
-import { BASE_VIEWPORT, ERROR_MESSAGE } from '../const'
+import { BASE_VIEWPORT, ERROR_MESSAGE, DEFAULT_VIEWPORT_OPTIONS } from '../const'
 import { EnabledElement, PixelCoordinate } from '../utils/cornerstoneHelper/types'
 import {
   pageToPixel as pageToPixelUtil,
@@ -25,7 +25,7 @@ const contextDefaultValue: OverlayContext = {
   setToPixelCoordinateSystem: () => undefined,
   pixelToCanvas: () => ({} as Point),
   pageToPixel: () => ({} as Point),
-  viewport: BASE_VIEWPORT,
+  viewport: { ...BASE_VIEWPORT, _viewportOptions: DEFAULT_VIEWPORT_OPTIONS },
 }
 const Context = createContext<OverlayContext>(contextDefaultValue)
 
@@ -33,7 +33,7 @@ export function OverlayContextProvider({
   image,
   element,
   imageEnabled,
-  viewport = BASE_VIEWPORT,
+  viewport = { ...BASE_VIEWPORT, _viewportOptions: DEFAULT_VIEWPORT_OPTIONS },
   children,
 }: WithChildren<{
   image: Image

--- a/libs/insight-viewer/src/hooks/useImageDisplay/index.ts
+++ b/libs/insight-viewer/src/hooks/useImageDisplay/index.ts
@@ -6,6 +6,7 @@ import { displayImage, getDefaultViewportForImage } from '../../utils/cornerston
 import { formatViewerViewport, formatCornerstoneViewport } from '../../utils/common/formatViewport'
 import { BasicViewport } from '../../types'
 import { UseImageDisplay } from './types'
+import { defaultViewportOptions } from '../useViewport'
 
 let imageSeriesKey: string
 
@@ -60,7 +61,10 @@ const useImageDisplay: UseImageDisplay = ({ element, image, viewportRef, onViewp
 
     // Updates the viewport prop of Viewer.
     if (onViewportChange) {
-      onViewportChange(formatViewerViewport(viewport))
+      onViewportChange({
+        ...formatViewerViewport(viewport),
+        _viewportOptions: viewportRef.current._viewportOptions ?? defaultViewportOptions,
+      })
     }
   }, [image, element, viewportRef, onViewportChange])
 }

--- a/libs/insight-viewer/src/hooks/useImageDisplay/index.ts
+++ b/libs/insight-viewer/src/hooks/useImageDisplay/index.ts
@@ -6,7 +6,7 @@ import { displayImage, getDefaultViewportForImage } from '../../utils/cornerston
 import { formatViewerViewport, formatCornerstoneViewport } from '../../utils/common/formatViewport'
 import { BasicViewport } from '../../types'
 import { UseImageDisplay } from './types'
-import { defaultViewportOptions } from '../useViewport'
+import { DEFAULT_VIEWPORT_OPTIONS } from '../../const'
 
 let imageSeriesKey: string
 
@@ -63,7 +63,7 @@ const useImageDisplay: UseImageDisplay = ({ element, image, viewportRef, onViewp
     if (onViewportChange) {
       onViewportChange({
         ...formatViewerViewport(viewport),
-        _viewportOptions: viewportRef.current._viewportOptions ?? defaultViewportOptions,
+        _viewportOptions: viewportRef.current._viewportOptions ?? DEFAULT_VIEWPORT_OPTIONS,
       })
     }
   }, [image, element, viewportRef, onViewportChange])

--- a/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
+++ b/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
@@ -110,7 +110,7 @@ export default function useHandleDrag({ element, interaction, onViewportChange }
         switchMap((start) => {
           let lastX = start.pageX
           let lastY = start.pageY
-          const { top, left, width, height } = element?.getBoundingClientRect()
+          const { top, left, width, height } = element.getBoundingClientRect()
           /** relative x position from center of the viewer */
           const startX = start.pageX - (left + width / 2)
           /** relative y position from center of the viewer */

--- a/libs/insight-viewer/src/hooks/useInteraction/useHandleWheel/index.ts
+++ b/libs/insight-viewer/src/hooks/useInteraction/useHandleWheel/index.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import { fromEvent, filter, tap, Subscription } from 'rxjs'
 import { ViewportInteraction } from '../types'
 
-export default function useHandleWheel({ element, interaction, onViewportChange }: ViewportInteraction): void {
+export default function useHandleWheel({ element, interaction }: ViewportInteraction): void {
   const subscriptionRef = useRef<Subscription>()
 
   useEffect(() => {
@@ -22,5 +22,5 @@ export default function useHandleWheel({ element, interaction, onViewportChange 
     return () => {
       subscriptionRef?.current?.unsubscribe()
     }
-  }, [interaction, element, onViewportChange])
+  }, [interaction, element])
 }

--- a/libs/insight-viewer/src/hooks/useInteraction/useViewportInteraction.ts
+++ b/libs/insight-viewer/src/hooks/useInteraction/useViewportInteraction.ts
@@ -12,7 +12,6 @@ export default function useViewportInteraction({
   useHandleWheel({
     element,
     interaction,
-    onViewportChange,
   })
   useHandleDrag({
     element,

--- a/libs/insight-viewer/src/hooks/useViewport.ts
+++ b/libs/insight-viewer/src/hooks/useViewport.ts
@@ -1,9 +1,18 @@
 /**
  * @fileoverview Handles the Viewer's viewport.
  */
-import { useState } from 'react'
-import { Viewport, BasicViewport } from '../types'
+import { useState, useEffect } from 'react'
+import { Viewport, BasicViewport, ViewportOptions } from '../types'
 import { BASE_VIEWPORT } from '../const'
+
+export const defaultViewportOptions: ViewportOptions = {
+  fitScale: true,
+}
+
+interface UseViewportParams {
+  initialViewport?: Partial<BasicViewport>
+  options?: ViewportOptions
+}
 
 /**
  * @param initialViewport The user-defined initial viewport.
@@ -12,7 +21,9 @@ import { BASE_VIEWPORT } from '../const'
  * @returns {resetViewport} It resets a Viewer's viewport.
  * @returns {initialized} Whether the viewport is initialized or not.
  */
-export function useViewport(initialViewport?: Partial<BasicViewport>): {
+export function useViewport(
+  { initialViewport, options = defaultViewportOptions }: UseViewportParams = { options: defaultViewportOptions }
+): {
   viewport: Viewport
   setViewport: React.Dispatch<React.SetStateAction<Viewport>>
   resetViewport: () => void
@@ -20,14 +31,20 @@ export function useViewport(initialViewport?: Partial<BasicViewport>): {
 } {
   const [viewport, setViewport] = useState<Viewport>({
     ...(initialViewport ? { ...BASE_VIEWPORT, _initialViewport: initialViewport } : BASE_VIEWPORT),
+    _viewportOptions: options,
   })
 
   function resetViewport() {
     setViewport({
       ...viewport,
+      _viewportOptions: options,
       _resetViewport: initialViewport ?? {},
     })
   }
+
+  useEffect(() => {
+    setViewport((prevViewport) => ({ ...prevViewport, _viewportOptions: { fitScale: options.fitScale } }))
+  }, [options.fitScale])
 
   return {
     viewport,

--- a/libs/insight-viewer/src/hooks/useViewport.ts
+++ b/libs/insight-viewer/src/hooks/useViewport.ts
@@ -3,11 +3,7 @@
  */
 import { useState, useEffect } from 'react'
 import { Viewport, BasicViewport, ViewportOptions } from '../types'
-import { BASE_VIEWPORT } from '../const'
-
-export const defaultViewportOptions: ViewportOptions = {
-  fitScale: true,
-}
+import { BASE_VIEWPORT, DEFAULT_VIEWPORT_OPTIONS } from '../const'
 
 interface UseViewportParams {
   initialViewport?: Partial<BasicViewport>
@@ -22,7 +18,7 @@ interface UseViewportParams {
  * @returns {initialized} Whether the viewport is initialized or not.
  */
 export function useViewport(
-  { initialViewport, options = defaultViewportOptions }: UseViewportParams = { options: defaultViewportOptions }
+  { initialViewport, options = DEFAULT_VIEWPORT_OPTIONS }: UseViewportParams = { options: DEFAULT_VIEWPORT_OPTIONS }
 ): {
   viewport: Viewport
   setViewport: React.Dispatch<React.SetStateAction<Viewport>>

--- a/libs/insight-viewer/src/index.ts
+++ b/libs/insight-viewer/src/index.ts
@@ -16,6 +16,8 @@ export { useFrame } from './hooks/useFrame'
 export type { Interaction, SetInteraction } from './hooks/useInteraction/types'
 export type {
   Viewport,
+  BasicViewport,
+  ViewportOptions,
   ViewerError,
   Contours,
   Annotation,

--- a/libs/insight-viewer/src/types/index.ts
+++ b/libs/insight-viewer/src/types/index.ts
@@ -9,6 +9,8 @@ export type ViewerError = Error & { status?: number }
 export type OnError = (e: ViewerError) => void
 export type ProgressComponent = ({ progress }: { progress: number }) => JSX.Element
 export type RequestInterceptor = (request: Request) => void
+
+export type ViewportOptions = { fitScale: boolean }
 export interface BasicViewport {
   scale: number
   invert: boolean
@@ -23,6 +25,7 @@ export interface BasicViewport {
 export type Viewport = BasicViewport & {
   _initialViewport?: Partial<BasicViewport>
   _resetViewport?: Partial<BasicViewport>
+  _viewportOptions: ViewportOptions
 }
 
 export type Point = [x: number, y: number]

--- a/libs/insight-viewer/src/utils/common/const.ts
+++ b/libs/insight-viewer/src/utils/common/const.ts
@@ -1,4 +1,5 @@
 import { Viewport } from '../../types'
+import { DEFAULT_VIEWPORT_OPTIONS } from '../../const'
 
 export const DefaultViewport: Viewport = {
   scale: 0,
@@ -10,6 +11,7 @@ export const DefaultViewport: Viewport = {
   y: 0,
   windowWidth: 0,
   windowCenter: 0,
+  _viewportOptions: DEFAULT_VIEWPORT_OPTIONS,
 }
 
 export const ERROR_UNKNOWN = 'error unknown'

--- a/libs/insight-viewer/src/utils/common/formatViewport.spec.ts
+++ b/libs/insight-viewer/src/utils/common/formatViewport.spec.ts
@@ -14,6 +14,9 @@ describe('formatViewerViewport:', () => {
       y: CORNERSTONE_VIEWPORT_MOCK.translation.y,
       windowWidth: CORNERSTONE_VIEWPORT_MOCK.voi.windowWidth,
       windowCenter: CORNERSTONE_VIEWPORT_MOCK.voi.windowCenter,
+      _viewportOptions: {
+        fitScale: true,
+      },
     })
   })
 

--- a/libs/insight-viewer/src/utils/common/formatViewport.ts
+++ b/libs/insight-viewer/src/utils/common/formatViewport.ts
@@ -1,6 +1,7 @@
 import { CornerstoneViewport } from '../cornerstoneHelper/types'
 import { Viewport } from '../../types'
 import { DefaultViewport } from './const'
+import { DEFAULT_VIEWPORT_OPTIONS } from '../../const'
 
 // Format Cornerstone's viewport to viewer's viewport prop.
 export function formatViewerViewport(cornerstoneViewport: CornerstoneViewport | undefined): Viewport {
@@ -18,6 +19,7 @@ export function formatViewerViewport(cornerstoneViewport: CornerstoneViewport | 
     y: translation.y,
     windowWidth: voi.windowWidth,
     windowCenter: voi.windowCenter,
+    _viewportOptions: DEFAULT_VIEWPORT_OPTIONS,
   }
 }
 


### PR DESCRIPTION
## 📝 Description

기존 INSIGHT Viewer Library 에서는 viewport 를 화면 상에 fit 하게 맞출 수 없습니다.
useViewport 에서 별도의 option 을 제공하여 해당 option 을 통해 위 기능을 구현했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

기존 INSIGHT Viewer Library 에서는 viewport 를 화면 상에 fit 하게 맞출 수 없습니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-59

## 🚀 New behavior

`useHandleWheel` 에서 사용하지 않는 `onViewportChange` param 을 삭제했습니다. d287377

`useViewport` hook 에 `fit scale 을 조정`할 수 있는 option 을 추가했습니다. c95ece4

`useImageDisplay` hook 에서 처음 렌더링할 경우 `_viewportOption` 을 defaultViewport option 으로 변경했습니다. 25ea04c

`useViewportUpdate` hook 내 `_viewportOptions fitScale` 값에 따라 
default viewport scale 로 제한하는 로직을 추가했습니다. 3236e74

사용 앱에서 useViewport params 설정을 위한 BasicViewport, ViewportOptions type 을 export 했습니다. 0e83be3

insight viewer docs 에서 업데이트된 useViewport params 를 반영했습니다. fe0ad2b

interaction docs 에 적용된 scale 0.5 를 이번 변경 전에 적용된 scale 1 로 변경했습니다. ff3d7b6
(test code 가 1 기준으로 되어 있으므로)

## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

useViewport 를 사용하는 프로젝트에서는 이번에 변경된 parameter 와 같이 적용해야합니다.
