### PR TITLE
VIEWER-8 / fix Annotation, Measurement test code

### DIFF
--- a/apps/insight-viewer-docs-e2e/src/e2e/annotation.drawer.cy.ts
+++ b/apps/insight-viewer-docs-e2e/src/e2e/annotation.drawer.cy.ts
@@ -154,6 +154,7 @@ describe(
 
       it('should display no annotation when there is no initial annotation', () => {
         // given
+        cy.get('[data-cy-initial-annotations]').click({ force: true })
         cy.get('[value="line"]').click({ force: true })
         cy.get('[data-cy-id]').should('have.length', 0)
 

--- a/apps/insight-viewer-docs-e2e/src/e2e/annotation.viewer.cy.ts
+++ b/apps/insight-viewer-docs-e2e/src/e2e/annotation.viewer.cy.ts
@@ -1,8 +1,4 @@
-import {
-  setup,
-  deleteAndCheckAnnotationOrMeasurement,
-  deleteAndCheckMultiAnnotationOrMeasurement,
-} from '../support/utils'
+import { setup } from '../support/utils'
 import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, $LOADED } from '../support/const'
 import {
   POLYGON_ANNOTATIONS,
@@ -33,7 +29,7 @@ describe(
         cy.get('[data-cy-show-label="false"]').click()
 
         POLYGON_ANNOTATIONS.forEach((annotation) => {
-          const targetId = annotation.id - 1
+          const targetId = annotation.id
           const targetDataAttr = `[data-cy-id="${targetId}"]`
 
           cy.get(targetDataAttr)
@@ -48,7 +44,7 @@ describe(
         cy.get('[data-cy-show-label="true"]').click()
 
         POLYGON_ANNOTATIONS.forEach((annotation) => {
-          const targetId = annotation.id - 1
+          const targetId = annotation.id
           const targetDataAttr = `[data-cy-id="${targetId}"]`
 
           cy.get(targetDataAttr)
@@ -66,62 +62,17 @@ describe(
       it('count polygon annotation', () => {
         cy.get('[data-cy-id]').should('have.length', mockPolygonAnnotationLength)
       })
-
-      it('Annotation cannot be deleted when remove mode is not activated', () => {
-        // Constant DOM Element
-        const targetAnnotation = POLYGON_ANNOTATIONS[0]
-
-        // Check Remove mode handling switch disabled
-        cy.get('[data-cy-remove-mode="false"]').should('exist')
-
-        deleteAndCheckAnnotationOrMeasurement(targetAnnotation)
-
-        cy.get('[data-cy-id]').should('have.length', mockPolygonAnnotationLength)
-      })
-
-      it('delete polygon annotation and count annotation', () => {
-        cy.get('[data-cy-remove-mode="false"]').click()
-
-        deleteAndCheckMultiAnnotationOrMeasurement(POLYGON_ANNOTATIONS, 'not.exist')
-
-        cy.get('[data-cy-id]').should('have.length', 0)
-      })
     })
 
     describe('Line Annotation', () => {
       const mockLineAnnotationLength = LINE_ANNOTATIONS.length
 
       it('click line radio', () => {
-        // cy.get('input').invoke('attr', 'value').should('eq', 'line').click()
         cy.get('[value="line"]').click({ force: true })
-      })
-
-      it('reset remove mode', () => {
-        cy.get('[data-cy-remove-mode="true"]').click()
       })
 
       it('count line annotation', () => {
         cy.get('[data-cy-id]').should('have.length', mockLineAnnotationLength)
-      })
-
-      it('Annotation cannot be deleted when remove mode is not activated', () => {
-        // Constant DOM Element
-        const targetAnnotation = LINE_ANNOTATIONS[0]
-
-        // Check Remove mode handling switch disabled
-        cy.get('[data-cy-remove-mode="false"]').should('exist')
-
-        deleteAndCheckAnnotationOrMeasurement(targetAnnotation)
-
-        cy.get('[data-cy-id]').should('have.length', mockLineAnnotationLength)
-      })
-
-      it('delete line annotation and count annotation', () => {
-        cy.get('[data-cy-remove-mode="false"]').click()
-
-        deleteAndCheckMultiAnnotationOrMeasurement(LINE_ANNOTATIONS, 'not.exist')
-
-        cy.get('[data-cy-id]').should('have.length', 0)
       })
     })
 
@@ -132,32 +83,8 @@ describe(
         cy.get('[value="freeLine"]').click({ force: true })
       })
 
-      it('reset remove mode', () => {
-        cy.get('[data-cy-remove-mode="true"]').click()
-      })
-
       it('count freeline annotation', () => {
         cy.get('[data-cy-id]').should('have.length', mockFreeLineAnnotationLength)
-      })
-
-      it('Annotation cannot be deleted when remove mode is not activated', () => {
-        // Constant DOM Element
-        const targetAnnotation = FREELINE_ANNOTATIONS[0]
-
-        // Check Remove mode handling switch disabled
-        cy.get('[data-cy-remove-mode="false"]').should('exist')
-
-        deleteAndCheckAnnotationOrMeasurement(targetAnnotation)
-
-        cy.get('[data-cy-id]').should('have.length', mockFreeLineAnnotationLength)
-      })
-
-      it('delete freeline annotation and count annotation', () => {
-        cy.get('[data-cy-remove-mode="false"]').click()
-
-        deleteAndCheckMultiAnnotationOrMeasurement(FREELINE_ANNOTATIONS, 'not.exist')
-
-        cy.get('[data-cy-id]').should('have.length', 0)
       })
     })
 
@@ -168,32 +95,8 @@ describe(
         cy.get('[value="text"]').click({ force: true })
       })
 
-      it('reset remove mode', () => {
-        cy.get('[data-cy-remove-mode="true"]').click()
-      })
-
       it('count text annotation', () => {
         cy.get('[data-cy-id]').should('have.length', mockTextAnnotationLength)
-      })
-
-      it('Annotation cannot be deleted when remove mode is not activated', () => {
-        // Constant DOM Element
-        const targetAnnotation = TEXT_ANNOTATIONS[0]
-
-        // Check Remove mode handling switch disabled
-        cy.get('[data-cy-remove-mode="false"]').should('exist')
-
-        deleteAndCheckAnnotationOrMeasurement(targetAnnotation)
-
-        cy.get('[data-cy-id]').should('have.length', mockTextAnnotationLength)
-      })
-
-      it('delete text annotation and count annotation', () => {
-        cy.get('[data-cy-remove-mode="false"]').click()
-
-        deleteAndCheckMultiAnnotationOrMeasurement(TEXT_ANNOTATIONS, 'not.exist')
-
-        cy.get('[data-cy-id]').should('have.length', 0)
       })
     })
   }

--- a/apps/insight-viewer-docs-e2e/src/e2e/measurement.viewer.cy.ts
+++ b/apps/insight-viewer-docs-e2e/src/e2e/measurement.viewer.cy.ts
@@ -26,39 +26,6 @@ describe(
       it('count ruler measurement', () => {
         cy.get('[data-cy-id]').should('have.length', mockRulerMeasurementLength)
       })
-
-      it('Measurement cannot be deleted when remove mode is not activated', () => {
-        // Constant DOM Element and data-attr
-        const targetRulerMeasurement = RULER_MEASUREMENTS[0]
-        const targetDataAttr = `[data-cy-id="${targetRulerMeasurement.id}"]`
-
-        // Check Remove mode handling switch disabled
-        cy.get('[data-cy-remove-mode="false"]').should('exist')
-
-        // Click target DOM Element
-        cy.get(targetDataAttr).click()
-
-        // Check mock measurement list and target Element
-        cy.get(targetDataAttr).should('exist')
-        cy.get('[data-cy-id]').should('have.length', mockRulerMeasurementLength)
-      })
-
-      it('delete ruler measurement and count measurement', () => {
-        cy.get('[data-cy-remove-mode="false"]').click()
-
-        RULER_MEASUREMENTS.forEach((measurement, i) => {
-          const targetDataAttr = `[data-cy-id="${measurement.id - 1}"]`
-
-          // Click target DOM Element
-          cy.get(targetDataAttr).click({ force: true })
-
-          // Check mock measurement list and target Element
-          cy.get(targetDataAttr).should('not.exist')
-          cy.get('[data-cy-id]').should('have.length', mockRulerMeasurementLength - (i + 1))
-        })
-
-        cy.get('[data-cy-id]').should('have.length', 0)
-      })
     })
 
     describe('Circle Measurement', () => {
@@ -66,42 +33,11 @@ describe(
       const mockCircleMeasurementLength = CIRCLE_MEASUREMENTS.length
 
       it('initial setting of circle measurement testing', () => {
-        cy.get('[data-cy-remove-mode="true"]').click()
         cy.get('[value="circle"]').click({ force: true })
       })
 
       it('count circle measurement', () => {
         cy.get('[data-cy-id]').should('have.length', mockCircleMeasurementLength)
-      })
-
-      it('Measurement cannot be deleted when remove mode is not activated', () => {
-        // Constant DOM Element and data-attr
-        const targetRulerMeasurement = CIRCLE_MEASUREMENTS[0]
-        const targetDataAttr = `[data-cy-id="${targetRulerMeasurement.id}"]`
-
-        // Click target DOM Element
-        cy.get(targetDataAttr).click({ force: true })
-
-        // Check mock measurement list and target Element
-        cy.get(targetDataAttr).should('exist')
-        cy.get('[data-cy-id]').should('have.length', mockCircleMeasurementLength)
-      })
-
-      it('delete circle measurement and count measurement', () => {
-        cy.get('[data-cy-remove-mode="false"]').click()
-
-        CIRCLE_MEASUREMENTS.forEach((measurement, i) => {
-          const targetDataAttr = `[data-cy-id="${measurement.id - 1}"]`
-
-          // Click target DOM Element
-          cy.get(targetDataAttr).click({ force: true })
-
-          // Check mock measurement list and target Element
-          cy.get(targetDataAttr).should('not.exist')
-          cy.get('[data-cy-id]').should('have.length', mockCircleMeasurementLength - (i + 1))
-        })
-
-        cy.get('[data-cy-id]').should('have.length', 0)
       })
     })
   }

--- a/apps/insight-viewer-docs-e2e/src/support/utils.ts
+++ b/apps/insight-viewer-docs-e2e/src/support/utils.ts
@@ -19,7 +19,7 @@ export function deleteAndCheckAnnotationOrMeasurement(
   element: Annotation | Measurement,
   domElementState: DomElementExistState = 'exist'
 ): void {
-  const targetDataAttr = `[data-cy-id="${element.id - 1}"]`
+  const targetDataAttr = `[data-cy-id="${element.id}"]`
 
   cy.get(targetDataAttr).click({ force: true })
   cy.get(targetDataAttr).should(domElementState)

--- a/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Annotation/Drawer/index.tsx
@@ -24,9 +24,10 @@ const DEFAULT_SIZE = { width: 700, height: 700 }
 function AnnotationDrawerContainer(): JSX.Element {
   const [annotationMode, setAnnotationMode] = useState<AnnotationMode>('polygon')
   const [lineHeadMode, setLineHeadMode] = useState<LineHeadMode>('normal')
-  const [isDrawing, setIsDrawing] = useState(true)
-  const [isEditing, setIsEditing] = useState(false)
-  const [isShowLabel, setIsShowLabel] = useState(false)
+  const [isDrawing, setIsDrawing] = useState<boolean>(true)
+  const [isEditing, setIsEditing] = useState<boolean>(false)
+  const [isShowLabel, setIsShowLabel] = useState<boolean>(false)
+  const [hasInitialAnnotations, setHasInitialAnnotations] = useState<boolean>(true)
 
   const { ImageSelect, selected } = useImageSelect()
   const { loadingState, image } = useImage({
@@ -44,8 +45,12 @@ function AnnotationDrawerContainer(): JSX.Element {
     removeAllAnnotation,
     resetAnnotation,
   } = useAnnotation({
-    initialAnnotation: INITIAL_POLYGON_ANNOTATIONS,
+    initialAnnotation: hasInitialAnnotations ? INITIAL_POLYGON_ANNOTATIONS : undefined,
   })
+
+  const handleInitialAnnotationChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setHasInitialAnnotations(event.target.checked)
+  }
 
   const handleAnnotationModeClick = (mode: AnnotationMode) => {
     setAnnotationMode(mode)
@@ -96,6 +101,14 @@ function AnnotationDrawerContainer(): JSX.Element {
         Edit enabled (E) <Switch data-cy-edit={isEditing} onChange={handleEditModeChange} isChecked={isEditing} />
       </Box>
       <Box>
+        Initial Viewport enabled{' '}
+        <Switch
+          data-cy-initial-annotations={hasInitialAnnotations}
+          onChange={handleInitialAnnotationChange}
+          isChecked={hasInitialAnnotations}
+        />
+      </Box>
+      <Box>
         Show label{' '}
         <Switch data-cy-show-label={isShowLabel} onChange={handleShowLabelModeChange} isChecked={isShowLabel} />
       </Box>
@@ -112,7 +125,7 @@ function AnnotationDrawerContainer(): JSX.Element {
       </RadioGroup>
       <RadioGroup onChange={handleLineHeadModeButtonChange} value={lineHeadMode}>
         <Stack direction="row">
-          <p style={{ marginRight: '10px' }}>Select Line Head mode</p>
+          <p style={{ marginRight: '10px' }}>Select Line Head mode - deprecated</p>
           <Radio value="normal">Normal</Radio>
           <Radio value="arrow">Arrow</Radio>
         </Stack>

--- a/apps/insight-viewer-docs/containers/Annotation/Viewer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Annotation/Viewer/index.tsx
@@ -43,7 +43,6 @@ const DEFAULT_SIZE = { width: 700, height: 700 }
 
 function AnnotationViewerContainer(): JSX.Element {
   const [annotationMode, setAnnotationMode] = useState<AnnotationMode>('polygon')
-  const [isRemove, setIsRemove] = useState(false)
   const [isShowLabel, setIsShowLabel] = useState(false)
   const { loadingState, image } = useImage({
     wadouri: IMAGES[11],
@@ -53,10 +52,6 @@ function AnnotationViewerContainer(): JSX.Element {
     useAnnotation({
       initialAnnotation: INITIAL_ANNOTATIONS[annotationMode],
     })
-
-  const handleRemoveModeChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setIsRemove(event.target.checked)
-  }
 
   const handleShowLabelModeChange = (event: ChangeEvent<HTMLInputElement>) => {
     setIsShowLabel(event.target.checked)
@@ -68,9 +63,6 @@ function AnnotationViewerContainer(): JSX.Element {
 
   return (
     <Box data-cy-loaded={loadingState}>
-      <Box>
-        remove mode <Switch data-cy-remove-mode={isRemove} onChange={handleRemoveModeChange} isChecked={isRemove} />
-      </Box>
       <Box>
         show label{' '}
         <Switch data-cy-show-label={isShowLabel} onChange={handleShowLabelModeChange} isChecked={isShowLabel} />
@@ -97,8 +89,6 @@ function AnnotationViewerContainer(): JSX.Element {
               selectedAnnotation={selectedAnnotation}
               mode={annotationMode}
               showAnnotationLabel={isShowLabel}
-              onFocus={isRemove ? hoverAnnotation : undefined}
-              onRemove={isRemove ? removeAnnotation : undefined}
               onSelect={selectAnnotation}
             />
           )}

--- a/apps/insight-viewer-docs/containers/Measurement/Viewer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Measurement/Viewer/index.tsx
@@ -1,5 +1,5 @@
-import { useState, ChangeEvent } from 'react'
-import { Box, Switch, Radio, RadioGroup, Stack } from '@chakra-ui/react'
+import { useState } from 'react'
+import { Box, Radio, RadioGroup, Stack } from '@chakra-ui/react'
 import { Resizable } from 're-resizable'
 import InsightViewer, {
   useMeasurement,
@@ -31,27 +31,15 @@ const DEFAULT_SIZE = { width: 700, height: 700 }
 
 function MeasurementViewerContainer(): JSX.Element {
   const [measurementMode, setMeasurementMode] = useState<MeasurementMode>('ruler')
-  const [isRemove, setIsRemove] = useState(false)
 
   const { loadingState, image } = useImage({
     wadouri: IMAGES[11],
   })
 
   const { viewport, setViewport } = useViewport()
-  const {
-    measurements,
-    hoveredMeasurement,
-    selectedMeasurement,
-    removeMeasurement,
-    selectMeasurement,
-    hoverMeasurement,
-  } = useMeasurement({
+  const { measurements, hoveredMeasurement, selectedMeasurement, selectMeasurement } = useMeasurement({
     initialMeasurement: INITIAL_MEASUREMENTS[measurementMode],
   })
-
-  const handleEditModeChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setIsRemove(event.target.checked)
-  }
 
   const handleMeasurementModeChange = (mode: MeasurementMode) => {
     setMeasurementMode(mode)
@@ -59,9 +47,6 @@ function MeasurementViewerContainer(): JSX.Element {
 
   return (
     <Box data-cy-loaded={loadingState}>
-      <Box>
-        remove mode <Switch data-cy-remove-mode={isRemove} onChange={handleEditModeChange} isChecked={isRemove} />
-      </Box>
       <RadioGroup onChange={handleMeasurementModeChange} value={measurementMode}>
         <Stack direction="row">
           <p style={{ marginRight: '10px' }}>Select Head mode</p>
@@ -80,8 +65,6 @@ function MeasurementViewerContainer(): JSX.Element {
               selectedMeasurement={selectedMeasurement}
               mode={measurementMode}
               onSelect={selectMeasurement}
-              onFocus={isRemove ? hoverMeasurement : undefined}
-              onRemove={isRemove ? removeMeasurement : undefined}
             />
           )}
         </InsightViewer>


### PR DESCRIPTION
## 📝 Description

Annotation, Measurement Viewer 스펙이 변경됨에 따라 불필요한 E2E 테스트 코드를 삭제조치 했습니다.
기타 테스트 실패하는 케이스에 대한 수정도 진행했습니다.

E2E 테스트 github action 은 별도의 PR 에서 진행할 예정입니다. 
더불어 Cypress 테스팅 병렬화 작업 역시 별도의 PR 에서 진행할 예정입니다.

해당 PR 에선 E2E 테스트 통과를 목적으로 하고 있습니다.
**로컬 환경에서 E2E 테스트 실행 및 테스트 통과 여부 확인 부탁드립니다.**

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [x] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

일부 테스트 코드가 동작하지 않습니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-8

## 🚀 New behavior

Initial Annotation 유무를 결정할 수 있게 Switch 를 추가했습니다. f517164
(이는 Initial Annotation 유무에 따른 화면 변화를 체크하기 위한 목적이며 이에 대한 E2E 테스트 대응을 위한 작업입니다.)

initial Annotation 유무를 결정하는 switch 를 기본 true 에서 false 로 전환하기 위해
cypress handling 코드를 추가했습니다. bd83799

Annotation, Measurement Viewer delete 관련 docs 로직 및 test 코드를 삭제했습니다. 8c8f4a8
이는 [Annotation select 시, isDrawing 을 false 로 변경할 경우 발생하는 이슈 해결 PR](https://github.com/lunit-io/frontend-components/pull/367) 건 조치 과정에서 Viewer 에선 Hover, Click 동작이 비활성화되는 방향으로 API 가 수정되었으므로
삭제 조치하였습니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
