### PR TITLE
VIEWER-125 / apply useRef to useViewport image, element parameter

### DIFF
--- a/apps/insight-viewer-docs/containers/Interaction/Image2.tsx
+++ b/apps/insight-viewer-docs/containers/Interaction/Image2.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react'
 import { Box, Text, Button, Stack, Switch } from '@chakra-ui/react'
-import InsightViewer, { useMultipleImages, useFrame } from '@lunit/insight-viewer'
+import InsightViewer, { useMultipleImages, useFrame, useInteraction, Wheel } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 import { IMAGES } from '@insight-viewer-library/fixtures'
 
@@ -12,6 +12,8 @@ import CustomProgress from '../../components/CustomProgress'
 import { ViewerWrapper } from '../../components/Wrapper'
 import { BASE_CODE } from './Code'
 import Canvas from './Canvas'
+import Control from './Control'
+import WheelControl from './Control/Wheel'
 
 export const PRIMARY_DRAG = 'primaryDrag'
 export const SECONDARY_DRAG = 'secondaryDrag'
@@ -19,13 +21,8 @@ export const PRIMARY_CLICK = 'primaryClick'
 export const SECONDARY_CLICK = 'secondaryClick'
 export const MOUSEWHEEL = 'mouseWheel'
 
-const DEFAULT_INTERACTION = {
-  [PRIMARY_DRAG]: undefined,
-  [SECONDARY_DRAG]: undefined,
-  [PRIMARY_CLICK]: undefined,
-  [SECONDARY_CLICK]: undefined,
-  [MOUSEWHEEL]: undefined,
-}
+const MIN_FRAME = 0
+const MAX_FRAME = IMAGES.length - 1
 
 interface ViewportSetting {
   options: ViewportOptions
@@ -41,7 +38,7 @@ export default function App(): JSX.Element {
   const { loadingStates, images } = useMultipleImages({
     wadouri: IMAGES,
   })
-  const { frame } = useFrame({
+  const { frame, setFrame } = useFrame({
     initial: 0,
     max: images.length - 1,
   })
@@ -53,16 +50,43 @@ export default function App(): JSX.Element {
     getInitialViewport: (defaultViewport: Viewport) => ({ ...defaultViewport, scale: defaultViewport.scale * 1.3 }),
   })
 
-  const interaction = { ...DEFAULT_INTERACTION, mouseWheel: 'scale' } as Interaction
+  const { interaction, setInteraction } = useInteraction()
+
+  const handleFrame: Wheel = (_, deltaY) => {
+    if (deltaY !== 0) setFrame((prev) => Math.min(Math.max(prev + (deltaY > 0 ? 1 : -1), MIN_FRAME), MAX_FRAME))
+  }
+
+  const handler = {
+    frame: handleFrame,
+    scale: 'scale' as const,
+  }
 
   const handleActiveFitScaleSwitchChange = (isChecked: boolean) => {
     setViewportSetting((prevSetting) => ({ ...prevSetting, options: { fitScale: isChecked } }))
+  }
+
+  const handleChange = (type: string) => {
+    return (value: string) => {
+      setInteraction((prev: Interaction) => ({
+        ...prev,
+        [type]: value === 'none' ? undefined : value,
+      }))
+    }
+  }
+
+  const handleWheel = (value: string) => {
+    setInteraction((prev: Interaction) => ({
+      ...prev,
+      mouseWheel: value === 'none' ? undefined : handler[value as keyof typeof handler],
+    }))
   }
 
   return (
     <Box data-cy-loaded={loadingStates[frame]}>
       <Stack direction="row" spacing="80px" align="flex-start">
         <Box>
+          <Control onChange={handleChange} />
+          <WheelControl onChange={handleWheel} />
           <Box>
             active fit scale{' '}
             <Switch

--- a/libs/insight-viewer/src/Viewport/useViewport/index.ts
+++ b/libs/insight-viewer/src/Viewport/useViewport/index.ts
@@ -98,8 +98,8 @@ export function useViewport(
   }, [])
 
   useEffect(() => {
-    setViewportWithValidation((prevViewport) => ({ ...prevViewport, _viewportOptions: options }))
-  }, [options, setViewportWithValidation])
+    setViewportWithValidation((prevViewport) => ({ ...prevViewport, _viewportOptions: { fitScale: options.fitScale } }))
+  }, [options.fitScale, setViewportWithValidation])
 
   useEffect(() => {
     imageRef.current = image

--- a/libs/insight-viewer/src/Viewport/useViewport/index.ts
+++ b/libs/insight-viewer/src/Viewport/useViewport/index.ts
@@ -8,7 +8,16 @@ import { formatViewerViewport } from '../../utils/common/formatViewport'
 import { getDefaultViewportForImage } from '../../utils/cornerstoneHelper'
 
 import type { Viewport } from '../../types'
+import type { Image } from '../../Viewer/types'
 import type { SetViewportAction, UseViewportReturnType, UseViewportParams } from './type'
+
+const getDefaultViewport = (image: Image | undefined, element: HTMLDivElement | undefined) => {
+  if (!image || !element) return null
+
+  const defaultViewport = getDefaultViewportForImage(element, image)
+
+  return formatViewerViewport(defaultViewport)
+}
 
 export function useViewport(
   { image, element, options = DEFAULT_VIEWPORT_OPTIONS, getInitialViewport }: UseViewportParams = {
@@ -22,17 +31,19 @@ export function useViewport(
     _viewportOptions: options,
   })
 
+  const imageRef = useRef(image)
+  const elementRef = useRef(element)
   const getInitialViewportRef = useRef(getInitialViewport)
 
   const getDefaultViewport = useCallback(() => {
-    if (image && element) {
-      const defaultViewport = getDefaultViewportForImage(element, image)
+    if (imageRef.current && elementRef.current) {
+      const defaultViewport = getDefaultViewportForImage(elementRef.current, imageRef.current)
 
       return formatViewerViewport(defaultViewport)
     }
 
     return null
-  }, [image, element])
+  }, [])
 
   const getViewportWithFitScaleOption = useCallback(
     (viewport: Viewport, fitScale: boolean): Viewport => {
@@ -107,6 +118,11 @@ export function useViewport(
     })
   }, [options.fitScale, getViewportWithFitScaleOption])
 
+  useEffect(() => {
+    imageRef.current = image
+    elementRef.current = element
+  }, [image, element])
+
   /**
    * The purpose of setting the initial Viewport value
    * when the image is changed
@@ -125,7 +141,7 @@ export function useViewport(
       ...initialViewport,
       _viewportOptions: prevViewport._viewportOptions,
     }))
-  }, [getInitialViewportRef, getDefaultViewport])
+  }, [image, element, getInitialViewportRef, getDefaultViewport])
 
   return {
     viewport,

--- a/libs/insight-viewer/src/Viewport/useViewport/index.ts
+++ b/libs/insight-viewer/src/Viewport/useViewport/index.ts
@@ -80,34 +80,26 @@ export function useViewport(
     } else {
       setViewport({ ...defaultViewport, _viewportOptions: options })
     }
-  }, [getDefaultViewport, getInitialViewport, options])
+  }, [getInitialViewport, options])
 
   /**
    * We assigned the function type and the value type
    * for the immediate viewport assignment as union type
    * to utilize the previous viewport.
    */
-  const setViewportWithValidation = useCallback(
-    (setViewportAction: SetViewportAction) => {
-      setViewport((prevViewport) => {
-        const newViewport =
-          typeof setViewportAction === 'function' ? setViewportAction(prevViewport) : setViewportAction
-
-        const updatedViewport = getViewportWithFitScaleOption(newViewport, prevViewport._viewportOptions.fitScale)
-
-        return updatedViewport
-      })
-    },
-    [getViewportWithFitScaleOption]
-  )
-
-  useEffect(() => {
+  const setViewportWithValidation = useCallback((setViewportAction: SetViewportAction) => {
     setViewport((prevViewport) => {
-      const updatedViewport = getViewportWithFitScaleOption(prevViewport, options.fitScale)
+      const newViewport = typeof setViewportAction === 'function' ? setViewportAction(prevViewport) : setViewportAction
+
+      const updatedViewport = getViewportWithFitScaleOption(newViewport, imageRef.current, elementRef.current)
 
       return updatedViewport
     })
-  }, [options.fitScale, getViewportWithFitScaleOption])
+  }, [])
+
+  useEffect(() => {
+    setViewportWithValidation((prevViewport) => ({ ...prevViewport, _viewportOptions: options }))
+  }, [options, setViewportWithValidation])
 
   useEffect(() => {
     imageRef.current = image
@@ -119,7 +111,7 @@ export function useViewport(
    * when the image is changed
    */
   useEffect(() => {
-    const defaultViewport = getDefaultViewport()
+    const defaultViewport = getDefaultViewport(imageRef.current, elementRef.current)
 
     if (!defaultViewport) return
 
@@ -132,7 +124,7 @@ export function useViewport(
       ...initialViewport,
       _viewportOptions: prevViewport._viewportOptions,
     }))
-  }, [image, element, getInitialViewportRef, getDefaultViewport])
+  }, [image, element, getInitialViewportRef])
 
   return {
     viewport,

--- a/libs/insight-viewer/src/Viewport/useViewport/index.ts
+++ b/libs/insight-viewer/src/Viewport/useViewport/index.ts
@@ -91,12 +91,12 @@ export function useViewport(
         const newViewport =
           typeof setViewportAction === 'function' ? setViewportAction(prevViewport) : setViewportAction
 
-        const updatedViewport = getViewportWithFitScaleOption(newViewport, options.fitScale)
+        const updatedViewport = getViewportWithFitScaleOption(newViewport, prevViewport._viewportOptions.fitScale)
 
         return updatedViewport
       })
     },
-    [getViewportWithFitScaleOption, options.fitScale]
+    [getViewportWithFitScaleOption]
   )
 
   useEffect(() => {

--- a/libs/insight-viewer/src/Viewport/useViewport/index.ts
+++ b/libs/insight-viewer/src/Viewport/useViewport/index.ts
@@ -19,6 +19,24 @@ const getDefaultViewport = (image: Image | undefined, element: HTMLDivElement | 
   return formatViewerViewport(defaultViewport)
 }
 
+const getViewportWithFitScaleOption = (
+  viewport: Viewport,
+  image: Image | undefined,
+  element: HTMLDivElement | undefined
+): Viewport => {
+  const defaultViewport = getDefaultViewport(image, element)
+
+  if (!defaultViewport) return viewport
+
+  const currentFitScaleOption = viewport._viewportOptions.fitScale
+
+  if (currentFitScaleOption && viewport.scale < defaultViewport.scale) {
+    return { ...viewport, scale: defaultViewport.scale }
+  }
+
+  return viewport
+}
+
 export function useViewport(
   { image, element, options = DEFAULT_VIEWPORT_OPTIONS, getInitialViewport }: UseViewportParams = {
     image: undefined,
@@ -35,35 +53,8 @@ export function useViewport(
   const elementRef = useRef(element)
   const getInitialViewportRef = useRef(getInitialViewport)
 
-  const getDefaultViewport = useCallback(() => {
-    if (imageRef.current && elementRef.current) {
-      const defaultViewport = getDefaultViewportForImage(elementRef.current, imageRef.current)
-
-      return formatViewerViewport(defaultViewport)
-    }
-
-    return null
-  }, [])
-
-  const getViewportWithFitScaleOption = useCallback(
-    (viewport: Viewport, fitScale: boolean): Viewport => {
-      const defaultViewport = getDefaultViewport()
-
-      const ViewportOfUpdatingFitScaleOption = { ...viewport, _viewportOptions: { fitScale } }
-
-      if (!defaultViewport) return ViewportOfUpdatingFitScaleOption
-
-      if (fitScale && ViewportOfUpdatingFitScaleOption.scale < defaultViewport.scale) {
-        return { ...ViewportOfUpdatingFitScaleOption, scale: defaultViewport.scale }
-      }
-
-      return ViewportOfUpdatingFitScaleOption
-    },
-    [getDefaultViewport]
-  )
-
   const resetViewport = useCallback(() => {
-    const defaultViewport = getDefaultViewport()
+    const defaultViewport = getDefaultViewport(imageRef.current, elementRef.current)
 
     if (!defaultViewport) {
       setViewport({

--- a/libs/insight-viewer/src/Viewport/useViewport/type.ts
+++ b/libs/insight-viewer/src/Viewport/useViewport/type.ts
@@ -12,7 +12,7 @@ export interface UseViewportReturnType {
   viewport: Viewport
   initialized: boolean
   resetViewport: () => void
-  getDefaultViewport: () => void
+  getDefaultViewport: (image: Image | undefined, element: HTMLDivElement | undefined) => void
   setViewport: (setViewportAction: SetViewportAction) => void
 }
 


### PR DESCRIPTION
## 📝 Description

이전 [useViewport Renewal PR](https://github.com/lunit-io/frontend-components/pull/371) 을 통해 추가된 hook 의 사용성을 개선했습니다.

useViewport image, element parameter 를 Ref 로 관리하여 이 두 데이터를 사용하는 쪽에서
`image`, `element` 에 대한 디펜던시를 제거하는 방향으로 변경했습니다.
(이와 동시에 한 번만 선언하는 function 은 useViewport hook 외부에 선언했습니다.)

이전 구조는 `image`, `element`, `fitScale` option 과 `return function` 간 커플링이 존재하며,
이에 대한 싱크를 사용하는 쪽에서 신경써야했습니다.
(parameter 에 있는 fitScale 을 그대로 사용하는 것도 해당 이슈에 영향을 줍니다.)

현재 구조는 viewport 와 관련된 내용은 setState 의 prevState 를 활용하여 이전보다 안정감 있게 값을 서빙하여
parameter 와 관계없이 안정된 값을 전달한다는 보장이 됩니다.

이렇게 개선하는 이유는 아래와 같습니다.
현재 useViewport hook 내 함수는 return value 에 포함되어 있습니다.

이 과정에서 이전 구조는 라이브러리 사용자 입장에선 최신의 값이 반영된 setViewport function 여부를 보장하기 어렵습니다. 
(fitScale, image, element 등에 대한 디펜던시가 전부 걸려있으므로.)
이 구조는 라이브러리 사용자 입장에서 까다로운 이슈로 작용할 수 있으므로 
**처음 한 번만 생성 -> 라이브러리 사용자는 처음 한 번만 생성된 function** 을 사용하는 방식으로 변경했습니다.
(위 function 은 항상 이전의 값을 참조하며, image, element 는 ref 를 통해 최신 값을 참조)

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

return value 중 setViewport 는 `image`, `element`, `fitScale` 에 대한 디펜던스를 가지고 있습니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-125

## 🚀 New behavior

useViewport hook image, element parameter 를 useRef 로 감싼 후 해당 값을 사용합니다.
이와 함께 getDefaultViewport function 을 useViewport 외부에 선언합니다. 4f6b2f6

getViewportWithFitScaleOption function 을 useViewport 외부에 선언합니다. 47738b3

외부로 선언한 function 및 image, element Ref 값을 적용합니다. 456a324

Interaction image2 Docs 에서 클로저 이슈로 인해 삭제한 useInteraction hook 을 복구했습니다. 31a4ed0
(해당 이슈 처리로 클로저 이슈도 함께 해결됩니다. https://lunit.atlassian.net/browse/VIEWER-123)

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
