### PR TITLE
VIEWER-121 / add mouse left click validation when annotation drawing

### DIFF
--- a/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
@@ -57,7 +57,7 @@ function useDrawingHandler({
 
     const handleMouseDown = (event: MouseEvent) => {
       // Apply Drawing only when left mouse button
-      if (event.button !== 0 || event.which !== 1) return
+      if (event.button !== 0) return
 
       activeMouseDrawEvents()
 

--- a/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
@@ -56,6 +56,9 @@ function useDrawingHandler({
     }
 
     const handleMouseDown = (event: MouseEvent) => {
+      // Apply Drawing only when left mouse button
+      if (event.button !== 0 || event.which !== 1) return
+
       activeMouseDrawEvents()
 
       const point = pageToPixel([event.pageX, event.pageY])

--- a/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
@@ -23,6 +23,9 @@ function useDrawingHandler({
     if (!svgElement || !enabledElement) return
 
     const handleMouseMove = (event: MouseEvent) => {
+      // Apply Drawing only when left mouse button is pressed
+      if (event.button !== 0) return
+
       setPreProcessEvent(event)
 
       const point = pageToPixel([event.pageX, event.pageY])
@@ -31,6 +34,8 @@ function useDrawingHandler({
     }
 
     const handleMouseUp = (event: MouseEvent) => {
+      if (event.button !== 0) return
+
       setPreProcessEvent(event)
 
       addDrewElement()
@@ -56,7 +61,6 @@ function useDrawingHandler({
     }
 
     const handleMouseDown = (event: MouseEvent) => {
-      // Apply Drawing only when left mouse button
       if (event.button !== 0) return
 
       activeMouseDrawEvents()


### PR DESCRIPTION
## 📝 Description

 마우스 왼쪽 클릭에 한해서 Annotation, Measurement Drawing 기능을 활성화 할 수 있도록 수정했습니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

모든 마우스 down 이벤트에서 Annotation, Measurement Drawing 이 가능합니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-121

## 🚀 New behavior

마우스 왼쪽 클릭에 한해서 Mouse down 로직이 돌아가도록 조건문 추가했습니다. [cc0827d](https://github.com/lunit-io/frontend-components/pull/373/commits/cc0827da55c1c76aba5b7df23c699a8c251a6413)
이를 통해 마우스 왼쪽 클릭에 한해서 Drawing 기능이 활성화 됩니다.

`event.witch` 의 경우 `deprecated` 처리된 상태이지만 라이브러리이므로 모든 브라우저 대응이 필요할 듯하여
조건문에 포함했습니다.

참고 문서: https://www.w3schools.com/jsref/event_button.asp
https://www.quirksmode.org/js/events_properties.html#button

## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

내부 동작 방식이 변경되었습니다.
만약 전체 마우스를 통해 Drawing 을 하고 계셨던 경우, 라이브러리 사용자께선 이에 대한 조치가 필요합니다.
