### PR TITLE
VIEWER-91 / Fix/select disappear

### DIFF
--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.types.ts
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.types.ts
@@ -5,6 +5,7 @@ export interface AnnotationDrawerProps extends SVGProps<SVGSVGElement> {
   selectedAnnotation: Annotation | null
   annotations: Annotation[]
 
+  isDrawing?: boolean
   isEditing?: boolean
 
   /**

--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
@@ -68,7 +68,6 @@ export function AnnotationDrawer({
   })
 
   const isSelectedAnnotation = isEditing && selectedAnnotation != null
-  const isDrawing = !selectedAnnotation
 
   return (
     <>
@@ -107,7 +106,6 @@ export function AnnotationDrawer({
                 editMode="startPoint"
                 isSelectedMode={currentEditMode === 'startPoint'}
                 isHighlightMode={isSelectedAnnotation}
-                isDrawing={isDrawing}
                 cx={editPoints[0]}
                 cy={editPoints[1]}
                 cursorStatus={cursorStatus}
@@ -117,7 +115,6 @@ export function AnnotationDrawer({
                 editMode="endPoint"
                 isHighlightMode={isSelectedAnnotation}
                 isSelectedMode={currentEditMode === 'endPoint'}
-                isDrawing={isDrawing}
                 cx={editPoints[2]}
                 cy={editPoints[3]}
                 cursorStatus={cursorStatus}

--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
@@ -14,6 +14,7 @@ export function AnnotationDrawer({
   style,
   width,
   height,
+  isDrawing = true,
   isEditing = false,
   showAnnotationLabel = false,
   annotations,
@@ -35,6 +36,7 @@ export function AnnotationDrawer({
   }
 
   const { annotation, editPoints, currentEditMode, setAnnotationEditMode, cursorStatus } = useAnnotationPointsHandler({
+    isDrawing,
     isEditing,
     mode,
     lineHead,

--- a/libs/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
@@ -41,8 +41,8 @@ export function AnnotationOverlay({
         showOutline={showOutline}
         showAnnotationLabel={showAnnotationLabel}
         annotationAttrs={annotationAttrs}
-        onFocus={onFocus}
-        onClick={isEditing ? onSelect : onRemove}
+        onFocus={isDrawing ? onFocus : undefined}
+        onClick={isDrawing ? (isEditing ? onSelect : onRemove) : undefined}
       />
       {onAdd && (
         <AnnotationDrawer

--- a/libs/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
@@ -44,7 +44,7 @@ export function AnnotationOverlay({
         onFocus={onFocus}
         onClick={isEditing ? onSelect : onRemove}
       />
-      {isDrawing && onAdd && (
+      {onAdd && (
         <AnnotationDrawer
           width={width}
           height={height}
@@ -54,6 +54,7 @@ export function AnnotationOverlay({
           hoveredAnnotation={hoveredAnnotation}
           className={className}
           style={style}
+          isDrawing={isDrawing}
           isEditing={isEditing}
           mode={mode}
           lineHead={lineHead}

--- a/libs/insight-viewer/src/Viewer/MeasurementDrawer/MeasurementDrawer.types.ts
+++ b/libs/insight-viewer/src/Viewer/MeasurementDrawer/MeasurementDrawer.types.ts
@@ -5,6 +5,7 @@ export interface MeasurementDrawerProps extends SVGProps<SVGSVGElement> {
   selectedMeasurement: Measurement | null
   measurements: Measurement[]
 
+  isDrawing?: boolean
   isEditing?: boolean
 
   /** When drawing is complete and a new annotation occurs */

--- a/libs/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
@@ -36,7 +36,6 @@ export function MeasurementDrawer({
     })
 
   const isSelectedMeasurement = isEditing && selectedMeasurement != null
-  const isDrawing = !selectedMeasurement
 
   if (!measurement || (measurement && measurement.measuredValue === 0)) return null
 
@@ -65,7 +64,6 @@ export function MeasurementDrawer({
             editMode="startPoint"
             isSelectedMode={currentEditMode === 'startPoint'}
             isHighlightMode={isSelectedMeasurement}
-            isDrawing={isDrawing}
             cx={editPoints[0]}
             cy={editPoints[1]}
             cursorStatus={cursorStatus}
@@ -75,7 +73,6 @@ export function MeasurementDrawer({
             editMode="endPoint"
             isSelectedMode={currentEditMode === 'endPoint'}
             isHighlightMode={isSelectedMeasurement}
-            isDrawing={isDrawing}
             cx={editPoints[2]}
             cy={editPoints[3]}
             cursorStatus={cursorStatus}

--- a/libs/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
@@ -12,6 +12,7 @@ export function MeasurementDrawer({
   style,
   width,
   height,
+  isDrawing = true,
   isEditing = false,
   measurements,
   selectedMeasurement,
@@ -26,6 +27,7 @@ export function MeasurementDrawer({
   const { editPoints, measurement, currentEditMode, setMeasurementEditMode, cursorStatus } =
     useMeasurementPointsHandler({
       mode,
+      isDrawing,
       isEditing,
       measurements,
       svgElement: svgRef,

--- a/libs/insight-viewer/src/Viewer/MeasurementOverlay/index.tsx
+++ b/libs/insight-viewer/src/Viewer/MeasurementOverlay/index.tsx
@@ -40,8 +40,8 @@ export function MeasurementOverlay({
         showOutline={showOutline}
         isEditing={isEditing}
         measurementAttrs={measurementAttrs}
-        onFocus={onFocus}
-        onClick={isEditing ? onSelect : onRemove}
+        onFocus={isDrawing ? onFocus : undefined}
+        onClick={isDrawing ? (isEditing ? onSelect : onRemove) : undefined}
       />
       {onAdd && (
         <MeasurementDrawer

--- a/libs/insight-viewer/src/Viewer/MeasurementOverlay/index.tsx
+++ b/libs/insight-viewer/src/Viewer/MeasurementOverlay/index.tsx
@@ -43,7 +43,7 @@ export function MeasurementOverlay({
         onFocus={onFocus}
         onClick={isEditing ? onSelect : onRemove}
       />
-      {isDrawing && onAdd && (
+      {onAdd && (
         <MeasurementDrawer
           width={width}
           height={height}
@@ -52,6 +52,7 @@ export function MeasurementOverlay({
           measurements={measurements}
           className={className}
           style={style}
+          isDrawing={isDrawing}
           isEditing={isEditing}
           mode={mode}
           onAdd={onAdd}

--- a/libs/insight-viewer/src/components/EditPointer/index.tsx
+++ b/libs/insight-viewer/src/components/EditPointer/index.tsx
@@ -11,7 +11,6 @@ interface EditPointerProps {
   cursorStatus: CursorStatus
   isSelectedMode?: boolean
   isHighlightMode?: boolean
-  isDrawing?: boolean
   setEditMode: (editMode: EditMode) => void
 }
 
@@ -22,7 +21,6 @@ export function EditPointer({
   isSelectedMode,
   isHighlightMode,
   setEditMode,
-  isDrawing,
   cursorStatus,
 }: EditPointerProps): JSX.Element {
   const handleOnMouseDown = () => setEditMode(editMode)

--- a/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
@@ -16,6 +16,7 @@ import type { Point, EditMode, Annotation } from '../../types'
 
 export default function useAnnotationPointsHandler({
   mode,
+  isDrawing,
   isEditing,
   lineHead,
   svgElement,
@@ -43,7 +44,7 @@ export default function useAnnotationPointsHandler({
   setClassName(enabledElement, cursorStatus)
 
   useEffect(() => {
-    if (!isEditing || selectedAnnotation == null) {
+    if (!isDrawing || !isEditing || selectedAnnotation == null) {
       setEditMode(null)
       setAnnotation(null)
       setEditStartPoint(null)
@@ -58,9 +59,12 @@ export default function useAnnotationPointsHandler({
 
     setAnnotation(selectedAnnotation)
     setEditTargetPoints(currentEditPoint)
-  }, [image, isEditing, selectedAnnotation, onSelectAnnotation, pixelToCanvas])
+  }, [image, isDrawing, isEditing, selectedAnnotation, onSelectAnnotation, pixelToCanvas])
 
   const setInitialAnnotation = (point: Point) => {
+    if (!isDrawing) {
+      return
+    }
     if (isEditing && selectedAnnotation) {
       setEditStartPoint(point)
       return
@@ -78,7 +82,13 @@ export default function useAnnotationPointsHandler({
   }
 
   const addDrawingAnnotation = (point: Point) => {
-    if (isEditing && selectedAnnotation != null && !editMode) return
+    if (!isDrawing) {
+      return
+    }
+
+    if (isEditing && selectedAnnotation != null && !editMode) {
+      return
+    }
 
     if (annotation == null) {
       setAnnotation(null)

--- a/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/types.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/types.ts
@@ -2,6 +2,7 @@ import type { AnnotationMode, Annotation, LineHeadMode, EditMode, CursorStatus }
 import type { EditPoints } from '../../utils/common/getEditPointPosition'
 
 export interface UseAnnotationPointsHandlerParams {
+  isDrawing: boolean
   isEditing: boolean
   mode: AnnotationMode
   lineHead: LineHeadMode

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -31,6 +31,7 @@ const getMeasurementEditingPoints = ({
 
 export default function useMeasurementPointsHandler({
   mode,
+  isDrawing,
   isEditing,
   svgElement,
   measurements,
@@ -60,7 +61,7 @@ export default function useMeasurementPointsHandler({
   setClassName(enabledElement, cursorStatus)
 
   useEffect(() => {
-    if (!isEditing || selectedMeasurement == null) {
+    if (!isDrawing || !isEditing || selectedMeasurement == null) {
       setEditMode(null)
       setMeasurement(null)
       setEditStartPoint(null)
@@ -75,9 +76,12 @@ export default function useMeasurementPointsHandler({
 
     setMeasurement(selectedMeasurement)
     setEditTargetPoints(currentEditPoint)
-  }, [isEditing, selectedMeasurement, pixelToCanvas, onSelectMeasurement])
+  }, [isDrawing, isEditing, selectedMeasurement, pixelToCanvas, onSelectMeasurement])
 
   const setInitialMeasurement = (point: [mouseDownX: number, mouseDownY: number]) => {
+    if (!isDrawing) {
+      return
+    }
     if (isEditing && selectedMeasurement != null) {
       setEditStartPoint(point)
       return
@@ -93,7 +97,13 @@ export default function useMeasurementPointsHandler({
   }
 
   const addDrawingMeasurement = (point: [mouseMoveX: number, mouseMoveY: number]) => {
-    if (isEditing && selectedMeasurement != null && !editMode) return
+    if (!isDrawing) {
+      return
+    }
+
+    if (isEditing && selectedMeasurement != null && !editMode) {
+      return
+    }
 
     setMeasurement(() => {
       if (!measurement) return null

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/types.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/types.ts
@@ -3,6 +3,7 @@ import type { EditPoints } from '../../utils/common/getEditPointPosition'
 import type { MeasurementMode, Measurement, EditMode, CursorStatus } from '../../types'
 
 export interface UseMeasurementPointsHandlerParams {
+  isDrawing: boolean
   isEditing: boolean
   mode: MeasurementMode
   measurements: Measurement[]


### PR DESCRIPTION
## 📝 Description

Annotation, Measurement를 선택한 상태에서 isDrawing을 false로 변경하면 선택한 객체가 뷰어에서 숨겨지는 현상을 수정합니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

isDrawing을 false로 변경하면 선택한 객체가 뷰어에서 숨겨지며, true로 변경하면 다시 나타납니다.

Issue Number: [VIEWER-91]

## 🚀 New behavior

isDrawing을 false로 변경하면 isEditing을 false로 변경했을때와 동일하게 선택이 해제되며, 숨겨지지 않습니다.
또한 Hover, Click 동작이 비활성화됩니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.


[VIEWER-91]: https://lunit.atlassian.net/browse/VIEWER-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ