### PR TITLE
VIEWER-69 / add reset annotation

### DIFF
--- a/apps/insight-viewer-docs-e2e/src/e2e/annotation.drawer.cy.ts
+++ b/apps/insight-viewer-docs-e2e/src/e2e/annotation.drawer.cy.ts
@@ -130,5 +130,41 @@ describe(
         cy.get('[data-cy-id]').should('have.length', mockFreelineAnnotationLength - 1)
       })
     })
+
+    describe('Reset Annotation', () => {
+      beforeEach(() => {
+        cy.visit('/annotation')
+
+        cy.get($LOADED).should('be.exist')
+        cy.get('[data-cy-tab="drawer"]').click()
+      })
+
+      it('should display only the initial annotation when there is an initial annotation', () => {
+        // given
+        cy.get('[data-cy-id]').should('have.length', INITIAL_POLYGON_ANNOTATIONS.length)
+
+        // when
+        drawAnnotations(POLYGON_ANNOTATIONS)
+        cy.get('[data-cy-id]').should('have.length', INITIAL_POLYGON_ANNOTATIONS.length + POLYGON_ANNOTATIONS.length)
+        cy.get('[data-cy-name="reset-button"]').click()
+
+        // then
+        cy.get('[data-cy-id]').should('have.length', INITIAL_POLYGON_ANNOTATIONS.length)
+      })
+
+      it('should display no annotation when there is no initial annotation', () => {
+        // given
+        cy.get('[value="line"]').click({ force: true })
+        cy.get('[data-cy-id]').should('have.length', 0)
+
+        // when
+        drawAnnotations(LINE_ANNOTATIONS)
+        cy.get('[data-cy-id]').should('have.length', LINE_ANNOTATIONS.length)
+        cy.get('[data-cy-name="reset-button"]').click()
+
+        // then
+        cy.get('[data-cy-id]').should('have.length', 0)
+      })
+    })
   }
 )

--- a/apps/insight-viewer-docs-e2e/src/e2e/annotation.drawer.cy.ts
+++ b/apps/insight-viewer-docs-e2e/src/e2e/annotation.drawer.cy.ts
@@ -1,6 +1,7 @@
 import { setup, drawAnnotation, drawAnnotations, deleteAndCheckAnnotationOrMeasurement } from '../support/utils'
 import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, $LOADED } from '../support/const'
 import {
+  INITIAL_POLYGON_ANNOTATIONS,
   POLYGON_ANNOTATIONS,
   SHORTER_THAN_MINIMUM_LENGTH_POLYGON_ANNOTATION,
   LINE_ANNOTATIONS,
@@ -28,9 +29,10 @@ describe(
 
     describe('Polygon Annotation', () => {
       const mockPolygonAnnotationLength = POLYGON_ANNOTATIONS.length
+      const initialPolygonAnnotationLength = INITIAL_POLYGON_ANNOTATIONS.length
 
       it('count polygon annotation before drawing', () => {
-        cy.get('[data-cy-id]').should('have.length', 0)
+        cy.get('[data-cy-id]').should('have.length', initialPolygonAnnotationLength)
       })
 
       /**
@@ -45,20 +47,23 @@ describe(
       it('cancel drawing if shorter than the minimum length', () => {
         drawAnnotation(SHORTER_THAN_MINIMUM_LENGTH_POLYGON_ANNOTATION)
 
-        cy.get('[data-cy-id]').should('have.length', 0)
+        cy.get('[data-cy-id]').should('have.length', initialPolygonAnnotationLength)
       })
 
       it('Annotation polygon drawing', () => {
         drawAnnotations(POLYGON_ANNOTATIONS)
 
-        cy.get('[data-cy-id]').should('have.length', mockPolygonAnnotationLength)
+        const totalLength = mockPolygonAnnotationLength + initialPolygonAnnotationLength
+        cy.get('[data-cy-id]').should('have.length', totalLength)
       })
 
       it('delete polygon annotation and count annotation', () => {
         const targetAnnotation = POLYGON_ANNOTATIONS[1]
 
         deleteAndCheckAnnotationOrMeasurement(targetAnnotation, 'not.exist')
-        cy.get('[data-cy-id]').should('have.length', mockPolygonAnnotationLength - 1)
+
+        const totalLength = mockPolygonAnnotationLength + initialPolygonAnnotationLength
+        cy.get('[data-cy-id]').should('have.length', totalLength - 1)
       })
     })
 

--- a/apps/insight-viewer-docs-e2e/src/support/utils.ts
+++ b/apps/insight-viewer-docs-e2e/src/support/utils.ts
@@ -33,7 +33,7 @@ export function deleteAndCheckMultiAnnotationOrMeasurement(
 }
 
 export function drawAnnotation(element: Annotation): void {
-  const canvas = cy.get('.cornerstone-canvas-wrapper')
+  cy.get('.cornerstone-canvas-wrapper').as('canvas')
 
   if (element.type === 'circle') {
     return undefined
@@ -42,14 +42,14 @@ export function drawAnnotation(element: Annotation): void {
   if (element.type === 'freeLine' || element.type === 'polygon') {
     element.points.forEach(([x, y], i) => {
       if (i === 0) {
-        canvas.trigger('mousedown', {
+        cy.get('@canvas').trigger('mousedown', {
           x,
           y,
         })
       } else if (i === element.points.length - 1) {
-        canvas.trigger('mouseup')
+        cy.get('@canvas').trigger('mouseup')
       } else {
-        canvas.trigger('mousemove', {
+        cy.get('@canvas').trigger('mousemove', {
           x,
           y,
         })
@@ -62,7 +62,7 @@ export function drawAnnotation(element: Annotation): void {
 
   const [startPoint, endPoint] = element.points
 
-  canvas
+  cy.get('@canvas')
     .trigger('mousedown', { x: startPoint[0], y: startPoint[1] })
     .trigger('mousemove', { x: endPoint[0], y: endPoint[1] })
     .trigger('mouseup')
@@ -108,24 +108,24 @@ export function moveAnnotation(annotation: Annotation, distance: number): void {
 }
 
 export const editAnnotation = (editTargetPoint: Point, distance: number): void => {
-  const canvas = cy.get('.cornerstone-canvas-wrapper')
+  cy.get('.cornerstone-canvas-wrapper').as('canvas')
   const [x, y] = editTargetPoint
 
-  canvas
+  cy.get('@canvas')
     .trigger('mousedown', { x, y })
     .trigger('mousemove', { x: x + distance, y: y + distance })
     .trigger('mouseup')
 
-  canvas.click()
+  cy.get('@canvas').click()
 }
 
 export const drawMeasurement = (measurement: Measurement): void => {
-  const canvas = cy.get('.cornerstone-canvas-wrapper')
+  cy.get('.cornerstone-canvas-wrapper').as('canvas')
 
   if (measurement.type === 'ruler') {
     const [startPoint, endPoint] = measurement.startAndEndPoint
 
-    canvas
+    cy.get('@canvas')
       .trigger('mousedown', { x: startPoint[0], y: startPoint[1] })
       .trigger('mousemove', { x: endPoint[0], y: endPoint[1] })
       .trigger('mouseup')
@@ -164,13 +164,13 @@ export const moveMeasurement = (measurement: Measurement, distance: number): voi
 }
 
 export const editPoint = (editTargetPoint: Point, distance: number): void => {
-  const canvas = cy.get('.cornerstone-canvas-wrapper')
+  cy.get('.cornerstone-canvas-wrapper').as('canvas')
   const [x, y] = editTargetPoint
 
-  canvas
+  cy.get('@canvas')
     .trigger('mousedown', { x, y })
     .trigger('mousemove', { x: x + distance, y: y + distance })
     .trigger('mouseup')
 
-  canvas.click()
+  cy.get('@canvas').click()
 }

--- a/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
@@ -10,12 +10,7 @@ import InsightViewer, {
   LineHeadMode,
   Annotation,
 } from '@lunit/insight-viewer'
-import {
-  POLYGON_ANNOTATIONS,
-  LINE_ANNOTATIONS,
-  FREELINE_ANNOTATIONS,
-  TEXT_ANNOTATIONS,
-} from '@insight-viewer-library/fixtures'
+import { INITIAL_POLYGON_ANNOTATIONS } from '@insight-viewer-library/fixtures'
 import useImageSelect from '../../../components/ImageSelect/useImageSelect'
 
 export type InitialAnnotations = {
@@ -32,12 +27,11 @@ const style = {
 const DEFAULT_SIZE = { width: 700, height: 700 }
 
 const INITIAL_ANNOTATIONS: InitialAnnotations = {
-  line: LINE_ANNOTATIONS,
-  freeLine: FREELINE_ANNOTATIONS,
-  polygon: POLYGON_ANNOTATIONS,
-  text: TEXT_ANNOTATIONS,
-  // TODO: Changed the mock data when adding Circle mode
-  circle: POLYGON_ANNOTATIONS,
+  line: [],
+  freeLine: [],
+  polygon: INITIAL_POLYGON_ANNOTATIONS,
+  text: [],
+  circle: [],
 }
 
 function AnnotationDrawerContainer(): JSX.Element {
@@ -110,7 +104,7 @@ function AnnotationDrawerContainer(): JSX.Element {
           <Radio value="arrow">Arrow</Radio>
         </Stack>
       </RadioGroup>
-      <Button data-cy-name="remove-button" size="sm" mb={2} mr={3} colorScheme="blue" onClick={resetAnnotation}>
+      <Button data-cy-name="reset-button" size="sm" mb={2} mr={3} colorScheme="blue" onClick={resetAnnotation}>
         reset
       </Button>
       <Button data-cy-name="remove-button" size="sm" mb={2} colorScheme="blue" onClick={removeAllAnnotation}>

--- a/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
@@ -8,8 +8,19 @@ import InsightViewer, {
   AnnotationOverlay,
   AnnotationMode,
   LineHeadMode,
+  Annotation,
 } from '@lunit/insight-viewer'
+import {
+  POLYGON_ANNOTATIONS,
+  LINE_ANNOTATIONS,
+  FREELINE_ANNOTATIONS,
+  TEXT_ANNOTATIONS,
+} from '@insight-viewer-library/fixtures'
 import useImageSelect from '../../../components/ImageSelect/useImageSelect'
+
+export type InitialAnnotations = {
+  [mode in AnnotationMode]: Annotation[]
+}
 
 const style = {
   display: 'flex',
@@ -19,6 +30,15 @@ const style = {
 
 /** Mock svg Size */
 const DEFAULT_SIZE = { width: 700, height: 700 }
+
+const INITIAL_ANNOTATIONS: InitialAnnotations = {
+  line: LINE_ANNOTATIONS,
+  freeLine: FREELINE_ANNOTATIONS,
+  polygon: POLYGON_ANNOTATIONS,
+  text: TEXT_ANNOTATIONS,
+  // TODO: Changed the mock data when adding Circle mode
+  circle: POLYGON_ANNOTATIONS,
+}
 
 function AnnotationDrawerContainer(): JSX.Element {
   const [annotationMode, setAnnotationMode] = useState<AnnotationMode>('polygon')
@@ -40,7 +60,10 @@ function AnnotationDrawerContainer(): JSX.Element {
     hoverAnnotation,
     selectAnnotation,
     removeAllAnnotation,
-  } = useAnnotation()
+    resetAnnotation,
+  } = useAnnotation({
+    initialAnnotation: INITIAL_ANNOTATIONS[annotationMode],
+  })
 
   const handleAnnotationModeClick = (mode: AnnotationMode) => {
     setAnnotationMode(mode)
@@ -74,7 +97,7 @@ function AnnotationDrawerContainer(): JSX.Element {
         <Stack direction="row">
           <p style={{ marginRight: '10px' }}>Select Annotation mode</p>
           <Radio value="polygon">Polygon</Radio>
-          <Radio value="line">line</Radio>
+          <Radio value="line">Line</Radio>
           <Radio value="freeLine">Free Line</Radio>
           <Radio value="text">Text</Radio>
           <Radio value="circle">Circle - Not implemented yet</Radio>
@@ -83,17 +106,14 @@ function AnnotationDrawerContainer(): JSX.Element {
       <RadioGroup onChange={handleLineHeadModeButtonChange} value={lineHeadMode}>
         <Stack direction="row">
           <p style={{ marginRight: '10px' }}>Select Line Head mode</p>
-          <Radio value="normal">normal</Radio>
-          <Radio value="arrow">arrow</Radio>
+          <Radio value="normal">Normal</Radio>
+          <Radio value="arrow">Arrow</Radio>
         </Stack>
       </RadioGroup>
-      <Button
-        data-cy-name="remove-button"
-        size="sm"
-        marginBottom="10px"
-        colorScheme="blue"
-        onClick={removeAllAnnotation}
-      >
+      <Button data-cy-name="remove-button" size="sm" mb={2} mr={3} colorScheme="blue" onClick={resetAnnotation}>
+        reset
+      </Button>
+      <Button data-cy-name="remove-button" size="sm" mb={2} colorScheme="blue" onClick={removeAllAnnotation}>
         remove all
       </Button>
       <Resizable style={style} defaultSize={DEFAULT_SIZE} className={`annotation ${annotationMode}`}>

--- a/libs/fixtures/src/annotation/polygons.ts
+++ b/libs/fixtures/src/annotation/polygons.ts
@@ -1,6 +1,6 @@
 import { PolygonAnnotation } from '@lunit/insight-viewer'
 
-export const POLYGON_ANNOTATIONS: PolygonAnnotation[] = [
+export const INITIAL_POLYGON_ANNOTATIONS: PolygonAnnotation[] = [
   {
     id: 1,
     labelPosition: [184.28571428571422, 153.05142857142857],
@@ -76,6 +76,9 @@ export const POLYGON_ANNOTATIONS: PolygonAnnotation[] = [
       [197.48571428571427, 131.85142857142856],
     ],
   },
+]
+
+export const POLYGON_ANNOTATIONS: PolygonAnnotation[] = [
   {
     id: 2,
     labelPosition: [283.06285714285707, 208.28571428571428],

--- a/libs/insight-viewer/src/hooks/useAnnotation/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotation/index.ts
@@ -30,6 +30,7 @@ interface AnnotationDrawingState {
   updateAnnotation: (annotation: Annotation, patch: Partial<Omit<AnnotationBase, 'id' | 'type'>>) => void
   removeAnnotation: (annotation: Annotation) => void
   removeAllAnnotation: () => void
+  resetAnnotation: () => void
 }
 
 export function useAnnotation({ nextId = 1, initialAnnotation }: UseAnnotationParams = {}): AnnotationDrawingState {
@@ -138,6 +139,12 @@ export function useAnnotation({ nextId = 1, initialAnnotation }: UseAnnotationPa
     setSelectedAnnotation(null)
   }
 
+  const resetAnnotation = () => {
+    setAnnotations(initialAnnotation || [])
+    setHoveredAnnotation(null)
+    setSelectedAnnotation(null)
+  }
+
   return {
     annotations,
     hoveredAnnotation,
@@ -148,5 +155,6 @@ export function useAnnotation({ nextId = 1, initialAnnotation }: UseAnnotationPa
     hoverAnnotation,
     selectAnnotation,
     removeAllAnnotation,
+    resetAnnotation,
   }
 }


### PR DESCRIPTION
## 📝 Description

* useAnnotation에 reset 기능을 추가합니다. c6c66e1c6da58842d0c62f2a93e734f65aba5d9d

* cypress에 lint error가 발생하여 수정하였습니다 [관련문서 link](https://docs.cypress.io/guides/references/best-practices#Assigning-Return-Values) a2137b110981da5413dde9708186c197b9d3ed13
<img width="500" alt="스크린샷 2022-11-02 오후 1 19 07" src="https://user-images.githubusercontent.com/36615680/199480337-cdbfefd8-c28e-4cf4-a1ca-08679cfda2ea.png">

* POLYGON_ANNOTATION mock의 index 0번을 initial polygon annotation mock을 옮겼습니다.
 test나 docs에 initial 값으로 보여집니다. c10c5adcc796882df6cd1a383250e393f5a7a4bc
* 관련 testing 추가 d13213395c635a3a458d6f1d76668b485f2b1745
 

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [x] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

Issue Number: N/A

## 🚀 New behavior

initialAnnotation 값이 있는 상태에서 resetAnnotation을 호출하면 initialAnnotation 만 남습니다. 
initialAnnotation 값이 없는 상태에서 resetAnnotation을 호출하면 annotation data가 []이 됩니다.

Annotation Drawer docs에 reset button이 추가되었습니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
