### PR TITLE
VIEWER-80 / fix text annotation

### DIFF
--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
@@ -49,7 +49,9 @@ export function AnnotationDrawer({
             if (a.label) {
               onAdd(a)
             } else {
-              setTempAnnotation(a as TextAnnotation)
+              if (!tempAnnotation) {
+                setTempAnnotation(a as TextAnnotation)
+              }
             }
           }
         : onAdd,

--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
@@ -49,8 +49,18 @@ export function AnnotationDrawer({
             if (a.label) {
               onAdd(a)
             } else {
+              // TODO: 추후 TextAnnotation 재설계 후 아래 주석과 코드 정리할 것.
+              // a 의 좌표가 유효하지 않을경우 setTempAnnotation 이 아예 실행되지 않도록 로직 추가
+              // Typing.tsx 에도 비슷한 코드가 존재하나 혹시 모를 사이드 이펙트를 고려하여 남겨둠
+              const textAnnotation = a as TextAnnotation
+              const [start, end] = textAnnotation.points
+
+              if (typeof end === 'undefined' || end[0] < start[0] || end[1] < start[1]) {
+                return
+              }
+
               if (!tempAnnotation) {
-                setTempAnnotation(a as TextAnnotation)
+                setTempAnnotation(textAnnotation)
               }
             }
           }


### PR DESCRIPTION
## 📝 Description

Text Annotation 추가할 때 생기는 다음의 버그를 수정했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

- Text Annotation 추가 시
  - Annotation box 안쪽을 클릭하면 작성중인 box 가 사라짐
  - 다시 클릭하면 박스 안쪽 클릭했던 위치에 Text Annotation 이 다시 나타남

- 해당 이슈가 발생하는 이유
  - Drawer 에서 마우스 클릭을 하면 tempAnnotation 에 클릭한 위치와 텍스트값을 임시로 저장하여 텍스트 입력을 받음
  - Text box 바깥을 클릭하면 현재까지 작성중인 text annotation 입력을 끝내고 tempAnnotation 정보를 지우도록 구현되어 있음 
  - Text box 안쪽을 클릭하면 작성중인 text annotation 이 끝나지 않은 채 새로 클릭한 위치의 annotation 정보로 업데이트 -> 이 부분이 문제

Issue Number: https://lunit.atlassian.net/browse/VIEWER-80

## 🚀 New behavior

Drawer 에서 text box 안쪽을 클릭했을 때 작성중인 text annotation 정보가 존재하면 새로운 annotation 정보로 업데이트 되지 않도록 수정

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No


