### PR TITLE
chore(docs): add metadata to set cache header

### DIFF
--- a/.github/workflows/insight-viewer-production.yml
+++ b/.github/workflows/insight-viewer-production.yml
@@ -41,3 +41,12 @@ jobs:
             ./dist/apps/insight-viewer-docs/exported \
             s3://lunit-cdn-for-production-virginia/${HOST} \
             --delete
+          aws s3 cp \
+            s3://lunit-cdn-for-production-virginia/${HOST} \
+            s3://lunit-cdn-for-production-virginia/${HOST} \
+            --recursive \
+            --exclude "*" \
+            --include "index.html" \
+            --metadata-directive REPLACE \
+            --cache-control no-store, no-cache, must-revalidate \
+            --content-type "text/html; charset=utf-8"


### PR DESCRIPTION
## 📝 Description

현재 프로덕션 배포인 `insight-viewer.lunit.io`에 새 사이트를 배포할 경우 Cloudfront에서 캐시한 index.html 파일을 전달하여 새 사이트를 조회할 수 없는 문제가 있습니다. `Cache-control: no-store, no-cache, must-revalidate` 헤더를 추가하여 CDN과 브라우저에서 index.html을 캐시하는 것을 방지합니다.
참고: https://developer.mozilla.org/ko/docs/Web/HTTP/Headers/Cache-Control

프로덕션 배포를 수정해야 하므로 master로 머지하겠습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [x] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Cloudfront 캐시가 index.html에 적용되어 새 배포시에도 이전 사이트가 조회됨

Issue Number: N/A

## 🚀 New behavior

index.html은 캐시 설정에서 제외되어 요청마다 최신 사이트가 조회됨

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
