### PR TITLE
VIEWER-84 / add tests of circle edit points

### DIFF
--- a/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
@@ -41,7 +41,41 @@ describe('getEditPointPosition: ', () => {
     expect(getEditPointPosition(MOCK_POINT_2, MOCK_EDIT_TARGET)).toEqual([30, 30, 50, 50])
   })
 
-  it('should return the points with circle type editTarget', () => {
+  it('should return the points with fixedPoints when drawing mode is circle', () => {
+    const MOCK_POINT_1: Point[] = [
+      [0, 0],
+      [10, 10],
+    ]
+    const MOCK_POINT_2: Point[] = [
+      [30, 30],
+      [50, 50],
+    ]
+
+    const MOCK_FIXED_POINTS: [Point, Point] = [
+      [10, 10],
+      [30, 50],
+    ]
+
+    const MOCK_EDIT_TARGET: Measurement = {
+      centerPoint: [0, 0],
+      id: 1,
+      lineWidth: 1.5,
+      measuredValue: 14.142135623730951,
+      radius: 14.142135623730951,
+      textPoint: null,
+      type: 'circle',
+      unit: 'px',
+    }
+
+    expect(getEditPointPosition(MOCK_POINT_1, MOCK_EDIT_TARGET, 'circle', undefined, MOCK_FIXED_POINTS)).toEqual([
+      -10, -10.000000000000002, 10.000000000000002, 10,
+    ])
+    expect(getEditPointPosition(MOCK_POINT_2, MOCK_EDIT_TARGET, 'circle', undefined, MOCK_FIXED_POINTS)).toEqual([
+      10, 9.999999999999996, 50, 50,
+    ])
+  })
+
+  it('should return the points with circle type editTarget and editingMode is move, textMove, or null', () => {
     const MOCK_POINT_1: Point[] = [
       [0, 0],
       [10, 10],
@@ -62,9 +96,44 @@ describe('getEditPointPosition: ', () => {
       unit: 'px',
     }
 
-    expect(getEditPointPosition(MOCK_POINT_1, MOCK_EDIT_TARGET)).toEqual([
+    expect(getEditPointPosition(MOCK_POINT_1, MOCK_EDIT_TARGET, undefined, 'move')).toEqual([
       -10, -10.000000000000002, 10.000000000000002, 10,
     ])
-    expect(getEditPointPosition(MOCK_POINT_2, MOCK_EDIT_TARGET)).toEqual([10, 9.999999999999996, 50, 50])
+    expect(getEditPointPosition(MOCK_POINT_2, MOCK_EDIT_TARGET, undefined, 'textMove')).toEqual([
+      10, 9.999999999999996, 50, 50,
+    ])
+  })
+
+  it('should return the points with circle type editTarget and editingMode is startPoint or endPoint', () => {
+    const MOCK_POINT_1: Point[] = [
+      [0, 0],
+      [10, 10],
+    ]
+    const MOCK_POINT_2: Point[] = [
+      [30, 30],
+      [50, 50],
+    ]
+    const MOCK_FIXED_POINTS: [Point, Point] = [
+      [10, 10],
+      [30, 50],
+    ]
+
+    const MOCK_EDIT_TARGET: Measurement = {
+      centerPoint: [0, 0],
+      id: 1,
+      lineWidth: 1.5,
+      measuredValue: 14.142135623730951,
+      radius: 14.142135623730951,
+      textPoint: null,
+      type: 'circle',
+      unit: 'px',
+    }
+
+    expect(getEditPointPosition(MOCK_POINT_1, MOCK_EDIT_TARGET, undefined, 'startPoint', MOCK_FIXED_POINTS)).toEqual([
+      10, 10, 30, 50,
+    ])
+    expect(getEditPointPosition(MOCK_POINT_2, MOCK_EDIT_TARGET, undefined, 'endPoint', MOCK_FIXED_POINTS)).toEqual([
+      30, 50, 10, 10,
+    ])
   })
 })


### PR DESCRIPTION
## 📝 Description

- [getEditPointPosition의 테스트 추가](https://lunit.atlassian.net/browse/VIEWER-84)
- 이전 [#350](https://github.com/lunit-io/frontend-components/pull/350) 작업에서 누락되었던 circle의 edit points 관련 테스트를 추가합니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [x] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

## 🚀 New behavior

> Please describe the behavior or changes this PR adds.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
