### PR TITLE
chore(docs): fix initialAnnotation on annotation page

### DIFF
--- a/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
@@ -8,14 +8,9 @@ import InsightViewer, {
   AnnotationOverlay,
   AnnotationMode,
   LineHeadMode,
-  Annotation,
 } from '@lunit/insight-viewer'
 import { INITIAL_POLYGON_ANNOTATIONS } from '@insight-viewer-library/fixtures'
 import useImageSelect from '../../../components/ImageSelect/useImageSelect'
-
-export type InitialAnnotations = {
-  [mode in AnnotationMode]: Annotation[]
-}
 
 const style = {
   display: 'flex',
@@ -25,14 +20,6 @@ const style = {
 
 /** Mock svg Size */
 const DEFAULT_SIZE = { width: 700, height: 700 }
-
-const INITIAL_ANNOTATIONS: InitialAnnotations = {
-  line: [],
-  freeLine: [],
-  polygon: INITIAL_POLYGON_ANNOTATIONS,
-  text: [],
-  circle: [],
-}
 
 function AnnotationDrawerContainer(): JSX.Element {
   const [annotationMode, setAnnotationMode] = useState<AnnotationMode>('polygon')
@@ -56,7 +43,7 @@ function AnnotationDrawerContainer(): JSX.Element {
     removeAllAnnotation,
     resetAnnotation,
   } = useAnnotation({
-    initialAnnotation: INITIAL_ANNOTATIONS[annotationMode],
+    initialAnnotation: INITIAL_POLYGON_ANNOTATIONS,
   })
 
   const handleAnnotationModeClick = (mode: AnnotationMode) => {


### PR DESCRIPTION
## 📝 Description

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/36615680/201291611-f75a3139-b50d-48f1-aeef-436dc230a0e9.png">

annotation drawer 페이지에서 
initial annotation 값을 annotation mode에 따라 다르게 설정한 탓에
mode가 바뀔때마다 mode와 관련된 annotation만 보이는 현상이 있었습니다. 
annotation viewer 페이지를 보시면 어떤 현상인지 참고가 되실 것 같습니다.   

이전처럼 모든 mode가 보이도록 수정하였습니다. 

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [x] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

## 🚀 New behavior

> Please describe the behavior or changes this PR adds.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
