### PR TITLE
VIEWER-55 / apply changed circle editting  

### DIFF
--- a/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
@@ -15,19 +15,6 @@ describe('getEditPointPosition: ', () => {
     expect(getEditPointPosition(MOCK_POINT_1, null)).toEqual([0, 0, 10, 10])
     expect(getEditPointPosition(MOCK_POINT_2, null)).toEqual([30, 30, 50, 50])
   })
-  it('should return null when editTarget is null but drawingMode is circle ', () => {
-    const MOCK_POINT_1: Point[] = [
-      [0, 0],
-      [10, 10],
-    ]
-    const MOCK_POINT_2: Point[] = [
-      [30, 30],
-      [50, 50],
-    ]
-
-    expect(getEditPointPosition(MOCK_POINT_1, null, 'circle')).toEqual(null)
-    expect(getEditPointPosition(MOCK_POINT_2, null, 'circle')).toEqual(null)
-  })
 
   it('should return the points with line type editTarget', () => {
     const MOCK_POINT_1: Point[] = [

--- a/libs/insight-viewer/src/utils/common/getEditPointPosition.ts
+++ b/libs/insight-viewer/src/utils/common/getEditPointPosition.ts
@@ -1,34 +1,44 @@
 import { getCircleEditPoints } from './getCircleEditPoints'
 import { getCircleRadiusByCenter } from '../../utils/common/getCircleRadius'
 
-import type { Point, Annotation, Measurement } from '../../types'
+import type { Point, Annotation, Measurement, EditMode } from '../../types'
 
 export type EditPoints = [startX: number, startY: number, endX: number, endY: number]
 
 export function getEditPointPosition(
   points: Point[],
   editTarget: Measurement | Annotation | null,
-  drawingMode?: 'circle' | 'ruler'
+  drawingMode?: 'circle' | 'ruler',
+  editingMode?: EditMode | null,
+  fixedPoints?: [Point, Point]
 ): EditPoints | null {
   // if there's more than 2 points, it cannot edit(can just move)
   if (points.length !== 2) return null
 
-  /**
-   * TODO
-   * drawingMode prop and below code should be deleted if the circle's edit method is changed
-   * when drawing but isn't editing: editTarget === null && drawingMode === 'circle'
-   */
-  if (editTarget === null && drawingMode === 'circle') {
-    return null
-  }
-
-  if (editTarget && editTarget.type === 'circle') {
+  if (
+    editTarget &&
+    editTarget.type === 'circle' &&
+    (!editingMode || editingMode === 'move' || editingMode === 'textMove')
+  ) {
     const [centerPoint, endPoint] = points
     const radius = getCircleRadiusByCenter(centerPoint, endPoint)
     const editPoints = getCircleEditPoints(centerPoint, radius)
     return editPoints
   }
 
+  if (fixedPoints && editTarget?.type === 'circle' && (editingMode === 'startPoint' || editingMode === 'endPoint')) {
+    const [start, end] = fixedPoints
+    const currentEditingPoints: [number, number, number, number] =
+      editingMode === 'startPoint' ? [start[0], start[1], end[0], end[1]] : [end[0], end[1], start[0], start[1]]
+
+    return currentEditingPoints
+  }
+
+  if (drawingMode === 'circle' && fixedPoints) {
+    const [start, end] = fixedPoints
+
+    return [start[0], start[1], end[0], end[1]]
+  }
   // line annotation or ruler measurement
   const [startPoint, endPoint] = points
 

--- a/libs/insight-viewer/src/utils/common/getMeasurementEditingPoints.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurementEditingPoints.spec.ts
@@ -2,7 +2,7 @@ import { Point } from '../../types'
 import { getMeasurementEditingPoints } from './getMeasurementEditingPoints'
 
 describe('getMeasurementEditingPoints: ', () => {
-  it('should return correct points when edit mode is startPoint and measurement mode is ruler', () => {
+  it('should return correct points when edit mode is startPoint and measurement mode is ruler or circle', () => {
     const MOCK_PREV_POINT_1: [Point, Point] = [
       [0, 0],
       [10, 10],
@@ -31,19 +31,19 @@ describe('getMeasurementEditingPoints: ', () => {
       [10, 10],
     ])
     expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'startPoint', 'ruler')
+      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'startPoint', 'circle')
     ).toEqual([
       [15, 15],
       [30, 40],
     ])
     expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, MOCK_EDIT_POINT_3, 'startPoint', 'ruler')
+      getMeasurementEditingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, MOCK_EDIT_POINT_3, 'startPoint', 'circle')
     ).toEqual([
       [25, 25],
       [80, 100],
     ])
   })
-  it('should return correct points when edit mode is endPoint and measurement mode is ruler', () => {
+  it('should return correct points when edit mode is endPoint and measurement mode is ruler or circle', () => {
     const MOCK_PREV_POINT_1: [Point, Point] = [
       [0, 0],
       [10, 10],
@@ -72,7 +72,7 @@ describe('getMeasurementEditingPoints: ', () => {
       [5, 5],
     ])
     expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'endPoint', 'ruler')
+      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'endPoint', 'circle')
     ).toEqual([
       [10, 20],
       [15, 15],
@@ -82,88 +82,6 @@ describe('getMeasurementEditingPoints: ', () => {
     ).toEqual([
       [40, 60],
       [25, 25],
-    ])
-  })
-  it('should return centerPoint when editMode is startPoint and measurement is circle', () => {
-    const MOCK_PREV_POINT_1: [Point, Point] = [
-      [0, 0],
-      [10, 10],
-    ]
-    const MOCK_PREV_POINT_2: [Point, Point] = [
-      [10, 20],
-      [30, 40],
-    ]
-    const MOCK_PREV_POINT_3: [Point, Point] = [
-      [40, 60],
-      [80, 100],
-    ]
-
-    const MOCK_CURRENT_POINT_1: Point = [5, 5]
-    const MOCK_CURRENT_POINT_2: Point = [15, 15]
-    const MOCK_CURRENT_POINT_3: Point = [25, 25]
-
-    const MOCK_EDIT_POINT_1: Point = [30, 30]
-    const MOCK_EDIT_POINT_2: Point = [50, 60]
-    const MOCK_EDIT_POINT_3: Point = [70, 90]
-
-    expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_1, MOCK_CURRENT_POINT_1, MOCK_EDIT_POINT_1, 'startPoint', 'circle')
-    ).toEqual([
-      [0, 0],
-      [7.0710678118654755, 0],
-    ])
-    expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'startPoint', 'circle')
-    ).toEqual([
-      [10, 20],
-      [17.071067811865476, 20],
-    ])
-    expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, MOCK_EDIT_POINT_3, 'startPoint', 'circle')
-    ).toEqual([
-      [40, 60],
-      [78.07886552931954, 60],
-    ])
-  })
-  it('should return centerPoint when editMode is endPoint and measurement is circle', () => {
-    const MOCK_PREV_POINT_1: [Point, Point] = [
-      [0, 0],
-      [10, 10],
-    ]
-    const MOCK_PREV_POINT_2: [Point, Point] = [
-      [10, 20],
-      [30, 40],
-    ]
-    const MOCK_PREV_POINT_3: [Point, Point] = [
-      [40, 60],
-      [80, 100],
-    ]
-
-    const MOCK_CURRENT_POINT_1: Point = [5, 5]
-    const MOCK_CURRENT_POINT_2: Point = [15, 15]
-    const MOCK_CURRENT_POINT_3: Point = [25, 25]
-
-    const MOCK_EDIT_POINT_1: Point = [30, 30]
-    const MOCK_EDIT_POINT_2: Point = [50, 60]
-    const MOCK_EDIT_POINT_3: Point = [70, 90]
-
-    expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_1, MOCK_CURRENT_POINT_1, MOCK_EDIT_POINT_1, 'endPoint', 'circle')
-    ).toEqual([
-      [0, 0],
-      [7.0710678118654755, 0],
-    ])
-    expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'endPoint', 'circle')
-    ).toEqual([
-      [10, 20],
-      [17.071067811865476, 20],
-    ])
-    expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, MOCK_EDIT_POINT_3, 'endPoint', 'circle')
-    ).toEqual([
-      [40, 60],
-      [78.07886552931954, 60],
     ])
   })
 

--- a/libs/insight-viewer/src/utils/common/getMeasurementEditingPoints.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurementEditingPoints.ts
@@ -1,6 +1,4 @@
 import { getMovedPoints } from './getMovedPoints'
-import { getCircleRadiusByCenter } from './getCircleRadius'
-import { getCircleEndPoint } from './getCircleEndPoint'
 
 import type { Point, EditMode, MeasurementMode } from '../../types'
 
@@ -11,21 +9,12 @@ export function getMeasurementEditingPoints(
   editMode: EditMode,
   mode: MeasurementMode
 ): [Point, Point] {
-  if (mode === 'ruler' && editMode === 'startPoint') {
+  if ((mode === 'ruler' || mode === 'circle') && editMode === 'startPoint') {
     return [currentPoint, prevPoints[1]]
   }
 
-  if (mode === 'ruler' && editMode === 'endPoint') {
+  if ((mode === 'ruler' || mode === 'circle') && editMode === 'endPoint') {
     return [prevPoints[0], currentPoint]
-  }
-
-  if (mode === 'circle' && (editMode === 'startPoint' || editMode === 'endPoint')) {
-    const prevCenter = prevPoints[0]
-
-    const currentRadius = getCircleRadiusByCenter(prevCenter, currentPoint)
-    const movedEndPoint = getCircleEndPoint(prevCenter, currentRadius)
-
-    return [prevCenter, movedEndPoint]
   }
 
   if ((mode === 'circle' || mode === 'ruler') && editMode === 'move') {

--- a/libs/insight-viewer/src/utils/common/getMeasurementPointsByMode.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurementPointsByMode.spec.ts
@@ -53,7 +53,7 @@ describe('getMeasurementPointsByMode: ', () => {
     ).toStrictEqual(MOCK_EXPECT_RESULT_2)
   })
 
-  it('should return the current start and end points when when isEditing is true and editMode is not null of circle', () => {
+  it('should return the current start and end points when when isEditing is true and editMode is textMove or move of circle', () => {
     const MOCK_MOUSE_DOWN_POINT_1: Point = [0, 0]
     const MOCK_MOUSE_DOWN_POINT_2 = null
 
@@ -80,7 +80,7 @@ describe('getMeasurementPointsByMode: ', () => {
     expect(
       getMeasurementPointsByMode(
         true,
-        'startPoint',
+        'textMove',
         DRAWING_MODE_CIRCLE,
         MOCK_MOUSE_DOWN_POINT_2,
         MOCK_MOUSE_MOVE_POINT_2,

--- a/libs/insight-viewer/src/utils/common/getMeasurementPointsByMode.ts
+++ b/libs/insight-viewer/src/utils/common/getMeasurementPointsByMode.ts
@@ -13,11 +13,15 @@ export function getMeasurementPointsByMode(
 ): [Point, Point] {
   let currentPoints = prevPoints
 
+  /**
+   * Except for editing move is move or text move,
+   * edit works the same as drawing.
+   */
   if (drawingMode === 'circle' && mouseDownPoint !== null) {
     currentPoints = [mouseDownPoint, mouseMovePoint]
   }
 
-  if (drawingMode === 'circle' && isEditing && editMode) {
+  if (drawingMode === 'circle' && isEditing && (editMode === 'move' || editMode === 'textMove')) {
     const [currentCenterPoint, currentEndPoint] = prevPoints
     const radius = getCircleRadiusByCenter(currentCenterPoint, currentEndPoint)
     const currentStartPoint = getCircleStartPoint(currentCenterPoint, radius)


### PR DESCRIPTION
## 📝 Description

Circle Measurement Edit 기능 시 동작 방식을 Drawing 때와 동일하게 동작하도록 수정했습니다.
이와 더불어 Editing Pointer 도 마우스 포인터를 따라가는 방향으로 개선했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Edit 기능이 Drawing 방식과 다릅니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-55

## 🚀 New behavior

Edit 기능과 Drawing 방식이 동일합니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [ ] No

Circle Measurement 의 Editing 동작 방식 및 Editing Pointer 위치 기능이 변경되었으니 참고 부탁드립니다.
