### PR TITLE
hotfix / apply Cornerstone resize to useImageDisplay

### DIFF
--- a/libs/insight-viewer/src/hooks/useImageDisplay/index.ts
+++ b/libs/insight-viewer/src/hooks/useImageDisplay/index.ts
@@ -2,7 +2,7 @@
  * @fileoverview Display image in a given HTML element and set viewport.
  */
 import { useEffect, useRef } from 'react'
-import { displayImage, getDefaultViewportForImage } from '../../utils/cornerstoneHelper'
+import { resize, displayImage, getDefaultViewportForImage } from '../../utils/cornerstoneHelper'
 import { formatViewerViewport, formatCornerstoneViewport } from '../../utils/common/formatViewport'
 import { BasicViewport } from '../../types'
 import { UseImageDisplay } from './types'
@@ -48,6 +48,8 @@ const useImageDisplay: UseImageDisplay = ({ element, image, viewportRef, onViewp
         ? viewportRef.current._initialViewport // The first render.
         : displayViewport
     )
+
+    resize(element)
 
     // In case of multiframe image, update imageSeriesKey.
     if (image._imageSeriesKey !== undefined && imageSeriesKey !== image._imageSeriesKey) {


### PR DESCRIPTION
## 📝 Description

`useImageDisplay` hook 에서 cornerstone displayImage 로 이미지 디스플레이 직후에
`cornerstone resize` method 를 실행하도록 로직을 추가했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

`cornerstone resize` 는 아래와 같은 시나리오에서만 동작합니다.
1. 제일 처음 viewer 렌더링 시점
2. image wrapper 사이즈 변경

Issue Number: N/A

## 🚀 New behavior

`cornerstone resize` 는 아래와 같은 시나리오에서만 동작합니다.
1. 제일 처음 viewer 렌더링 시점
2. image wrapper 사이즈 변경
3. viewer 에 image 가 display 되는 시점 (추가)

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
