### PR TITLE
reset states of useAnnotationPointsHandler hook (measurement)

### DIFF
--- a/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
@@ -43,7 +43,14 @@ export default function useAnnotationPointsHandler({
   setClassName(enabledElement, cursorStatus)
 
   useEffect(() => {
-    if (!isEditing || selectedAnnotation == null) return
+    if (!isEditing || selectedAnnotation == null) {
+      setEditMode(null)
+      setAnnotation(null)
+      setEditStartPoint(null)
+      onSelectAnnotation(null)
+      setEditTargetPoints(null)
+      return
+    }
 
     const selectedAnnotationPoints = getExistingAnnotationPoints(selectedAnnotation, image)
     const currentPoints = selectedAnnotationPoints.map(pixelToCanvas)
@@ -51,7 +58,7 @@ export default function useAnnotationPointsHandler({
 
     setAnnotation(selectedAnnotation)
     setEditTargetPoints(currentEditPoint)
-  }, [image, isEditing, selectedAnnotation, pixelToCanvas])
+  }, [image, isEditing, selectedAnnotation, onSelectAnnotation, pixelToCanvas])
 
   const setInitialAnnotation = (point: Point) => {
     if (isEditing && selectedAnnotation) {

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -60,13 +60,22 @@ export default function useMeasurementPointsHandler({
   setClassName(enabledElement, cursorStatus)
 
   useEffect(() => {
-    if (!isEditing || selectedMeasurement == null) return
+    if (!isEditing || selectedMeasurement == null) {
+      setEditMode(null)
+      setMeasurement(null)
+      setEditStartPoint(null)
+      setEditTargetPoints(null)
+      onSelectMeasurement(null)
+      setMouseDownPoint(null)
+      setSelectedMeasurementEditingFixedPoint(null)
+      return
+    }
 
     const currentEditPoint = getMeasurementEditingPoints({ measurement: selectedMeasurement, pixelToCanvas })
 
     setMeasurement(selectedMeasurement)
     setEditTargetPoints(currentEditPoint)
-  }, [isEditing, selectedMeasurement, pixelToCanvas])
+  }, [isEditing, selectedMeasurement, pixelToCanvas, onSelectMeasurement])
 
   const setInitialMeasurement = (point: [mouseDownX: number, mouseDownY: number]) => {
     if (isEditing && selectedMeasurement != null) {


### PR DESCRIPTION
## 📝 Description

useAnnotationPointsHandler (measurement) handler useEffect 내
isEditing 이 false 이고 selecedAnnotation(measurement) 가 null 일때
모든 states 를 초기화합니다.

이를 통해 외부에서 edit 기능 중 selectedMeasurement 를 초기화 했을 때
내부 상태값 그대로 유지되어 drawing 상태가 유지되는 버그를 해결하고자 합니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

외부에서 `selectAnnotation(null)` 을 하더라도 editing 상태에서 drawing 상태로 변경될 뿐
selectedAnnotation 이 사라지지 않습니다.
(정확히는 selectedAnnotation 의해 생긴 useAnnotationPoinsHandler 내 annotation 이 사라지지 않음)

Issue Number: N/A

## 🚀 New behavior

외부에서 `selectAnnotation(null)` 을 하면 selectedAnnotation 이 사라지고, 내부 annotation 도 삭제됩니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
