### PR TITLE
Fix/initial annotation

### DIFF
--- a/libs/insight-viewer/src/hooks/useAnnotation/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotation/index.ts
@@ -46,8 +46,8 @@ export function useAnnotation({ nextId, initialAnnotation }: UseAnnotationParams
 
             return {
               ...addedAnnotation,
-              id: nextId ?? i,
-              labelPosition: polylabel([annotationLabelPoints], 1),
+              id: addedAnnotation.id ?? nextId ?? i,
+              labelPosition: addedAnnotation.labelPosition ?? polylabel([annotationLabelPoints], 1),
             } as Annotation
           })
         : []

--- a/libs/insight-viewer/src/hooks/useAnnotation/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotation/index.ts
@@ -32,7 +32,7 @@ interface AnnotationDrawingState {
   removeAllAnnotation: () => void
 }
 
-export function useAnnotation({ nextId, initialAnnotation }: UseAnnotationParams = {}): AnnotationDrawingState {
+export function useAnnotation({ nextId = 1, initialAnnotation }: UseAnnotationParams = {}): AnnotationDrawingState {
   const [annotations, setAnnotations] = useState<Annotation[]>([])
   const [hoveredAnnotation, setHoveredAnnotation] = useState<Annotation | null>(null)
   const [selectedAnnotation, setSelectedAnnotation] = useState<Annotation | null>(null)
@@ -46,7 +46,7 @@ export function useAnnotation({ nextId, initialAnnotation }: UseAnnotationParams
 
             return {
               ...addedAnnotation,
-              id: addedAnnotation.id ?? nextId ?? i,
+              id: addedAnnotation.id ?? nextId + i,
               labelPosition: addedAnnotation.labelPosition ?? polylabel([annotationLabelPoints], 1),
             } as Annotation
           })

--- a/libs/insight-viewer/src/hooks/useMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurement/index.ts
@@ -14,7 +14,7 @@ function validateDataAttrs(dataAttrs?: { [attr: string]: string }) {
   })
 }
 
-export function useMeasurement({ nextId, initialMeasurement }: UseMeasurementParams): MeasurementDrawingState {
+export function useMeasurement({ nextId = 1, initialMeasurement }: UseMeasurementParams): MeasurementDrawingState {
   const [measurements, setMeasurements] = useState<Measurement[]>([])
   const [hoveredMeasurement, setHoveredMeasurement] = useState<Measurement | null>(null)
   const [selectedMeasurement, setSelectedMeasurement] = useState<Measurement | null>(null)
@@ -26,7 +26,7 @@ export function useMeasurement({ nextId, initialMeasurement }: UseMeasurementPar
             (addedMeasurement, i) =>
               ({
                 ...addedMeasurement,
-                id: addedMeasurement.id ?? nextId ?? i,
+                id: addedMeasurement.id ?? nextId + i,
               } as Measurement)
           )
         : []

--- a/libs/insight-viewer/src/hooks/useMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurement/index.ts
@@ -26,7 +26,7 @@ export function useMeasurement({ nextId, initialMeasurement }: UseMeasurementPar
             (addedMeasurement, i) =>
               ({
                 ...addedMeasurement,
-                id: nextId ?? i,
+                id: addedMeasurement.id ?? nextId ?? i,
               } as Measurement)
           )
         : []


### PR DESCRIPTION
## 📝 Description

`useAnnotation/useMeasurement`의 `initialAnnotation`은 받은 annotation들의 id를 0부터 초기화합니다. 이 동작은 다음과 같은 문제가 있습니다.
- 유저 입력으로 직접 annotation을 추가할 경우 id는 1부터 시작합니다. 이 차이때문에 예상치 못한 버그가 발생합니다.
- 유저 입력으로 추가한 annotation들을 서버 등에 저장했다가 다시 initialAnnotation으로 불러올 경우 id가 보존되지 않아 혼란을 줄 수 있습니다.
- 또한 기존의 `nextId`가 모든 annotation에 같은 값으로 부여되는 것은 네이밍이나 실용성 등을 고려했을 때 단순 버그로 판단됩니다.

id가 이미 존재한다면 그대로 사용하고, 아니라면 nextId부터 시작하도록 새로 부여하는 방향이 합리적으로 보입니다.


## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

> Please describe the current behavior that you are modifying, or link to a relevant issue.

`initialAnnotation`의 id를 0부터 순차적으로 증가하도록 초기화합니다.

Issue Number: N/A

## 🚀 New behavior

> Please describe the behavior or changes this PR adds.

`initialAnnotation`의 id가 이미 있다면 그대로 사용합니다. 없다면 nextId부터 순차적으로 증가하도록 초기화합니다. nextId의 기본값은 1입니다.

## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
