### PR TITLE
VIEWER-124 / fix useViewport reset bug

### DIFF
--- a/apps/insight-viewer-docs/containers/Interaction/Tabs.tsx
+++ b/apps/insight-viewer-docs/containers/Interaction/Tabs.tsx
@@ -16,7 +16,7 @@ export default function App(): JSX.Element {
       <TabList>
         <Tab>Base Interaction</Tab>
         <Tab className="custom-tab">Custom Interaction</Tab>
-        <Tab className="custom-tab">Renewal Interaction</Tab>
+        <Tab className="renewal-tab">Renewal Interaction</Tab>
       </TabList>
 
       <TabPanels>

--- a/libs/insight-viewer/src/hooks/useViewport.ts
+++ b/libs/insight-viewer/src/hooks/useViewport.ts
@@ -34,10 +34,12 @@ export function useViewport(
   })
 
   function resetViewport() {
-    setViewport({
-      ...viewport,
-      _viewportOptions: options,
-      _resetViewport: initialViewport ?? {},
+    setViewport((prevViewport) => {
+      return {
+        ...prevViewport,
+        _viewportOptions: options,
+        _resetViewport: initialViewport ?? {},
+      }
     })
   }
 

--- a/libs/insight-viewer/src/hooks/useViewportUpdate.ts
+++ b/libs/insight-viewer/src/hooks/useViewportUpdate.ts
@@ -57,6 +57,7 @@ export default function useViewportUpdate({ element, image, viewport: newViewpor
       // When resetting, update Viewer's viewport prop
       if (willReset) {
         onViewportChange({
+          isLegacyViewport: true,
           ...formatViewerViewport(defaultViewport),
           ...(newViewportProp?._resetViewport ?? {}),
           _viewportOptions: newViewportOptions,


### PR DESCRIPTION
## 📝 Description

Legacy useViewport reset 기능이 한 번 사용한 후 다시 reset 기능 사용 시,
동작하지 않는 버그를 해결합니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

useViewport 의 reset 기능을 한 번 사용한 후 다시 사용할 경우, reset 을 하지 않습니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-124

## 🚀 New behavior

reset 버튼을 클릭할 경우 항상 viewport 를 초기 상태로 reset 합니다.

useViewport hook 의 resetViewport function 에서 setState 의 
prevState 를 활용하는 방향으로 수정했습니다.     316a9d9

useViewportUpdate hook 에서 reset 할 경우 isLegacyViewport 값을 true 로 설정합니다.     783174e

useViewportUpdate hook 의 reset 은 레거시 코드일 경우에만 동작합니다.
해당 값 할당을 하지 않는 이슈로 인해 한 번 사용 후, isLegacyViewport 값이 undefined 로 처리되어
이 후 reset 시 상위 조건문에서 걸러지면서 버그가 발생했습니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
