### PR TITLE
VIEWER-130 / Modify Circle Measurement naming to Area Measurement

### DIFF
--- a/apps/insight-viewer-docs-e2e/src/e2e/measurement.viewer.cy.ts
+++ b/apps/insight-viewer-docs-e2e/src/e2e/measurement.viewer.cy.ts
@@ -1,6 +1,6 @@
 import { setup } from '../support/utils'
 import { VIEWPORT_WIDTH, VIEWPORT_HEIGHT, $LOADED } from '../support/const'
-import { RULER_MEASUREMENTS, CIRCLE_MEASUREMENTS } from '@insight-viewer-library/fixtures'
+import { RULER_MEASUREMENTS, AREA_MEASUREMENTS } from '@insight-viewer-library/fixtures'
 
 describe(
   'Measurement Viewer',
@@ -28,16 +28,16 @@ describe(
       })
     })
 
-    describe('Circle Measurement', () => {
-      // Gets the number of circle mock data used by Measurement Viewer docs
-      const mockCircleMeasurementLength = CIRCLE_MEASUREMENTS.length
+    describe('Area Measurement', () => {
+      // Gets the number of area mock data used by Measurement Viewer docs
+      const mockAreaMeasurementLength = AREA_MEASUREMENTS.length
 
-      it('initial setting of circle measurement testing', () => {
-        cy.get('[value="circle"]').click({ force: true })
+      it('initial setting of area measurement testing', () => {
+        cy.get('[value="area"]').click({ force: true })
       })
 
-      it('count circle measurement', () => {
-        cy.get('[data-cy-id]').should('have.length', mockCircleMeasurementLength)
+      it('count area measurement', () => {
+        cy.get('[data-cy-id]').should('have.length', mockAreaMeasurementLength)
       })
     })
   }

--- a/apps/insight-viewer-docs/containers/Measurement/Drawer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Measurement/Drawer/index.tsx
@@ -84,7 +84,7 @@ function MeasurementDrawerContainer(): JSX.Element {
       <RadioGroup onChange={handleMeasurementModeClick} value={measurementMode}>
         <Stack direction="row">
           <Radio value="ruler">Ruler</Radio>
-          <Radio value="circle">Circle</Radio>
+          <Radio value="area">Area</Radio>
         </Stack>
       </RadioGroup>
       <Button data-cy-name="remove-button" marginBottom="10px" colorScheme="blue" onClick={removeAllMeasurement}>

--- a/apps/insight-viewer-docs/containers/Measurement/Viewer/index.tsx
+++ b/apps/insight-viewer-docs/containers/Measurement/Viewer/index.tsx
@@ -9,7 +9,7 @@ import InsightViewer, {
   Measurement,
 } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
-import { IMAGES, RULER_MEASUREMENTS, CIRCLE_MEASUREMENTS } from '@insight-viewer-library/fixtures'
+import { IMAGES, RULER_MEASUREMENTS, AREA_MEASUREMENTS } from '@insight-viewer-library/fixtures'
 
 export type InitialMeasurements = {
   [mode in MeasurementMode]: Measurement[]
@@ -17,7 +17,7 @@ export type InitialMeasurements = {
 
 const INITIAL_MEASUREMENTS: InitialMeasurements = {
   ruler: RULER_MEASUREMENTS,
-  circle: CIRCLE_MEASUREMENTS,
+  area: AREA_MEASUREMENTS,
 }
 
 const style = {
@@ -56,7 +56,7 @@ function MeasurementViewerContainer(): JSX.Element {
         <Stack direction="row">
           <p style={{ marginRight: '10px' }}>Select Head mode</p>
           <Radio value="ruler">Ruler</Radio>
-          <Radio value="circle">Circle</Radio>
+          <Radio value="area">Area</Radio>
         </Stack>
       </RadioGroup>
       <Resizable style={style} defaultSize={DEFAULT_SIZE} className={`measurement ${measurementMode}`}>

--- a/libs/fixtures/src/annotation/circles.ts
+++ b/libs/fixtures/src/annotation/circles.ts
@@ -1,10 +1,10 @@
-import { CircleMeasurement } from '@lunit/insight-viewer'
+import { AreaMeasurement } from '@lunit/insight-viewer'
 
-export const CIRCLE_MEASUREMENTS: CircleMeasurement[] = [
+export const AREA_MEASUREMENTS: AreaMeasurement[] = [
   {
     id: 1,
     lineWidth: 1.5,
-    type: 'circle',
+    type: 'area',
     centerPoint: [319.6342857142857, 186.7085714285714],
     measuredValue: 17.79273190023253,
     radius: 17.79273190023253,
@@ -14,7 +14,7 @@ export const CIRCLE_MEASUREMENTS: CircleMeasurement[] = [
   {
     id: 2,
     lineWidth: 1.5,
-    type: 'circle',
+    type: 'area',
     centerPoint: [264.7771428571428, 283.2571428571428],
     measuredValue: 14.285706971428565,
     radius: 14.285706971428565,
@@ -24,7 +24,7 @@ export const CIRCLE_MEASUREMENTS: CircleMeasurement[] = [
   {
     id: 3,
     lineWidth: 1.5,
-    type: 'circle',
+    type: 'area',
     centerPoint: [204.0685714285714, 354.9371428571428],
     measuredValue: 22.993443374236477,
     radius: 22.993443374236477,
@@ -34,7 +34,7 @@ export const CIRCLE_MEASUREMENTS: CircleMeasurement[] = [
   {
     id: 4,
     lineWidth: 1.5,
-    type: 'circle',
+    type: 'area',
     centerPoint: [141.16571428571427, 218.89142857142855],
     measuredValue: 16.9670963417275,
     radius: 16.9670963417275,

--- a/libs/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.types.ts
+++ b/libs/insight-viewer/src/Viewer/CircleDrawer/CircleDrawer.types.ts
@@ -1,8 +1,8 @@
-import type { EditMode, CircleMeasurement, CursorStatus } from '../../types'
+import type { EditMode, AreaMeasurement, CursorStatus } from '../../types'
 
 export interface CircleDrawerProps {
   isSelectedMode: boolean
-  measurement: CircleMeasurement
+  measurement: AreaMeasurement
   setMeasurementEditMode: (targetPoint: EditMode) => void
   cursorStatus: CursorStatus
 }

--- a/libs/insight-viewer/src/Viewer/CircleViewer/CircleViewer.types.ts
+++ b/libs/insight-viewer/src/Viewer/CircleViewer/CircleViewer.types.ts
@@ -1,3 +1,3 @@
-import { MeasurementViewerProps, CircleMeasurement } from '../../types'
+import { MeasurementViewerProps, AreaMeasurement } from '../../types'
 
-export type CircleViewerProps = MeasurementViewerProps<CircleMeasurement>
+export type CircleViewerProps = MeasurementViewerProps<AreaMeasurement>

--- a/libs/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/MeasurementDrawer/index.tsx
@@ -51,7 +51,7 @@ export function MeasurementDrawer({
           cursorStatus={cursorStatus}
         />
       )}
-      {measurement.type === 'circle' && (
+      {measurement.type === 'area' && (
         <CircleDrawer
           isSelectedMode={isSelectedMeasurement}
           measurement={measurement}

--- a/libs/insight-viewer/src/Viewer/MeasurementViewer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/MeasurementViewer/index.tsx
@@ -11,7 +11,6 @@ const measurementStyle: React.CSSProperties = {
   pointerEvents: 'auto',
 }
 function MeasurementsDraw({
-  isEditing,
   measurements,
   showOutline,
   hoveredMeasurement,
@@ -56,7 +55,7 @@ function MeasurementsDraw({
         style={measurementStyle}
       >
         {measurement.type === 'ruler' && <RulerViewer measurement={measurement} {...viewerProps} />}
-        {measurement.type === 'circle' && <CircleViewer measurement={measurement} {...viewerProps} />}
+        {measurement.type === 'area' && <CircleViewer measurement={measurement} {...viewerProps} />}
       </g>
     )
   })

--- a/libs/insight-viewer/src/hooks/useCircleMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useCircleMeasurement/index.ts
@@ -10,7 +10,7 @@ import { modifyConnectingLine } from '../../utils/common/modifyConnectingLine'
 import { stringifyPoints } from '../../utils/common/stringifyPoints'
 
 import { HALF_OF_RULER_TEXT_BOX } from '../../const'
-import type { CircleMeasurement, Point } from '../../types'
+import type { AreaMeasurement, Point } from '../../types'
 
 const formatCircleValue = (area: number, unit: string) =>
   `Area = ${area.toLocaleString(undefined, {
@@ -18,7 +18,7 @@ const formatCircleValue = (area: number, unit: string) =>
     maximumFractionDigits: 1,
   })}${unit}2`
 
-const useCircleMeasurement = ({ centerPoint, radius, measuredValue, textPoint, unit }: CircleMeasurement) => {
+const useCircleMeasurement = ({ centerPoint, radius, measuredValue, textPoint, unit }: AreaMeasurement) => {
   const { pixelToCanvas } = useOverlayContext()
   const [textBox, ref] = useTextBox()
 

--- a/libs/insight-viewer/src/hooks/useMeasurement/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurement/index.ts
@@ -43,7 +43,7 @@ export function useMeasurement({ nextId = 1, initialMeasurement }: UseMeasuremen
     measurementInfo: Pick<Measurement, 'dataAttrs'> | undefined
   ): Measurement | null => {
     if (measurement.type === 'ruler' && isSamePoints(measurement.startAndEndPoint)) return null
-    if (measurement.type === 'circle' && measurement.radius === 0) return null
+    if (measurement.type === 'area' && measurement.radius === 0) return null
     if (measurementInfo?.dataAttrs) {
       validateDataAttrs(measurementInfo?.dataAttrs)
     }

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/index.ts
@@ -146,7 +146,7 @@ export default function useMeasurementPointsHandler({
       const editPoints = getEditPointPosition(editPointsOnCanvas, selectedMeasurement, drawingMode)
       setEditTargetPoints(editPoints)
 
-      if (drawingMode === 'circle' && mouseDownPoint) {
+      if (drawingMode === 'area' && mouseDownPoint) {
         const currentPointsWithFixedPoint: [Point, Point] = [point, mouseDownPoint]
         const currentPointsWithFixedPointOnCanvas = currentPointsWithFixedPoint.map(pixelToCanvas) as [Point, Point]
 
@@ -160,7 +160,7 @@ export default function useMeasurementPointsHandler({
 
         setEditTargetPoints(editPoints)
       } else if (
-        currentMeasurement.type === 'circle' &&
+        currentMeasurement.type === 'area' &&
         selectedMeasurementEditingFixedPoint &&
         (editMode === 'startPoint' || editMode === 'endPoint')
       ) {
@@ -220,7 +220,7 @@ export default function useMeasurementPointsHandler({
     if (
       targetPoint &&
       selectedMeasurement &&
-      selectedMeasurement.type === 'circle' &&
+      selectedMeasurement.type === 'area' &&
       (targetPoint === 'startPoint' || targetPoint === 'endPoint')
     ) {
       const targetMeasurement = measurement ?? selectedMeasurement

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getExistingMeasurementPoints.spec.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getExistingMeasurementPoints.spec.ts
@@ -11,7 +11,7 @@ describe('getExistingMeasurementPoints: ', () => {
       radius: 20,
       measuredValue: 20,
       textPoint: null,
-      type: 'circle',
+      type: 'area',
       unit: 'px',
     }
     const MOCK_MEASUREMENT_2: Measurement = {
@@ -21,7 +21,7 @@ describe('getExistingMeasurementPoints: ', () => {
       radius: 30,
       measuredValue: 30,
       textPoint: null,
-      type: 'circle',
+      type: 'area',
       unit: 'px',
     }
 
@@ -43,7 +43,7 @@ describe('getExistingMeasurementPoints: ', () => {
       radius: 20,
       measuredValue: 20,
       textPoint: null,
-      type: 'circle',
+      type: 'area',
       unit: 'mm',
     }
     const MOCK_MEASUREMENT_2: Measurement = {
@@ -53,7 +53,7 @@ describe('getExistingMeasurementPoints: ', () => {
       radius: 30,
       measuredValue: 30,
       textPoint: null,
-      type: 'circle',
+      type: 'area',
       unit: 'mm',
     }
 

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getExistingMeasurementPoints.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getExistingMeasurementPoints.ts
@@ -8,7 +8,7 @@ export function getExistingMeasurementPoints(measurement: Measurement): [Point, 
       const rulerPoints = measurement.startAndEndPoint
       return rulerPoints
     }
-    case 'circle': {
+    case 'area': {
       const { centerPoint, radius } = measurement
       const endPoint = getCircleEndPoint(centerPoint, radius)
       const circlePoints: [Point, Point] = [centerPoint, endPoint]

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurement.spec.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurement.spec.ts
@@ -78,21 +78,21 @@ describe('getMeasurement: ', () => {
     })
   })
 
-  it('should return the measurement in circle mode without text, image', () => {
+  it('should return the measurement in area mode without text, image', () => {
     const MOCK_POINTS: [startPoint: Point, endPoint: Point] = [
       [0, 0],
       [20, 20],
     ]
     const MOCK_MEASUREMENTS: Measurement[] = []
 
-    expect(getMeasurement(MOCK_POINTS, null, 'circle', MOCK_MEASUREMENTS, null)).toStrictEqual({
+    expect(getMeasurement(MOCK_POINTS, null, 'area', MOCK_MEASUREMENTS, null)).toStrictEqual({
       centerPoint: [10, 10],
       id: 1,
       lineWidth: 1.5,
       measuredValue: 14.142135623730951,
       radius: 14.142135623730951,
       textPoint: null,
-      type: 'circle',
+      type: 'area',
       unit: 'px',
     })
 
@@ -104,7 +104,7 @@ describe('getMeasurement: ', () => {
         measuredValue: 14.142135623730951,
         radius: 14.142135623730951,
         textPoint: null,
-        type: 'circle',
+        type: 'area',
         unit: 'px',
       },
     ]
@@ -115,14 +115,14 @@ describe('getMeasurement: ', () => {
       measuredValue: 14.142135623730951,
       radius: 14.142135623730951,
       textPoint: null,
-      type: 'circle',
+      type: 'area',
       unit: 'px',
     }
 
-    expect(getMeasurement(MOCK_POINTS, null, 'circle', MOCK_ADDED_MEASUREMENTS, null)).toStrictEqual(EXPECTED_2)
+    expect(getMeasurement(MOCK_POINTS, null, 'area', MOCK_ADDED_MEASUREMENTS, null)).toStrictEqual(EXPECTED_2)
   })
 
-  it('should return the measurement in circle mode with text, image', () => {
+  it('should return the measurement in area mode with text, image', () => {
     const MOCK_POINTS: [startPoint: Point, endPoint: Point] = [
       [10, 10],
       [15, 60],
@@ -134,14 +134,14 @@ describe('getMeasurement: ', () => {
       rowPixelSpacing: 0.6,
     } as Image
 
-    expect(getMeasurement(MOCK_POINTS, MOCK_TEXT_POINT, 'circle', MOCK_MEASUREMENTS, MOCK_IMAGE)).toStrictEqual({
+    expect(getMeasurement(MOCK_POINTS, MOCK_TEXT_POINT, 'area', MOCK_MEASUREMENTS, MOCK_IMAGE)).toStrictEqual({
       id: 1,
       measuredValue: 15.074813431681335,
       radius: 25.124689052802225,
       lineWidth: 1.5,
       centerPoint: [12.5, 35],
       textPoint: [50, 50],
-      type: 'circle',
+      type: 'area',
       unit: 'mm',
     })
   })

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurement.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurement.ts
@@ -23,14 +23,14 @@ export function getMeasurement(
     lineWidth: 1.5,
   }
 
-  if (mode === 'circle') {
+  if (mode === 'area') {
     const centerPoint = getCircleCenterPoint(startPoint, endPoint)
     const radiusWithoutUnit = getCircleRadius(startPoint, endPoint)
     const { radius, unit } = getCircleRadiusByMeasuringUnit(startPoint, endPoint, image)
 
     return {
       ...defaultMeasurementInfo,
-      type: 'circle',
+      type: 'area',
       centerPoint: centerPoint,
       textPoint,
       radius: radiusWithoutUnit,

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementDrawingPoints.spec.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementDrawingPoints.spec.ts
@@ -33,7 +33,7 @@ describe('getMeasurementDrawingPoints: ', () => {
       [25, 25],
     ])
   })
-  it('should return the points in circle mode', () => {
+  it('should return the points in area mode', () => {
     const MOCK_PREV_POINT_1: [Point, Point] = [
       [0, 0],
       [10, 10],
@@ -51,15 +51,15 @@ describe('getMeasurementDrawingPoints: ', () => {
     const MOCK_CURRENT_POINT_2: Point = [15, 15]
     const MOCK_CURRENT_POINT_3: Point = [25, 25]
 
-    expect(getMeasurementDrawingPoints(MOCK_PREV_POINT_1, MOCK_CURRENT_POINT_1, 'circle')).toEqual([
+    expect(getMeasurementDrawingPoints(MOCK_PREV_POINT_1, MOCK_CURRENT_POINT_1, 'area')).toEqual([
       [0, 0],
       [5, 5],
     ])
-    expect(getMeasurementDrawingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, 'circle')).toEqual([
+    expect(getMeasurementDrawingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, 'area')).toEqual([
       [10, 20],
       [15, 15],
     ])
-    expect(getMeasurementDrawingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, 'circle')).toEqual([
+    expect(getMeasurementDrawingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, 'area')).toEqual([
       [40, 60],
       [25, 25],
     ])

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementDrawingPoints.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementDrawingPoints.ts
@@ -5,7 +5,7 @@ export function getMeasurementDrawingPoints(
   currentPoint: Point,
   mode: MeasurementMode
 ): [Point, Point] {
-  if (mode === 'ruler' || mode === 'circle') {
+  if (mode === 'ruler' || mode === 'area') {
     return [prevPoints[0], currentPoint]
   }
 

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementEditingPoints.spec.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementEditingPoints.spec.ts
@@ -2,7 +2,7 @@ import { Point } from '../../../types'
 import { getMeasurementEditingPoints } from './getMeasurementEditingPoints'
 
 describe('getMeasurementEditingPoints: ', () => {
-  it('should return correct points when edit mode is startPoint and measurement mode is ruler or circle', () => {
+  it('should return correct points when edit mode is startPoint and measurement mode is ruler or area', () => {
     const MOCK_PREV_POINT_1: [Point, Point] = [
       [0, 0],
       [10, 10],
@@ -31,19 +31,19 @@ describe('getMeasurementEditingPoints: ', () => {
       [10, 10],
     ])
     expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'startPoint', 'circle')
+      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'startPoint', 'area')
     ).toEqual([
       [15, 15],
       [30, 40],
     ])
     expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, MOCK_EDIT_POINT_3, 'startPoint', 'circle')
+      getMeasurementEditingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, MOCK_EDIT_POINT_3, 'startPoint', 'area')
     ).toEqual([
       [25, 25],
       [80, 100],
     ])
   })
-  it('should return correct points when edit mode is endPoint and measurement mode is ruler or circle', () => {
+  it('should return correct points when edit mode is endPoint and measurement mode is ruler or area', () => {
     const MOCK_PREV_POINT_1: [Point, Point] = [
       [0, 0],
       [10, 10],
@@ -72,7 +72,7 @@ describe('getMeasurementEditingPoints: ', () => {
       [5, 5],
     ])
     expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'endPoint', 'circle')
+      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'endPoint', 'area')
     ).toEqual([
       [10, 20],
       [15, 15],
@@ -85,7 +85,7 @@ describe('getMeasurementEditingPoints: ', () => {
     ])
   })
 
-  it('should return correct points when edit mode is move and measurement mode is ruler or circle', () => {
+  it('should return correct points when edit mode is move and measurement mode is ruler or area', () => {
     const MOCK_PREV_POINT_1: [Point, Point] = [
       [0, 0],
       [10, 10],
@@ -126,19 +126,19 @@ describe('getMeasurementEditingPoints: ', () => {
       [35, 35],
     ])
     expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_1, MOCK_CURRENT_POINT_1, MOCK_EDIT_POINT_1, 'move', 'circle')
+      getMeasurementEditingPoints(MOCK_PREV_POINT_1, MOCK_CURRENT_POINT_1, MOCK_EDIT_POINT_1, 'move', 'area')
     ).toEqual([
       [-25, -25],
       [-15, -15],
     ])
     expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'move', 'circle')
+      getMeasurementEditingPoints(MOCK_PREV_POINT_2, MOCK_CURRENT_POINT_2, MOCK_EDIT_POINT_2, 'move', 'area')
     ).toEqual([
       [-25, -25],
       [-5, -5],
     ])
     expect(
-      getMeasurementEditingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, MOCK_EDIT_POINT_3, 'move', 'circle')
+      getMeasurementEditingPoints(MOCK_PREV_POINT_3, MOCK_CURRENT_POINT_3, MOCK_EDIT_POINT_3, 'move', 'area')
     ).toEqual([
       [-5, -5],
       [35, 35],

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementEditingPoints.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementEditingPoints.ts
@@ -9,15 +9,15 @@ export function getMeasurementEditingPoints(
   editMode: EditMode,
   mode: MeasurementMode
 ): [Point, Point] {
-  if ((mode === 'ruler' || mode === 'circle') && editMode === 'startPoint') {
+  if ((mode === 'ruler' || mode === 'area') && editMode === 'startPoint') {
     return [currentPoint, prevPoints[1]]
   }
 
-  if ((mode === 'ruler' || mode === 'circle') && editMode === 'endPoint') {
+  if ((mode === 'ruler' || mode === 'area') && editMode === 'endPoint') {
     return [prevPoints[0], currentPoint]
   }
 
-  if ((mode === 'circle' || mode === 'ruler') && editMode === 'move') {
+  if ((mode === 'area' || mode === 'ruler') && editMode === 'move') {
     const movedPoint = getMovedPoints({ prevPoints, editStartPoint, currentPoint })
 
     return movedPoint

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementPointsByMode.spec.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementPointsByMode.spec.ts
@@ -3,7 +3,7 @@ import { getMeasurementPointsByMode } from './getMeasurementPointsByMode'
 import type { Point } from '../../../types'
 
 describe('getMeasurementPointsByMode: ', () => {
-  const DRAWING_MODE_CIRCLE = 'circle'
+  const DRAWING_MODE_AREA = 'area'
   const DRAWING_MODE_RULER = 'ruler'
 
   const MOCK_PREV_POINTS_1: [centerPoint: Point, endPoint: Point] = [
@@ -17,7 +17,7 @@ describe('getMeasurementPointsByMode: ', () => {
   const MOCK_MOUSE_MOVE_POINT_1: Point = [300, 210]
   const MOCK_MOUSE_MOVE_POINT_2: Point = [123089, 29]
 
-  it('should return the mouse-down and mouse-move points when drawing mode is circle and mouse-down point is not null', () => {
+  it('should return the mouse-down and mouse-move points when drawing mode is area and mouse-down point is not null', () => {
     const MOCK_MOUSE_DOWN_POINT_1: Point = [0, 0]
     const MOCK_MOUSE_DOWN_POINT_2: Point = [10000, 10000]
 
@@ -34,7 +34,7 @@ describe('getMeasurementPointsByMode: ', () => {
       getMeasurementPointsByMode(
         false,
         null,
-        DRAWING_MODE_CIRCLE,
+        DRAWING_MODE_AREA,
         MOCK_MOUSE_DOWN_POINT_1,
         MOCK_MOUSE_MOVE_POINT_1,
         MOCK_PREV_POINTS_1
@@ -45,7 +45,7 @@ describe('getMeasurementPointsByMode: ', () => {
       getMeasurementPointsByMode(
         false,
         null,
-        DRAWING_MODE_CIRCLE,
+        DRAWING_MODE_AREA,
         MOCK_MOUSE_DOWN_POINT_2,
         MOCK_MOUSE_MOVE_POINT_2,
         MOCK_PREV_POINTS_2
@@ -53,7 +53,7 @@ describe('getMeasurementPointsByMode: ', () => {
     ).toStrictEqual(MOCK_EXPECT_RESULT_2)
   })
 
-  it('should return the current start and end points when when isEditing is true and editMode is textMove or move of circle', () => {
+  it('should return the current start and end points when when isEditing is true and editMode is textMove or move of area', () => {
     const MOCK_MOUSE_DOWN_POINT_1: Point = [0, 0]
     const MOCK_MOUSE_DOWN_POINT_2 = null
 
@@ -70,7 +70,7 @@ describe('getMeasurementPointsByMode: ', () => {
       getMeasurementPointsByMode(
         true,
         'move',
-        DRAWING_MODE_CIRCLE,
+        DRAWING_MODE_AREA,
         MOCK_MOUSE_DOWN_POINT_1,
         MOCK_MOUSE_MOVE_POINT_1,
         MOCK_PREV_POINTS_1
@@ -81,7 +81,7 @@ describe('getMeasurementPointsByMode: ', () => {
       getMeasurementPointsByMode(
         true,
         'textMove',
-        DRAWING_MODE_CIRCLE,
+        DRAWING_MODE_AREA,
         MOCK_MOUSE_DOWN_POINT_2,
         MOCK_MOUSE_MOVE_POINT_2,
         MOCK_PREV_POINTS_2
@@ -89,7 +89,7 @@ describe('getMeasurementPointsByMode: ', () => {
     ).toStrictEqual(MOCK_EXPECT_RESULT_2)
   })
 
-  it('should return previous points when mouse-down points of circle is null', () => {
+  it('should return previous points when mouse-down points of area is null', () => {
     const MOCK_MOUSE_DOWN_POINT = null
 
     const MOCK_EXPECT_RESULT_1 = [
@@ -105,7 +105,7 @@ describe('getMeasurementPointsByMode: ', () => {
       getMeasurementPointsByMode(
         true,
         null,
-        DRAWING_MODE_CIRCLE,
+        DRAWING_MODE_AREA,
         MOCK_MOUSE_DOWN_POINT,
         MOCK_MOUSE_MOVE_POINT_1,
         MOCK_PREV_POINTS_1
@@ -116,7 +116,7 @@ describe('getMeasurementPointsByMode: ', () => {
       getMeasurementPointsByMode(
         false,
         null,
-        DRAWING_MODE_CIRCLE,
+        DRAWING_MODE_AREA,
         MOCK_MOUSE_DOWN_POINT,
         MOCK_MOUSE_MOVE_POINT_2,
         MOCK_PREV_POINTS_2

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementPointsByMode.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getMeasurementPointsByMode.ts
@@ -17,11 +17,11 @@ export function getMeasurementPointsByMode(
    * Except for editing move is move or text move,
    * edit works the same as drawing.
    */
-  if (drawingMode === 'circle' && mouseDownPoint !== null) {
+  if (drawingMode === 'area' && mouseDownPoint !== null) {
     currentPoints = [mouseDownPoint, mouseMovePoint]
   }
 
-  if (drawingMode === 'circle' && isEditing && (editMode === 'move' || editMode === 'textMove')) {
+  if (drawingMode === 'area' && isEditing && (editMode === 'move' || editMode === 'textMove')) {
     const [currentCenterPoint, currentEndPoint] = prevPoints
     const radius = getCircleRadiusByCenter(currentCenterPoint, currentEndPoint)
     const currentStartPoint = getCircleStartPoint(currentCenterPoint, radius)

--- a/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getTextPosition.spec.ts
+++ b/libs/insight-viewer/src/hooks/useMeasurementPointsHandler/utils/getTextPosition.spec.ts
@@ -13,7 +13,7 @@ describe('getTextPosition: ', () => {
       measuredValue: 20,
       radius: 20,
       textPoint: null,
-      type: 'circle',
+      type: 'area',
       unit: 'px',
     }
     const MOCK_MEASUREMENT_2: Measurement = {
@@ -35,7 +35,7 @@ describe('getTextPosition: ', () => {
       radius: 20,
       measuredValue: 20,
       textPoint: [40, 10],
-      type: 'circle',
+      type: 'area',
       unit: 'px',
     }
 
@@ -51,7 +51,7 @@ describe('getTextPosition: ', () => {
       radius: 20,
       measuredValue: 20,
       textPoint: null,
-      type: 'circle',
+      type: 'area',
       unit: 'px',
     }
 

--- a/libs/insight-viewer/src/index.ts
+++ b/libs/insight-viewer/src/index.ts
@@ -35,7 +35,7 @@ export type {
   MeasurementBase,
   MeasurementMode,
   RulerMeasurement,
-  CircleMeasurement,
+  AreaMeasurement,
   ArrowLineAnnotation,
 } from './types'
 export type { DragAction, DragEvent, Click, Drag, Wheel } from './hooks/useInteraction/types'

--- a/libs/insight-viewer/src/types/index.ts
+++ b/libs/insight-viewer/src/types/index.ts
@@ -157,7 +157,7 @@ export interface AnnotationViewerProps<T extends AnnotationBase> {
   annotationAttrs?: (annotation: Annotation, showOutline: boolean) => SVGProps<SVGPolygonElement>
 }
 
-export type MeasurementMode = 'ruler' | 'circle'
+export type MeasurementMode = 'ruler' | 'area'
 export interface MeasurementBase {
   id: number
   type: MeasurementMode
@@ -176,13 +176,13 @@ export interface RulerMeasurement extends MeasurementBase {
   startAndEndPoint: [startPoint: Point, endPoint: Point]
 }
 
-export interface CircleMeasurement extends MeasurementBase {
-  type: 'circle'
+export interface AreaMeasurement extends MeasurementBase {
+  type: 'area'
   centerPoint: Point
   radius: number
 }
 
-export type Measurement = RulerMeasurement | CircleMeasurement
+export type Measurement = RulerMeasurement | AreaMeasurement
 
 export interface MeasurementViewerProps<T extends MeasurementBase> {
   measurement: T

--- a/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
+++ b/libs/insight-viewer/src/utils/common/getEditPointPosition.spec.ts
@@ -53,7 +53,7 @@ describe('getEditPointPosition: ', () => {
     ])
   })
 
-  it('should return the points with fixedPoints when drawing mode is circle', () => {
+  it('should return the points with fixedPoints when drawing mode is area', () => {
     const MOCK_POINT_1: Point[] = [
       [0, 0],
       [10, 10],
@@ -75,21 +75,21 @@ describe('getEditPointPosition: ', () => {
       measuredValue: 14.142135623730951,
       radius: 14.142135623730951,
       textPoint: null,
-      type: 'circle',
+      type: 'area',
       unit: 'px',
     }
 
-    expect(getEditPointPosition(MOCK_POINT_1, MOCK_EDIT_TARGET, 'circle', undefined, MOCK_FIXED_POINTS)).toEqual([
+    expect(getEditPointPosition(MOCK_POINT_1, MOCK_EDIT_TARGET, 'area', undefined, MOCK_FIXED_POINTS)).toEqual([
       [-10, -10.000000000000002],
       [10.000000000000002, 10],
     ])
-    expect(getEditPointPosition(MOCK_POINT_2, MOCK_EDIT_TARGET, 'circle', undefined, MOCK_FIXED_POINTS)).toEqual([
+    expect(getEditPointPosition(MOCK_POINT_2, MOCK_EDIT_TARGET, 'area', undefined, MOCK_FIXED_POINTS)).toEqual([
       [10, 9.999999999999996],
       [50, 50],
     ])
   })
 
-  it('should return the points with circle type editTarget and editingMode is move, textMove, or null', () => {
+  it('should return the points with area type editTarget and editingMode is move, textMove, or null', () => {
     const MOCK_POINT_1: Point[] = [
       [0, 0],
       [10, 10],
@@ -106,7 +106,7 @@ describe('getEditPointPosition: ', () => {
       measuredValue: 14.142135623730951,
       radius: 14.142135623730951,
       textPoint: null,
-      type: 'circle',
+      type: 'area',
       unit: 'px',
     }
 
@@ -120,7 +120,7 @@ describe('getEditPointPosition: ', () => {
     ])
   })
 
-  it('should return the points with circle type editTarget and editingMode is startPoint or endPoint', () => {
+  it('should return the points with area type editTarget and editingMode is startPoint or endPoint', () => {
     const MOCK_POINT_1: Point[] = [
       [0, 0],
       [10, 10],
@@ -141,7 +141,7 @@ describe('getEditPointPosition: ', () => {
       measuredValue: 14.142135623730951,
       radius: 14.142135623730951,
       textPoint: null,
-      type: 'circle',
+      type: 'area',
       unit: 'px',
     }
 

--- a/libs/insight-viewer/src/utils/common/getEditPointPosition.ts
+++ b/libs/insight-viewer/src/utils/common/getEditPointPosition.ts
@@ -1,14 +1,14 @@
 import { getCircleEditPoints } from './getCircleEditPoints'
 import { getCircleRadiusByCenter } from './getCircleRadius'
 
-import type { Point, Annotation, Measurement, EditMode } from '../../types'
+import type { Point, Annotation, Measurement, EditMode, MeasurementMode } from '../../types'
 
 export type EditPoints = [Point, Point]
 
 export function getEditPointPosition(
   points: Point[],
   editTarget: Measurement | Annotation | null,
-  drawingMode?: 'circle' | 'ruler',
+  drawingMode?: MeasurementMode,
   editingMode?: EditMode | null,
   fixedPoints?: [Point, Point]
 ): EditPoints | null {
@@ -16,8 +16,7 @@ export function getEditPointPosition(
   if (points.length !== 2) return null
 
   if (
-    editTarget &&
-    editTarget.type === 'circle' &&
+    (editTarget?.type === 'area' || editTarget?.type === 'circle') &&
     (!editingMode || editingMode === 'move' || editingMode === 'textMove')
   ) {
     const [centerPoint, endPoint] = points
@@ -26,7 +25,11 @@ export function getEditPointPosition(
     return editPoints
   }
 
-  if (fixedPoints && editTarget?.type === 'circle' && (editingMode === 'startPoint' || editingMode === 'endPoint')) {
+  if (
+    fixedPoints &&
+    (editTarget?.type === 'area' || editTarget?.type === 'circle') &&
+    (editingMode === 'startPoint' || editingMode === 'endPoint')
+  ) {
     const [start, end] = fixedPoints
     const currentEditingPoints: [Point, Point] =
       editingMode === 'startPoint'
@@ -42,7 +45,7 @@ export function getEditPointPosition(
     return currentEditingPoints
   }
 
-  if (drawingMode === 'circle' && fixedPoints) {
+  if (drawingMode === 'area' && fixedPoints) {
     const [start, end] = fixedPoints
 
     return [


### PR DESCRIPTION
## 📝 Description

Circle Annotation 과 네이밍이 겹치는 부분으로 인해 Area Measurement 로 변경했습니다. 
이를 통해 Circle Annotation, Circle Measurement 를 구분하는 것이 명확해집니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Circle Annotation, Circle Measurement 의 type 이 동일하게 circle 입니다.
이로 인해 circle type 좁히기를 시도해도 Measurement, Annotation 을 구분해야하는 불필요한
로직이 필요합니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-130

## 🚀 New behavior

Circle Measurement 의 네이밍을 Area 로 변경했습니다.
기존 네이밍 중첩으로 인한 이슈를 해결합니다.

## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

Circle Measurement 를 사용하고 있을 경우 이를 area 로 변경해야합니다.
