### PR TITLE
Feature modify class name for cursor

### DIFF
--- a/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
@@ -96,7 +96,7 @@ function AnnotationDrawerContainer(): JSX.Element {
       >
         remove all
       </Button>
-      <Resizable style={style} defaultSize={DEFAULT_SIZE}>
+      <Resizable style={style} defaultSize={DEFAULT_SIZE} className={`annotation ${annotationMode}`}>
         <InsightViewer image={image} viewport={viewport} onViewportChange={setViewport}>
           {loadingState === 'success' && (
             <AnnotationOverlay

--- a/apps/insight-viewer-docs/containers/Annotation/Viewer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Annotation/Viewer/index.tsx
@@ -83,7 +83,7 @@ function AnnotationViewerContainer(): JSX.Element {
           <Radio value="circle">Circle - Not implemented yet</Radio>
         </Stack>
       </RadioGroup>
-      <Resizable style={style} defaultSize={DEFAULT_SIZE}>
+      <Resizable style={style} defaultSize={DEFAULT_SIZE} className={`annotation ${annotationMode}`}>
         <InsightViewer image={image} viewport={viewport} onViewportChange={setViewport}>
           {loadingState === 'success' && (
             <AnnotationOverlay

--- a/apps/insight-viewer-docs/containers/Measurement/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Measurement/Drawer/index.tsx
@@ -67,7 +67,7 @@ function MeasurementDrawerContainer(): JSX.Element {
         remove all
       </Button>
 
-      <Box data-cy-loaded={loadingState} className={`measurement-${measurementMode}`}>
+      <Box data-cy-loaded={loadingState} className={`measurement ${measurementMode}`}>
         <Resizable style={style} defaultSize={DEFAULT_SIZE}>
           <InsightViewer image={image} viewport={viewport} onViewportChange={setViewport}>
             {loadingState === 'success' && (

--- a/apps/insight-viewer-docs/containers/Measurement/Viewer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Measurement/Viewer/index.tsx
@@ -69,7 +69,7 @@ function MeasurementViewerContainer(): JSX.Element {
           <Radio value="circle">Circle</Radio>
         </Stack>
       </RadioGroup>
-      <Resizable style={style} defaultSize={DEFAULT_SIZE}>
+      <Resizable style={style} defaultSize={DEFAULT_SIZE} className={`measurement ${measurementMode}`}>
         <InsightViewer image={image} viewport={viewport} onViewportChange={setViewport}>
           {loadingState === 'success' && (
             <MeasurementOverlay

--- a/apps/insight-viewer-docs/styles/globals.css
+++ b/apps/insight-viewer-docs/styles/globals.css
@@ -19,19 +19,40 @@ a {
   box-sizing: border-box;
 }
 
-/* Custom Cursor 적용 방법
-html {
-  cursor: url('../assets/default.png') 10 10, auto;
+/* Custom Cursor 적용 방법 */
+
+.measurement {
+  cursor: url('../assets/ruler.png') 10 10, auto;
+}
+
+.editing {
+  cursor: url('../assets/move.png') 20 20, auto !important;
+}
+
+.editable {
+  cursor: url('../assets/crosshair.png') 20 20, auto !important;
 }
 
 .pointer {
+  cursor: url('../assets/default.png') 10 10, auto;
+}
+
+.moving {
   cursor: url('../assets/default.png') 10 10, auto !important;
 }
 
-.pointer .grab:active {
-  cursor: url('../assets/grab.png') 10 10, auto !important;
+.annotation.line {
+  cursor: url('../assets/crosshair.png') 20 20, auto !important;
 }
 
-.move {
-  cursor: url('../assets/move.png') 10 10, auto !important;
-} */
+.annotation.polygon {
+  cursor: url('../assets/pen.png') 10 10, auto !important;
+}
+
+.annotation.freeLine {
+  cursor: url('../assets/pen.png') 10 10, auto !important;
+}
+
+.annotation.text {
+  cursor: url('../assets/crosshair.png') 20 20, auto !important;
+}

--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
@@ -34,7 +34,7 @@ export function AnnotationDrawer({
     }
   }
 
-  const { annotation, editPoints, currentEditMode, setAnnotationEditMode } = useAnnotationPointsHandler({
+  const { annotation, editPoints, currentEditMode, setAnnotationEditMode, cursorStatus } = useAnnotationPointsHandler({
     isEditing,
     mode,
     lineHead,
@@ -77,6 +77,7 @@ export function AnnotationDrawer({
               lineHead={lineHead}
               selectedAnnotationLabel={selectedAnnotation ? selectedAnnotation.label ?? selectedAnnotation.id : null}
               setAnnotationEditMode={setAnnotationEditMode}
+              cursorStatus={cursorStatus}
             />
           )}
           {annotation.type === 'text' && (
@@ -84,6 +85,7 @@ export function AnnotationDrawer({
               annotation={annotation}
               isSelectedMode={isSelectedAnnotation}
               setAnnotationEditMode={setAnnotationEditMode}
+              cursorStatus={cursorStatus}
             />
           )}
           {editPoints && (
@@ -96,6 +98,7 @@ export function AnnotationDrawer({
                 isDrawing={isDrawing}
                 cx={editPoints[0]}
                 cy={editPoints[1]}
+                cursorStatus={cursorStatus}
               />
               <EditPointer
                 setEditMode={setAnnotationEditMode}
@@ -105,6 +108,7 @@ export function AnnotationDrawer({
                 isDrawing={isDrawing}
                 cx={editPoints[2]}
                 cy={editPoints[3]}
+                cursorStatus={cursorStatus}
               />
             </>
           )}

--- a/libs/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.types.ts
+++ b/libs/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.types.ts
@@ -1,7 +1,8 @@
-import { EditMode, CircleMeasurement } from '../../types'
+import type { EditMode, CircleMeasurement, CursorStatus } from '../../types'
 
 export interface CircleDrawerProps {
   isSelectedMode: boolean
   measurement: CircleMeasurement
   setMeasurementEditMode: (targetPoint: EditMode) => void
+  cursorStatus: CursorStatus
 }

--- a/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
@@ -17,7 +17,7 @@ export function CircleDrawer({
   const handleMoveOnMouseDown = () => setMeasurementEditMode('move')
   const handleTextMoveOnMouseDown = () => setMeasurementEditMode('textMove')
 
-  const cursorClassName = cursorStatus ?? 'pointer'
+  const cursorClassName = cursorStatus === null ? 'pointer' : ''
 
   return (
     <>

--- a/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/CircleDrawer/index.tsx
@@ -2,12 +2,14 @@ import React, { ReactElement } from 'react'
 import useCircleMeasurement from '../../hooks/useCircleMeasurement'
 
 import { svgWrapperStyle, textStyle } from '../Viewer.styles'
+
 import type { CircleDrawerProps } from './CircleDrawer.types'
 
 export function CircleDrawer({
   isSelectedMode,
   measurement,
   setMeasurementEditMode,
+  cursorStatus,
 }: CircleDrawerProps): ReactElement | null {
   const { centerPointOnCanvas, formattedValue, ref, drawingRadius, textBoxPoint, connectingLine, visibility } =
     useCircleMeasurement(measurement)
@@ -15,31 +17,36 @@ export function CircleDrawer({
   const handleMoveOnMouseDown = () => setMeasurementEditMode('move')
   const handleTextMoveOnMouseDown = () => setMeasurementEditMode('textMove')
 
+  const cursorClassName = cursorStatus ?? 'pointer'
+
   return (
     <>
       <circle
+        className={`measurement-circle ${cursorClassName}`}
         style={svgWrapperStyle.outline}
         cx={centerPointOnCanvas[0]}
         cy={centerPointOnCanvas[1]}
         r={drawingRadius}
       />
       <circle
+        className={`measurement-circle ${cursorClassName}`}
         style={svgWrapperStyle[isSelectedMode ? 'select' : 'default']}
         cx={centerPointOnCanvas[0]}
         cy={centerPointOnCanvas[1]}
         r={drawingRadius}
       />
       <circle
+        className={`measurement-circle ${cursorClassName}`}
         onMouseDown={handleMoveOnMouseDown}
         style={{ ...svgWrapperStyle.extendsArea, cursor: isSelectedMode ? 'grab' : 'pointer' }}
         cx={centerPointOnCanvas[0]}
         cy={centerPointOnCanvas[1]}
         r={drawingRadius}
-        className="measurement-circle pointer drag"
       />
       <polyline style={{ ...svgWrapperStyle.dashLine, visibility }} points={connectingLine} />
       <text
         ref={ref}
+        className={`measurement-circle label ${cursorClassName}`}
         onMouseDown={handleTextMoveOnMouseDown}
         style={{
           ...textStyle[isSelectedMode ? 'select' : 'default'],
@@ -47,7 +54,6 @@ export function CircleDrawer({
         }}
         x={textBoxPoint[0]}
         y={textBoxPoint[1]}
-        className="measurement-circle label pointer"
       >
         {formattedValue}
       </text>

--- a/libs/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
@@ -23,16 +23,18 @@ export function MeasurementDrawer({
 }: MeasurementDrawerProps): JSX.Element | null {
   const svgRef = useRef<SVGSVGElement>(null)
 
-  const { editPoints, measurement, currentEditMode, setMeasurementEditMode } = useMeasurementPointsHandler({
-    mode,
-    isEditing,
-    measurements,
-    svgElement: svgRef,
-    selectedMeasurement,
-    onSelectMeasurement,
-    hoveredMeasurement,
-    addMeasurement: onAdd,
-  })
+  const { editPoints, measurement, currentEditMode, setMeasurementEditMode, cursorStatus } =
+    useMeasurementPointsHandler({
+      mode,
+      isEditing,
+      measurements,
+      svgElement: svgRef,
+      selectedMeasurement,
+      onSelectMeasurement,
+      hoveredMeasurement,
+      addMeasurement: onAdd,
+    })
+
   const isSelectedMeasurement = isEditing && selectedMeasurement != null
   const isDrawing = !selectedMeasurement
 
@@ -45,6 +47,7 @@ export function MeasurementDrawer({
           isSelectedMode={isSelectedMeasurement}
           measurement={measurement}
           setMeasurementEditMode={setMeasurementEditMode}
+          cursorStatus={cursorStatus}
         />
       )}
       {measurement.type === 'circle' && (
@@ -52,6 +55,7 @@ export function MeasurementDrawer({
           isSelectedMode={isSelectedMeasurement}
           measurement={measurement}
           setMeasurementEditMode={setMeasurementEditMode}
+          cursorStatus={cursorStatus}
         />
       )}
       {editPoints && (
@@ -64,6 +68,7 @@ export function MeasurementDrawer({
             isDrawing={isDrawing}
             cx={editPoints[0]}
             cy={editPoints[1]}
+            cursorStatus={cursorStatus}
           />
           <EditPointer
             setEditMode={setMeasurementEditMode}
@@ -73,6 +78,7 @@ export function MeasurementDrawer({
             isDrawing={isDrawing}
             cx={editPoints[2]}
             cy={editPoints[3]}
+            cursorStatus={cursorStatus}
           />
         </>
       )}

--- a/libs/insight-viewer/src/Viewer/PolylineDrawer/PolylineDrawer.types.ts
+++ b/libs/insight-viewer/src/Viewer/PolylineDrawer/PolylineDrawer.types.ts
@@ -1,4 +1,11 @@
-import { LineHeadMode, EditMode, PolygonAnnotation, FreeLineAnnotation, LineAnnotation } from '../../types'
+import type {
+  LineHeadMode,
+  EditMode,
+  PolygonAnnotation,
+  FreeLineAnnotation,
+  LineAnnotation,
+  CursorStatus,
+} from '../../types'
 
 export interface PolylineDrawerProps {
   annotation: PolygonAnnotation | FreeLineAnnotation | LineAnnotation
@@ -8,4 +15,5 @@ export interface PolylineDrawerProps {
   selectedAnnotationLabel: string | number | null
   setAnnotationEditMode: (mode: EditMode) => void
   isPolygonSelected: boolean
+  cursorStatus: CursorStatus
 }

--- a/libs/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
@@ -19,8 +19,9 @@ export function PolylineDrawer({
   isSelectedMode,
   selectedAnnotationLabel,
   showAnnotationLabel,
-  isPolygonSelected: polygonSelected,
+  isPolygonSelected,
   setAnnotationEditMode,
+  cursorStatus,
 }: PolylineDrawerProps): ReactElement {
   const { pixelToCanvas } = useOverlayContext()
 
@@ -48,8 +49,7 @@ export function PolylineDrawer({
   }
 
   const labelPosition = selectedAnnotationLabel ? polylabel([points.map(pixelToCanvas)]) : null
-  const isPolygonSelected = Boolean(polygonSelected)
-  const isDrawing = isPolygonSelected ? undefined : 'isDrawing'
+  const cursorClassName = cursorStatus ?? 'pointer'
 
   return (
     <g data-cy-annotation onMouseDown={() => setAnnotationEditMode('move')}>
@@ -59,11 +59,13 @@ export function PolylineDrawer({
           {lineHead === 'arrow' && (
             <>
               <PolylineElement
+                className={`annotation-polyline ${cursorClassName} `}
                 isPolygon={isPolygonSelected}
                 style={svgWrapperStyle.outline}
                 points={getArrowPoints()}
               />
               <PolylineElement
+                className={`annotation-polyline ${cursorClassName}`}
                 isPolygon={isPolygonSelected}
                 style={svgWrapperStyle[isSelectedMode ? 'select' : 'default']}
                 points={getArrowPoints()}
@@ -71,18 +73,22 @@ export function PolylineDrawer({
             </>
           )}
           <PolylineElement
+            className={`annotation-polyline ${cursorClassName}`}
             isPolygon={isPolygonSelected}
-            className={`annotation-polyline pointer ${isDrawing}`}
             style={svgWrapperStyle[isSelectedMode ? 'select' : 'default']}
             points={polylinePoints}
           />
-          <PolylineElement isPolygon={isPolygonSelected} style={svgWrapperStyle.extendsArea} points={polylinePoints} />
-          className={`annotation-polyline pointer ${isDrawing}`}
+          <PolylineElement
+            className={`annotation-polyline ${cursorClassName}`}
+            isPolygon={isPolygonSelected}
+            style={svgWrapperStyle.extendsArea}
+            points={polylinePoints}
+          />
         </>
       )}
       {showAnnotationLabel && selectedAnnotationLabel && labelPosition && (
         <text
-          className={`annotation-polyline label pointer ${isDrawing}`}
+          className={`annotation-polyline label ${cursorClassName}`}
           style={{ ...textStyle.default }}
           x={labelPosition[0]}
           y={labelPosition[1]}

--- a/libs/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
@@ -49,7 +49,7 @@ export function PolylineDrawer({
   }
 
   const labelPosition = selectedAnnotationLabel ? polylabel([points.map(pixelToCanvas)]) : null
-  const cursorClassName = cursorStatus ?? 'pointer'
+  const cursorClassName = cursorStatus === null ? 'pointer' : ''
 
   return (
     <g data-cy-annotation onMouseDown={() => setAnnotationEditMode('move')}>

--- a/libs/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.types.ts
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/RulerDrawer.types.ts
@@ -1,7 +1,8 @@
-import { EditMode, RulerMeasurement } from '../../types'
+import type { CursorStatus, EditMode, RulerMeasurement } from '../../types'
 
 export interface RulerDrawerProps {
   isSelectedMode: boolean
   measurement: RulerMeasurement
   setMeasurementEditMode: (targetPoint: EditMode) => void
+  cursorStatus: CursorStatus
 }

--- a/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
@@ -15,7 +15,7 @@ export function RulerDrawer({
   const handleMoveOnMouseDown = () => setMeasurementEditMode('move')
   const handleTextMoveOnMouseDown = () => setMeasurementEditMode('textMove')
 
-  const cursorClassName = cursorStatus ?? 'pointer'
+  const cursorClassName = cursorStatus === null ? 'pointer' : ''
 
   return (
     <>

--- a/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/RulerDrawer/index.tsx
@@ -8,44 +8,45 @@ export function RulerDrawer({
   measurement,
   isSelectedMode,
   setMeasurementEditMode,
+  cursorStatus,
 }: RulerDrawerProps): ReactElement | null {
   const { rulerLine, ref, connectingLine, formattedValue, textBoxPoint, visibility } = useRulerMeasurement(measurement)
 
   const handleMoveOnMouseDown = () => setMeasurementEditMode('move')
   const handleTextMoveOnMouseDown = () => setMeasurementEditMode('textMove')
 
+  const cursorClassName = cursorStatus ?? 'pointer'
+
   return (
     <>
-      <polyline style={svgWrapperStyle.outline} points={rulerLine} />
-      <polyline data-cy-move style={svgWrapperStyle[isSelectedMode ? 'select' : 'default']} points={rulerLine} />
       <polyline
-        className="measurement-ruler pointer"
+        className={`measurement-ruler ${cursorClassName}`}
         onMouseDown={handleMoveOnMouseDown}
         style={svgWrapperStyle.outline}
         points={rulerLine}
       />
       <polyline
         data-cy-move
-        className="measurement-ruler pointer"
+        className={`measurement-ruler ${cursorClassName}`}
         onMouseDown={handleMoveOnMouseDown}
         style={{ ...svgWrapperStyle[isSelectedMode ? 'selectedExtendsArea' : 'extendsArea'] }}
         points={rulerLine}
       />
       <polyline
         data-cy-move
-        className="measurement-ruler pointer"
+        className={`measurement-ruler ${cursorClassName}`}
         style={svgWrapperStyle[isSelectedMode ? 'select' : 'default']}
         points={rulerLine}
       />
       <polyline
-        className="measurement-ruler pointer"
+        className={`measurement-ruler ${cursorClassName}`}
         style={{ ...svgWrapperStyle.dashLine, visibility }}
         points={connectingLine}
       />
 
       <text
         ref={ref}
-        className="measurement-ruler label pointer grab"
+        className={`measurement-ruler label ${cursorClassName}`}
         onMouseDown={handleTextMoveOnMouseDown}
         style={{ ...textStyle[isSelectedMode ? 'select' : 'default'], visibility }}
         x={textBoxPoint[0]}

--- a/libs/insight-viewer/src/Viewer/TextDrawer/TextDrawer.types.ts
+++ b/libs/insight-viewer/src/Viewer/TextDrawer/TextDrawer.types.ts
@@ -1,7 +1,8 @@
-import { EditMode, TextAnnotation } from '../../types'
+import type { CursorStatus, EditMode, TextAnnotation } from '../../types'
 
 export interface TextDrawerProps {
   annotation: TextAnnotation
   isSelectedMode: boolean
+  cursorStatus: CursorStatus
   setAnnotationEditMode: (mode: EditMode) => void
 }

--- a/libs/insight-viewer/src/Viewer/TextDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/TextDrawer/index.tsx
@@ -23,7 +23,7 @@ export function TextDrawer({
   }
   const dimensions = [end[0] - start[0], end[1] - start[1]]
 
-  const cursorClassName = cursorStatus ?? 'pointer'
+  const cursorClassName = cursorStatus === null ? 'pointer' : ''
 
   return (
     <>

--- a/libs/insight-viewer/src/Viewer/TextDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/TextDrawer/index.tsx
@@ -7,7 +7,11 @@ import { TEXT_PADDING } from '../../const'
 import type { TextDrawerProps } from './TextDrawer.types'
 export { Typing as TypingDrawer } from './Typing'
 
-export function TextDrawer({ annotation, setAnnotationEditMode }: TextDrawerProps): React.ReactElement | null {
+export function TextDrawer({
+  annotation,
+  setAnnotationEditMode,
+  cursorStatus,
+}: TextDrawerProps): React.ReactElement | null {
   const { pixelToCanvas } = useOverlayContext()
 
   const { points, label } = annotation
@@ -19,11 +23,13 @@ export function TextDrawer({ annotation, setAnnotationEditMode }: TextDrawerProp
   }
   const dimensions = [end[0] - start[0], end[1] - start[1]]
 
+  const cursorClassName = cursorStatus ?? 'pointer'
+
   return (
     <>
       {label && (
         <text
-          className="annotation-text label grab"
+          className={`annotation-text label ${cursorClassName}`}
           style={{
             ...textStyle.select,
             textAnchor: 'start',
@@ -44,7 +50,7 @@ export function TextDrawer({ annotation, setAnnotationEditMode }: TextDrawerProp
         </text>
       )}
       <rect
-        className="annotation-text box grab"
+        className={`annotation-text box ${cursorClassName}`}
         style={svgBoxStyle.select}
         x={start[0]}
         y={start[1]}

--- a/libs/insight-viewer/src/Viewer/TextViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/TextViewer/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 
-import { TextViewerProps } from './TextViewer.types'
 import { textStyle, svgBoxStyle, TEXT_SIZE, LINE_HEIGHT } from '../Viewer.styles'
 import { useOverlayContext } from '../../contexts'
 import { TEXT_PADDING } from '../../const'
+
+import type { TextViewerProps } from './TextViewer.types'
 
 export function TextViewer({ annotation, hoveredAnnotation }: TextViewerProps): React.ReactElement {
   const { pixelToCanvas } = useOverlayContext()
@@ -26,7 +27,7 @@ export function TextViewer({ annotation, hoveredAnnotation }: TextViewerProps): 
       >
         {annotation.label.split('\n').map((line, index) => (
           <tspan
-            className="annotation-text label"
+            className="annotation-text label pointer"
             x={start[0] + TEXT_PADDING}
             y={start[1] + index * TEXT_SIZE * LINE_HEIGHT + TEXT_PADDING}
             key={index}

--- a/libs/insight-viewer/src/Viewer/Viewer.styles.ts
+++ b/libs/insight-viewer/src/Viewer/Viewer.styles.ts
@@ -59,19 +59,16 @@ export const svgWrapperStyle: ViewerStyle = {
     strokeWidth: DEFAULT_WIDTH,
     stroke: DEFAULT_COLOR,
     fill: 'transparent',
-    cursor: 'pointer',
   },
   outline: {
     fill: 'transparent',
     strokeWidth: OUTLINE_WIDTH,
     stroke: OUTLINE_COLOR,
-    cursor: 'pointer',
   },
   hoveredOutline: {
     fill: 'transparent',
     strokeWidth: OUTLINE_WIDTH,
     stroke: HOVERED_OUTLINE_COLOR,
-    cursor: 'pointer',
   },
   dashLine: {
     strokeWidth: DASH_LINE_WIDTH,
@@ -83,19 +80,16 @@ export const svgWrapperStyle: ViewerStyle = {
     fill: 'transparent',
     strokeWidth: EXTENDED_AREA_WIDTH,
     stroke: 'transparent',
-    cursor: 'pointer',
   },
   selectedExtendsArea: {
     fill: 'transparent',
     strokeWidth: EXTENDED_AREA_WIDTH,
     stroke: 'transparent',
-    cursor: 'grab',
   },
   select: {
     stroke: SELECTED_COLOR,
     strokeWidth: DEFAULT_WIDTH,
     fill: 'transparent',
-    cursor: 'grab',
   },
 }
 
@@ -103,19 +97,16 @@ export const svgBoxStyle: ViewerStyle = {
   default: {
     fill: 'transparent',
     stroke: 'transparent',
-    cursor: 'pointer',
   },
   hover: {
     fill: 'transparent',
     stroke: HOVERED_TEXT_BOX_COLOR,
     strokeWidth: TEXT_BOX_WIDTH,
-    cursor: 'pointer',
   },
   select: {
     fill: 'transparent',
     stroke: HOVERED_TEXT_BOX_COLOR,
     strokeWidth: TEXT_BOX_WIDTH,
-    cursor: 'grab',
   },
 }
 
@@ -124,41 +115,34 @@ export const editPointerStyle: ViewerStyle = {
     strokeWidth: EDIT_DEFAULT_WIDTH,
     stroke: DEFAULT_COLOR,
     fill: DEFAULT_COLOR,
-    cursor: 'move',
   },
   highlight: {
     strokeWidth: EDIT_DEFAULT_WIDTH,
     stroke: EDIT_POINTER_HIGHLIGHT_COLOR,
     fill: EDIT_POINTER_HIGHLIGHT_COLOR,
-    cursor: 'move',
   },
   select: {
     strokeWidth: EDIT_DEFAULT_WIDTH,
     stroke: EDIT_POINTER_SELECTED_COLOR,
     fill: EDIT_POINTER_SELECTED_COLOR,
-    cursor: 'move',
   },
   outline: {
     strokeWidth: EDIT_OUTLINE_WIDTH,
     stroke: OUTLINE_COLOR,
-    fill: 'transparent',
   },
   selectedOutline: {
     strokeWidth: EDIT_SELECTED_OUTLINE_WIDTH,
     stroke: DEFAULT_COLOR,
-    fill: 'transparent',
   },
   hover: {
     strokeWidth: EDIT_DEFAULT_WIDTH,
     stroke: EDIT_POINTER_SELECTED_COLOR,
     fill: EDIT_POINTER_SELECTED_COLOR,
-    cursor: 'move',
   },
   extendsArea: {
     fill: 'transparent',
     strokeWidth: EXTENDED_AREA_WIDTH,
     stroke: 'transparent',
-    cursor: 'move',
   },
 }
 
@@ -174,7 +158,6 @@ export const textStyle: ViewerStyle = {
     lineHeight: LINE_HEIGHT,
     fontWeight: FONT_WIDTH,
     textAnchor: 'middle',
-    cursor: 'pointer',
   },
   hover: {
     fill: '#FFFFFF',
@@ -187,7 +170,6 @@ export const textStyle: ViewerStyle = {
     lineHeight: LINE_HEIGHT,
     fontWeight: FONT_WIDTH,
     textAnchor: 'middle',
-    cursor: 'pointer',
   },
   select: {
     fill: '#00FFF0',
@@ -200,6 +182,5 @@ export const textStyle: ViewerStyle = {
     lineHeight: LINE_HEIGHT,
     fontWeight: FONT_WIDTH,
     textAnchor: 'middle',
-    cursor: 'grab',
   },
 }

--- a/libs/insight-viewer/src/components/EditPointer/index.tsx
+++ b/libs/insight-viewer/src/components/EditPointer/index.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react'
-import { EditMode } from '../../types'
 import { EDIT_CIRCLE_RADIUS } from '../../const'
 import { editPointerStyle } from '../../Viewer/Viewer.styles'
+import type { CursorStatus, EditMode } from '../../types'
 
 interface EditPointerProps {
   cx: number
   cy: number
   editMode: EditMode
+  cursorStatus: CursorStatus
   isSelectedMode?: boolean
   isHighlightMode?: boolean
   isDrawing?: boolean
@@ -22,15 +23,17 @@ export function EditPointer({
   isHighlightMode,
   setEditMode,
   isDrawing,
+  cursorStatus,
 }: EditPointerProps): JSX.Element {
   const handleOnMouseDown = () => setEditMode(editMode)
 
-  const pointerType = isDrawing ? `drawing-pointer` : `editing-pointer`
+  const cursorClassName = cursorStatus ?? `editable`
 
   return (
     <>
       <circle
         onMouseDown={handleOnMouseDown}
+        className={`editing-pointer ${cursorClassName}`}
         cx={cx}
         cy={cy}
         r={EDIT_CIRCLE_RADIUS}
@@ -38,13 +41,14 @@ export function EditPointer({
       />
       <circle
         onMouseDown={handleOnMouseDown}
+        className={`editing-pointer ${cursorClassName}`}
         cx={cx}
         cy={cy}
         r={EDIT_CIRCLE_RADIUS}
         style={editPointerStyle[isSelectedMode ? 'select' : isHighlightMode ? 'highlight' : 'default']}
       />
       <circle
-        className={`${pointerType} move`}
+        className={`editing-pointer ${cursorClassName}`}
         onMouseDown={handleOnMouseDown}
         cx={cx}
         cy={cy}

--- a/libs/insight-viewer/src/components/EditPointer/index.tsx
+++ b/libs/insight-viewer/src/components/EditPointer/index.tsx
@@ -27,7 +27,7 @@ export function EditPointer({
 }: EditPointerProps): JSX.Element {
   const handleOnMouseDown = () => setEditMode(editMode)
 
-  const cursorClassName = cursorStatus ?? `editable`
+  const cursorClassName = cursorStatus === null ? 'editable' : ''
 
   return (
     <>

--- a/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
@@ -1,15 +1,18 @@
+import { getCursorStatus } from './../../utils/common/getCursorStatus'
 import { useState, useEffect } from 'react'
 
-import { UseAnnotationPointsHandlerParams, UseAnnotationPointsHandlerReturnType } from './types'
-import { Point, EditMode, Annotation } from '../../types'
 import { useOverlayContext } from '../../contexts'
 import { getAnnotationPoints } from '../../utils/common/getAnnotationPoints'
 import { getDrawingAnnotation } from '../../utils/common/getDrawingAnnotation'
 import { getInitialAnnotation } from '../../utils/common/getInitialAnnotation'
 import { getEditPointPosition, EditPoints } from '../../utils/common/getEditPointPosition'
 import { getExistingAnnotationPoints } from '../../utils/common/getExistingAnnotationPoints'
+import { setClassName } from '../../utils/common/setClassName'
 
 import useDrawingHandler from '../useDrawingHandler'
+
+import type { UseAnnotationPointsHandlerParams, UseAnnotationPointsHandlerReturnType } from './types'
+import type { Point, EditMode, Annotation } from '../../types'
 
 export default function useAnnotationPointsHandler({
   mode,
@@ -27,7 +30,17 @@ export default function useAnnotationPointsHandler({
   const [editTargetPoints, setEditTargetPoints] = useState<EditPoints | null>(null)
   const [annotation, setAnnotation] = useState<Annotation | null>(null)
 
-  const { image, pixelToCanvas } = useOverlayContext()
+  const { image, pixelToCanvas, enabledElement } = useOverlayContext()
+
+  const cursorStatus = getCursorStatus({
+    drawing: annotation,
+    selectedDrawing: selectedAnnotation,
+    editTargetPoints,
+    editMode,
+    editStartPoint,
+  })
+
+  setClassName(enabledElement, cursorStatus)
 
   useEffect(() => {
     if (!isEditing || selectedAnnotation == null) return
@@ -128,5 +141,5 @@ export default function useAnnotationPointsHandler({
     hoveredDrawing: hoveredAnnotation,
   })
 
-  return { annotation, editPoints: editTargetPoints, currentEditMode: editMode, setAnnotationEditMode }
+  return { annotation, editPoints: editTargetPoints, currentEditMode: editMode, setAnnotationEditMode, cursorStatus }
 }

--- a/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/types.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/types.ts
@@ -1,5 +1,5 @@
-import { AnnotationMode, Annotation, LineHeadMode, EditMode } from '../../types'
-import { EditPoints } from '../../utils/common/getEditPointPosition'
+import type { AnnotationMode, Annotation, LineHeadMode, EditMode, CursorStatus } from '../../types'
+import type { EditPoints } from '../../utils/common/getEditPointPosition'
 
 export interface UseAnnotationPointsHandlerParams {
   isEditing: boolean
@@ -17,5 +17,6 @@ export interface UseAnnotationPointsHandlerReturnType {
   annotation: Annotation | null
   editPoints: EditPoints | null
   currentEditMode: EditMode | null
+  cursorStatus: CursorStatus
   setAnnotationEditMode: (targetPoint: EditMode) => void
 }

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react'
-
 import { useOverlayContext } from '../../contexts'
 
 import { getMeasurement } from '../../utils/common/getMeasurement'
@@ -8,6 +7,8 @@ import { getTextPosition } from '../../utils/common/getTextPosition'
 import { getMeasurementPoints } from '../../utils/common/getMeasurementPoints'
 import { getEditPointPosition, EditPoints } from '../../utils/common/getEditPointPosition'
 import { getExistingMeasurementPoints } from '../../utils/common/getExistingMeasurementPoints'
+import { getCursorStatus } from '../../utils/common/getCursorStatus'
+import { setClassName } from '../../utils/common/setClassName'
 
 import useDrawingHandler from '../useDrawingHandler'
 
@@ -20,9 +21,9 @@ export default function useMeasurementPointsHandler({
   svgElement,
   measurements,
   selectedMeasurement,
+  hoveredMeasurement,
   addMeasurement,
   onSelectMeasurement,
-  hoveredMeasurement,
 }: UseMeasurementPointsHandlerParams): UseMeasurementPointsHandlerReturnType {
   const [editMode, setEditMode] = useState<EditMode | null>(null)
   const [editStartPoint, setEditStartPoint] = useState<Point | null>(null)
@@ -30,7 +31,17 @@ export default function useMeasurementPointsHandler({
   const [mouseDownPoint, setMouseDownPoint] = useState<Point | null>(null)
   const [measurement, setMeasurement] = useState<Measurement | null>(null)
 
-  const { image, pixelToCanvas } = useOverlayContext()
+  const { image, pixelToCanvas, enabledElement } = useOverlayContext()
+
+  const cursorStatus = getCursorStatus({
+    drawing: measurement,
+    selectedDrawing: selectedMeasurement,
+    editTargetPoints,
+    editMode,
+    editStartPoint,
+  })
+
+  setClassName(enabledElement, cursorStatus)
 
   useEffect(() => {
     if (!isEditing || selectedMeasurement == null) return
@@ -117,12 +128,13 @@ export default function useMeasurementPointsHandler({
     setEditStartPoint(null)
     setEditTargetPoints(null)
     onSelectMeasurement(null)
+    setMouseDownPoint(null)
   }
 
   const addDrewMeasurement = () => {
     const isEditingMode = editMode && selectedMeasurement
     if (!measurement || isEditingMode) return
-    addMeasurement(measurement)
+    if (addMeasurement) addMeasurement(measurement)
   }
 
   const setMeasurementEditMode = (targetPoint: EditMode) => {
@@ -146,5 +158,6 @@ export default function useMeasurementPointsHandler({
     currentEditMode: editMode,
     editPoints: editTargetPoints,
     setMeasurementEditMode,
+    cursorStatus,
   }
 }

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/types.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/types.ts
@@ -1,16 +1,15 @@
-import { RefObject } from 'react'
-
-import { EditPoints } from '../../utils/common/getEditPointPosition'
-import { MeasurementMode, Measurement, EditMode } from '../../types'
+import type { RefObject } from 'react'
+import type { EditPoints } from '../../utils/common/getEditPointPosition'
+import type { MeasurementMode, Measurement, EditMode, CursorStatus } from '../../types'
 
 export interface UseMeasurementPointsHandlerParams {
   isEditing: boolean
   mode: MeasurementMode
   measurements: Measurement[]
   selectedMeasurement: Measurement | null
-  svgElement: RefObject<SVGSVGElement> | null
   hoveredMeasurement: Measurement | null
-  addMeasurement: (measurement: Measurement) => void
+  svgElement: RefObject<SVGSVGElement> | null
+  addMeasurement?: (measurement: Measurement) => void
   onSelectMeasurement: (measurement: Measurement | null) => void
 }
 
@@ -18,5 +17,6 @@ export interface UseMeasurementPointsHandlerReturnType {
   editPoints: EditPoints | null
   currentEditMode: EditMode | null
   measurement: Measurement | null
+  cursorStatus: CursorStatus
   setMeasurementEditMode: (targetPoint: EditMode) => void
 }

--- a/libs/insight-viewer/src/types/index.ts
+++ b/libs/insight-viewer/src/types/index.ts
@@ -168,3 +168,5 @@ export interface MeasurementViewerProps<T extends MeasurementBase> {
   measurement: T
   hoveredMeasurement: Measurement | null
 }
+
+export type CursorStatus = 'drawing' | 'editing' | 'moving' | null

--- a/libs/insight-viewer/src/utils/common/getCursorStatus.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getCursorStatus.spec.ts
@@ -1,0 +1,81 @@
+import { getCursorStatus } from './getCursorStatus'
+
+import type { Annotation, Measurement, Point } from './../../types'
+import type { EditPoints } from './getEditPointPosition'
+
+describe('getCursorStatus :', () => {
+  it('should return null when drawing is null and selectedDrawing is null', () => {
+    expect(
+      getCursorStatus({
+        drawing: null,
+        selectedDrawing: null,
+        editMode: null,
+        editStartPoint: null,
+        editTargetPoints: null,
+      })
+    ).toBeNull()
+  })
+
+  it('should return "drawing" when drawing is not null and selectedDrawing is null', () => {
+    expect(
+      getCursorStatus({
+        drawing: {} as Measurement,
+        selectedDrawing: null,
+        editMode: null,
+        editStartPoint: null,
+        editTargetPoints: null,
+      })
+    ).toBe('drawing')
+    expect(
+      getCursorStatus({
+        drawing: {} as Annotation,
+        selectedDrawing: null,
+        editMode: null,
+        editStartPoint: null,
+        editTargetPoints: null,
+      })
+    ).toBe('drawing')
+  })
+
+  it('should return "editing" when editMode is not null and editStartPoint or editTargetPoints is not null', () => {
+    expect(
+      getCursorStatus({
+        drawing: null,
+        selectedDrawing: null,
+        editMode: 'startPoint',
+        editStartPoint: [] as unknown as Point,
+        editTargetPoints: null,
+      })
+    ).toBe('editing')
+    expect(
+      getCursorStatus({
+        drawing: null,
+        selectedDrawing: null,
+        editMode: 'endPoint',
+        editStartPoint: null,
+        editTargetPoints: [] as unknown as EditPoints,
+      })
+    ).toBe('editing')
+  })
+
+  it('should return "moving" when editMode is not null and editStartPoint or editTargetPoints is not null', () => {
+    expect(
+      getCursorStatus({
+        drawing: null,
+        selectedDrawing: null,
+        editMode: 'move',
+        editStartPoint: null,
+        editTargetPoints: [] as unknown as EditPoints,
+      })
+    ).toBe('moving')
+    expect(
+      getCursorStatus({
+        drawing: null,
+        selectedDrawing: null,
+        editMode: 'textMove',
+        editStartPoint: null,
+        editTargetPoints: [] as unknown as EditPoints,
+      })
+    ).toBe('moving')
+  })
+})

--- a/libs/insight-viewer/src/utils/common/getCursorStatus.ts
+++ b/libs/insight-viewer/src/utils/common/getCursorStatus.ts
@@ -1,0 +1,30 @@
+import type { Annotation } from './../../types'
+import type { EditMode, Measurement, Point } from '../../types'
+import type { EditPoints } from '../../utils/common/getEditPointPosition'
+
+export const getCursorStatus = <T extends Measurement | Annotation>({
+  drawing,
+  selectedDrawing,
+  editMode,
+  editStartPoint,
+  editTargetPoints,
+}: {
+  drawing: T | null
+  selectedDrawing: T | null
+  editMode: EditMode | null
+  editStartPoint: Point | null
+  editTargetPoints: EditPoints | null
+}) => {
+  console.log('getCursorStatus', drawing, selectedDrawing, editMode, editStartPoint, editTargetPoints)
+  if (editMode !== null && (editStartPoint !== null || editTargetPoints !== null)) {
+    if (editMode === 'startPoint' || editMode === 'endPoint') {
+      return 'editing'
+    } else {
+      return 'moving'
+    }
+  }
+  if (drawing !== null && selectedDrawing === null) {
+    return 'drawing'
+  }
+  return null
+}

--- a/libs/insight-viewer/src/utils/common/getCursorStatus.ts
+++ b/libs/insight-viewer/src/utils/common/getCursorStatus.ts
@@ -15,7 +15,6 @@ export const getCursorStatus = <T extends Measurement | Annotation>({
   editStartPoint: Point | null
   editTargetPoints: EditPoints | null
 }) => {
-  console.log('getCursorStatus', drawing, selectedDrawing, editMode, editStartPoint, editTargetPoints)
   if (editMode !== null && (editStartPoint !== null || editTargetPoints !== null)) {
     if (editMode === 'startPoint' || editMode === 'endPoint') {
       return 'editing'

--- a/libs/insight-viewer/src/utils/common/setClassName.spec.ts
+++ b/libs/insight-viewer/src/utils/common/setClassName.spec.ts
@@ -1,0 +1,56 @@
+import { setClassName } from './setClassName'
+import type { EnabledElement } from 'cornerstone-core'
+
+describe('setClassName :', () => {
+  it('should do nothing when enabledElement is null', () => {
+    const enabledElement = null
+    const cursorStatus = 'drawing'
+
+    setClassName(enabledElement, cursorStatus)
+
+    expect(enabledElement).toBeNull()
+  })
+
+  it('should remove all classes when cursorStatus is null', () => {
+    const enabledElement = {
+      element: {
+        classList: {
+          add: jest.fn(),
+          remove: jest.fn(),
+        },
+      },
+    } as unknown as EnabledElement
+
+    setClassName(enabledElement, null)
+
+    expect(enabledElement.element.classList.add).toHaveBeenCalledTimes(0)
+    expect(enabledElement.element.classList.remove).toHaveBeenCalledTimes(3)
+  })
+
+  it('should remove drawing, moving, editing className', () => {
+    const element = document.createElement('div')
+    element.classList.add('MOCK_CLASS_NAME')
+
+    const enabledElement = {
+      element,
+    } as unknown as EnabledElement
+
+    setClassName(enabledElement, 'drawing')
+
+    expect(enabledElement.element.classList.contains('drawing')).toBeTruthy()
+    expect(enabledElement.element.classList.contains('moving')).toBeFalsy()
+    expect(enabledElement.element.classList.contains('editing')).toBeFalsy()
+
+    setClassName(enabledElement, 'moving')
+
+    expect(enabledElement.element.classList.contains('drawing')).toBeFalsy()
+    expect(enabledElement.element.classList.contains('moving')).toBeTruthy()
+    expect(enabledElement.element.classList.contains('editing')).toBeFalsy()
+
+    setClassName(enabledElement, 'editing')
+
+    expect(enabledElement.element.classList.contains('drawing')).toBeFalsy()
+    expect(enabledElement.element.classList.contains('moving')).toBeFalsy()
+    expect(enabledElement.element.classList.contains('editing')).toBeTruthy()
+  })
+})

--- a/libs/insight-viewer/src/utils/common/setClassName.ts
+++ b/libs/insight-viewer/src/utils/common/setClassName.ts
@@ -1,0 +1,14 @@
+import type { CursorStatus } from '../../types'
+import type { EnabledElement } from '../cornerstoneHelper/types'
+
+export const setClassName = (enabledElement: EnabledElement | null, cursorStatus: CursorStatus) => {
+  if (!(enabledElement && enabledElement.element)) return
+
+  enabledElement.element.classList.remove('drawing')
+  enabledElement.element.classList.remove('moving')
+  enabledElement.element.classList.remove('editing')
+
+  if (cursorStatus === null) return
+
+  enabledElement.element.classList.add(cursorStatus)
+}


### PR DESCRIPTION
## 📝 Description

https://lunit.atlassian.net/browse/IIV-194 를 해결하기 위한 작업입니다.

1. 동적인 클래스 네임을 통한 커서 스타일링 수단 추가
2. 기존에 문제가 되었던 기본 커서 스타일 제거
3. 기존에 추가되어 있던 상태용 클래스네임은 제거하였지만, 식별용 클래스네임은 유지

기존의 클래스 네임 방식은 객체에 스타일 입혀 그 객체에 스타일로 지정되어있는 커서를 보여주고 있었습니다.
하지만 이 방식은 객체가 동적인 요소인 경우, 마우스 커서를 따라다니면서 싱크가 일치해야 정상적으로 동작합니다.
하지만 가끔 마우스 커서가 빨리 움직이거나, 동적 요소의 크기가 작은 이유로 동적 요소 위를 벗어나게 되면 커서 스타일이 비활성되는 문제가 있었습니다. 그래서 현재 커서 스타일을 확인하고 캔버스 전체에 커서 스타일을 동적으로 주는 방식으로 변경하였습니다.

그리고 기존에 객체에 호버 상태를 동적으로 판별하는 데에는 내부 로직에 한계가 있고, 만약 변경하게 되더라도 성능적인 문제가 발생할 수 밖에 없는 구조였기 때문에 정적인 객체들에 스타일은 동적인 상태의 클래스가 들어 오지 않을 때 기본 값으로 주도록 변경 하였습니다.

![image](https://user-images.githubusercontent.com/97934818/197962674-a6f1d960-87b0-4162-867f-607dc6112c48.png)

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: https://lunit.atlassian.net/browse/IIV-194

## 🚀 New behavior

> Please describe the behavior or changes this PR adds.

## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
