### PR TITLE
VIEWER-90 / feat(docs): add shortkeys in drawing page

### DIFF
--- a/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from 'react'
+import { ChangeEvent, useState, useEffect } from 'react'
 import { Box, Switch, Radio, RadioGroup, Stack, Button } from '@chakra-ui/react'
 import { Resizable } from 're-resizable'
 import InsightViewer, {
@@ -23,6 +23,7 @@ const DEFAULT_SIZE = { width: 700, height: 700 }
 function AnnotationDrawerContainer(): JSX.Element {
   const [annotationMode, setAnnotationMode] = useState<AnnotationMode>('polygon')
   const [lineHeadMode, setLineHeadMode] = useState<LineHeadMode>('normal')
+  const [isDrawing, setIsDrawing] = useState(true)
   const [isEditing, setIsEditing] = useState(false)
   const [isShowLabel, setIsShowLabel] = useState(false)
 
@@ -58,16 +59,40 @@ function AnnotationDrawerContainer(): JSX.Element {
     setIsShowLabel(event.target.checked)
   }
 
+  const handleDrawModeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setIsDrawing(event.target.checked)
+  }
+
+  useEffect(() => {
+    function handleKeyDown({ code }: KeyboardEvent) {
+      if (code === 'KeyD') {
+        setIsDrawing((prev) => !prev)
+      }
+      if (code === 'KeyE') {
+        setIsEditing((prev) => !prev)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [setIsDrawing, setIsEditing])
+
   return (
     <Box data-cy-loaded={loadingState}>
       <Box>
         <ImageSelect />
       </Box>
       <Box>
-        edit mode <Switch data-cy-edit={isEditing} onChange={handleEditModeChange} isChecked={isEditing} />
+        Draw enabled (D) <Switch data-cy-edit={isDrawing} onChange={handleDrawModeChange} isChecked={isDrawing} />
       </Box>
       <Box>
-        show label{' '}
+        Edit enabled (E) <Switch data-cy-edit={isEditing} onChange={handleEditModeChange} isChecked={isEditing} />
+      </Box>
+      <Box>
+        Show label{' '}
         <Switch data-cy-show-label={isShowLabel} onChange={handleShowLabelModeChange} isChecked={isShowLabel} />
       </Box>
       <RadioGroup onChange={handleAnnotationModeClick} value={annotationMode}>
@@ -100,7 +125,7 @@ function AnnotationDrawerContainer(): JSX.Element {
         <InsightViewer image={image} viewport={viewport} onViewportChange={setViewport}>
           {loadingState === 'success' && (
             <AnnotationOverlay
-              isDrawing
+              isDrawing={isDrawing}
               isEditing={isEditing}
               width={700}
               height={700}

--- a/apps/insight-viewer-docs/containers/Measurement/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Measurement/Drawer/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-unresolved */
-import React, { useState, ChangeEvent } from 'react'
+import React, { useState, ChangeEvent, useEffect } from 'react'
 import { Box, Switch, Radio, RadioGroup, Stack, Button } from '@chakra-ui/react'
 import { Resizable } from 're-resizable'
 import InsightViewer, {
@@ -23,6 +23,7 @@ const DEFAULT_SIZE = { width: 700, height: 700 }
 function MeasurementDrawerContainer(): JSX.Element {
   const [measurementMode, setMeasurementMode] = useState<MeasurementMode>('ruler')
   const [isEditing, setIsEditing] = useState(false)
+  const [isDrawing, setIsDrawing] = useState(true)
 
   const { ImageSelect, selected } = useImageSelect()
   const { loadingState, image } = useImage({
@@ -48,6 +49,26 @@ function MeasurementDrawerContainer(): JSX.Element {
   const handleEditModeChange = (event: ChangeEvent<HTMLInputElement>) => {
     setIsEditing(event.target.checked)
   }
+  const handleDrawModeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setIsDrawing(event.target.checked)
+  }
+
+  useEffect(() => {
+    function handleKeyDown({ code }: KeyboardEvent) {
+      if (code === 'KeyD') {
+        setIsDrawing((prev) => !prev)
+      }
+      if (code === 'KeyE') {
+        setIsEditing((prev) => !prev)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [setIsDrawing, setIsEditing])
 
   return (
     <>
@@ -55,7 +76,10 @@ function MeasurementDrawerContainer(): JSX.Element {
         <ImageSelect />
       </Box>
       <Box>
-        edit mode <Switch data-cy-edit={isEditing} onChange={handleEditModeChange} isChecked={isEditing} />
+        Draw enabled (D) <Switch data-cy-edit={isDrawing} onChange={handleDrawModeChange} isChecked={isDrawing} />
+      </Box>
+      <Box>
+        Edit enabled (E) <Switch data-cy-edit={isEditing} onChange={handleEditModeChange} isChecked={isEditing} />
       </Box>
       <RadioGroup onChange={handleMeasurementModeClick} value={measurementMode}>
         <Stack direction="row">
@@ -82,7 +106,7 @@ function MeasurementDrawerContainer(): JSX.Element {
                 onSelect={selectMeasurement}
                 onRemove={removeMeasurement}
                 isEditing={isEditing}
-                isDrawing
+                isDrawing={isDrawing}
                 mode={measurementMode}
                 // If no mode is defined, the default value is ruler.
               />


### PR DESCRIPTION
## 📝 Description

Annotation, Measurement Drawing 페이지에 단축키를 추가합니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [x] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

isDrawing, isEditing은 스위치를 마우스로 클릭해서만 변경할 수 있음

Issue Number: VIEWER-90

## 🚀 New behavior

단축키 D, E로 각 Props를 변경 가능

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
